### PR TITLE
v1.4: deterministic ranking baseline (tie-breakers only)

### DIFF
--- a/src/lele_manager/ml/similarity.py
+++ b/src/lele_manager/ml/similarity.py
@@ -126,14 +126,14 @@ class LessonSimilarityIndex:
         else:
             mask = np.ones_like(scores, dtype=bool)
 
-        # Ordina per score desc
-        if ranking.argsort_kind is None:
-            idx_sorted = np.argsort(scores[mask])[::-1]
-        else:
-            idx_sorted = np.argsort(scores[mask], kind=ranking.argsort_kind)[::-1]
-        scores_filtered = scores[mask][idx_sorted]
-
-        lesson_ids_filtered = self.lesson_ids[mask][idx_sorted]
+        # Deterministic ranking:
+        # 1) score DESC
+        # 2) lesson_id ASC (tie-breaker)
+        scores_m = scores[mask]
+        lesson_ids_m = self.lesson_ids[mask].astype(str)
+        order = np.lexsort((lesson_ids_m, -scores_m))
+        scores_filtered = scores_m[order]
+        lesson_ids_filtered = lesson_ids_m[order]
 
         results: List[LessonSimilarityResult] = []
         for lesson_id, score in zip(lesson_ids_filtered[:top_k], scores_filtered[:top_k]):

--- a/tests/test_similarity_deterministic_tiebreak.py
+++ b/tests/test_similarity_deterministic_tiebreak.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pandas as pd
+
+from lele_manager.ml.features import LessonFeatureExtractor
+from lele_manager.ml.similarity import LessonSimilarityIndex
+
+
+def test_most_similar_tiebreaker_lesson_id_asc(monkeypatch) -> None:
+    # 3 lessons with intentionally unsorted ids
+    df = pd.DataFrame(
+        [
+            {"id": "b", "text": "same", "importance": 0},
+            {"id": "a", "text": "same", "importance": 0},
+            {"id": "c", "text": "same", "importance": 0},
+        ]
+    )
+
+    transformer = LessonFeatureExtractor()
+    transformer.fit(df)
+    index = LessonSimilarityIndex.from_dataframe(df=df, transformer=transformer, id_column="id")
+
+    # Force equal scores to exercise tie-breaker deterministically
+    def fake_cosine_similarity(query_vec, feature_matrix):
+        return np.array([[1.0, 1.0, 1.0]], dtype=float)
+
+    # Patch the cosine_similarity used inside the module
+    import lele_manager.ml.similarity as sim_mod
+    monkeypatch.setattr(sim_mod, "cosine_similarity", fake_cosine_similarity)
+
+    res = index.most_similar("whatever", top_k=3, min_score=0.0)
+    assert [r.lesson_id for r in res] == ["a", "b", "c"]


### PR DESCRIPTION
Implements #33 (part 1/1):
- Deterministic ordering for similarity results
- Tie-breaker: lesson_id ASC when scores are equal
- No scoring changes; no API/CLI schema changes
Adds a non-flaky unit test (monkeypatched cosine_similarity).