### PR TITLE
CI: gate PyPI publish behind PYPI_ENABLED repo variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,23 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade build twine
-
       - name: Build
         run: python -m build
-
       - name: Twine check
         run: python -m twine check dist/*
-
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -38,21 +34,19 @@ jobs:
           path: dist/*
 
   publish:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
-
     permissions:
       id-token: write
       contents: read
-
     steps:
       - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
-
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
- Prevent failing Release runs when PyPI is not configured.\n- Build+twine+artifacts still run on tags.\n- Publish runs only when vars.PYPI_ENABLED == 'true'.