### PR TITLE
Introduce RankingConfig (prep for #33)

### DIFF
--- a/src/lele_manager/core/ranking.py
+++ b/src/lele_manager/core/ranking.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Literal
+
+
+ArgsortKind = Literal["quicksort", "mergesort", "heapsort", "stable"]
+TieBreaker = Literal["none", "lesson_id_asc"]
+
+
+@dataclass(frozen=True, slots=True)
+class SimilarityRankingConfig:
+    """
+    Configurazione ranking per LessonSimilarityIndex.
+
+    #34: SOLO introduzione configurazione.
+    Default = comportamento attuale.
+    """
+
+    # Default attuali (replicano most_similar)
+    top_k_default: int = 5
+    min_score_default: float = 0.0
+
+    # None => np.argsort default (replica comportamento attuale)
+    argsort_kind: ArgsortKind | None = None
+
+    # #34: nessun tie-breaker (replica comportamento attuale)
+    tiebreaker: TieBreaker = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class RankingConfig:
+    """
+    Root config di ranking (prep #33 / future v2).
+    """
+
+    similarity: SimilarityRankingConfig = SimilarityRankingConfig()
+
+    @classmethod
+    def default(cls) -> "RankingConfig":
+        return cls()
+
+    def to_dict(self) -> Dict[str, Any]:
+        # Serializzabile e deterministico
+        return asdict(self)

--- a/src/lele_manager/ml/similarity.py
+++ b/src/lele_manager/ml/similarity.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -11,6 +11,7 @@ from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.pipeline import Pipeline
 
 from .features import LessonFeatureExtractor
+from lele_manager.core.ranking import SimilarityRankingConfig
 
 @dataclass
 class LessonSimilarityResult:
@@ -77,16 +78,45 @@ class LessonSimilarityIndex:
 
         return cls.from_dataframe(df=df, transformer=transformer, id_column=id_column)
 
+    def most_similar_with_ranking(
+        self,
+        query_text: str,
+        *,
+        ranking: SimilarityRankingConfig,
+        top_k: Optional[int] = None,
+        min_score: Optional[float] = None,
+    ) -> List[LessonSimilarityResult]:
+        """
+        Entry-point interna per usare RankingConfig senza cambiare semantica
+        o default della API pubblica `most_similar`.
+
+        #34: non è usata dal server/CLI (nessun behavior change).
+        """
+        if top_k is None:
+            top_k = ranking.top_k_default
+        if min_score is None:
+            min_score = ranking.min_score_default
+        return self.most_similar(
+            query_text=query_text,
+            top_k=top_k,
+            min_score=min_score,
+            ranking=ranking,
+        )
+
     # --- Query ---
     def most_similar(
         self,
         query_text: str,
         top_k: int = 5,
         min_score: float = 0.0,
+        ranking: Optional[SimilarityRankingConfig] = None,
     ) -> List[LessonSimilarityResult]:
         """
         Restituisce fino a `top_k` lesson simili al testo dato.
         """
+        if ranking is None:
+            ranking = SimilarityRankingConfig()
+
         query_df = pd.DataFrame({"text": [query_text]})
         query_vec = self.transformer.transform(query_df)
 
@@ -97,7 +127,10 @@ class LessonSimilarityIndex:
             mask = np.ones_like(scores, dtype=bool)
 
         # Ordina per score desc
-        idx_sorted = np.argsort(scores[mask])[::-1]
+        if ranking.argsort_kind is None:
+            idx_sorted = np.argsort(scores[mask])[::-1]
+        else:
+            idx_sorted = np.argsort(scores[mask], kind=ranking.argsort_kind)[::-1]
         scores_filtered = scores[mask][idx_sorted]
 
         lesson_ids_filtered = self.lesson_ids[mask][idx_sorted]

--- a/src/lele_manager/ml/text_ml.py
+++ b/src/lele_manager/ml/text_ml.py
@@ -1,3 +1,12 @@
+"""
+LEGACY (soft-deprecated)
+
+Questo modulo contiene una pipeline similarity TF-IDF precedente.
+L'API server usa lele_manager.ml.similarity.LessonSimilarityIndex.
+
+Non rimuovere/refactor qui in #34: bonifica in issue dedicata.
+"""
+
 from dataclasses import dataclass
 from typing import List, Sequence, Tuple
 

--- a/tests/test_guardrail_server_imports.py
+++ b/tests/test_guardrail_server_imports.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_server_imports_similarity_index_from_non_legacy_module() -> None:
+    server_py = Path("src/lele_manager/api/server.py")
+    text = server_py.read_text(encoding="utf-8")
+
+    assert "from lele_manager.ml.similarity import LessonSimilarityIndex" in text
+    assert "lele_manager.ml.text_ml" not in text

--- a/tests/test_ranking_config.py
+++ b/tests/test_ranking_config.py
@@ -1,0 +1,18 @@
+from lele_manager.core.ranking import RankingConfig, SimilarityRankingConfig
+
+
+def test_ranking_config_defaults_match_current_behavior() -> None:
+    cfg = RankingConfig.default()
+    assert isinstance(cfg.similarity, SimilarityRankingConfig)
+    assert cfg.similarity.top_k_default == 5
+    assert cfg.similarity.min_score_default == 0.0
+    assert cfg.similarity.argsort_kind is None
+    assert cfg.similarity.tiebreaker == "none"
+
+
+def test_ranking_config_serialization_is_jsonable() -> None:
+    cfg = RankingConfig.default()
+    d = cfg.to_dict()
+    assert d["similarity"]["top_k_default"] == 5
+    assert d["similarity"]["min_score_default"] == 0.0
+    assert d["similarity"]["argsort_kind"] is None


### PR DESCRIPTION
Implements #34:
- Add core RankingConfig / SimilarityRankingConfig (defaults match current behavior)
- Add optional argsort kind hook for future deterministic ranking (default unchanged)
- Soft-deprecate legacy ml/text_ml.py (docstring only)
- Add guardrail test to prevent accidental legacy imports

No API/CLI schema changes. No behavior changes. All tests green.