### PR TITLE
ml: add opt-in LSA similarity backend (v2-18a)

### DIFF
--- a/src/lele_manager/ml/similarity_backend.py
+++ b/src/lele_manager/ml/similarity_backend.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from typing import Optional, Protocol
 
+import numpy as np
 import pandas as pd
 
 from lele_manager.core.ranking import SimilarityRankingConfig
@@ -38,6 +41,158 @@ class SimilarityBackend(Protocol):
         ranking: Optional[SimilarityRankingConfig] = None,
     ) -> list[LessonSimilarityResult]:
         ...
+
+
+@dataclass(frozen=True)
+class _LsaCacheKey:
+    """
+    In-process cache key.
+
+    Note: this is intentionally process-local and keyed on object identity + shape.
+    Determinism is guaranteed by fixed random_state and deterministic ranking.
+    """
+
+    df_id: int
+    transformer_id: int
+    n_rows: int
+    n_cols: int
+
+
+@dataclass
+class _LsaIndexCache:
+    lesson_ids: np.ndarray
+    x_dense: np.ndarray
+    # store fitted svd so we can transform query vectors consistently
+    svd: object
+
+
+class TfidfLsaSimilarityBackend:
+    """
+    Experimental backend: TF-IDF features -> TruncatedSVD (LSA) -> cosine similarity.
+
+    Opt-in only (service default remains TF-IDF).
+    """
+
+    def __init__(self, *, n_components: int = 128, random_state: int = 0) -> None:
+        self._n_components = int(n_components)
+        self._random_state = int(random_state)
+        self._cache: dict[_LsaCacheKey, _LsaIndexCache] = {}
+
+    @property
+    def name(self) -> str:
+        return "lsa"
+
+    def _build_or_get_index(
+        self, *, df: pd.DataFrame, transformer: LessonFeatureExtractor
+    ) -> _LsaIndexCache:
+        key = _LsaCacheKey(
+            df_id=id(df),
+            transformer_id=id(transformer),
+            n_rows=int(df.shape[0]),
+            n_cols=int(df.shape[1]),
+        )
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+
+        from scipy import sparse
+        from sklearn.decomposition import TruncatedSVD
+
+        # ids are derived exactly like LessonSimilarityIndex.from_dataframe
+        if "id" in df.columns:
+            lesson_ids = df["id"].astype(str).to_numpy()
+        else:
+            lesson_ids = df.index.astype(str).to_numpy()
+
+        x = sparse.csr_matrix(transformer.transform(df))
+
+        # Guardrails: TruncatedSVD requires 1 < n_components < min(n_samples, n_features)
+        n_samples = int(x.shape[0])
+        n_features = int(x.shape[1])
+        max_allowed = max(0, min(n_samples - 1, n_features - 1))
+        n_components = min(self._n_components, max_allowed)
+        if n_components < 2:
+            raise ValueError(
+                f"LSA backend requires at least 2 components; "
+                f"got n_components={n_components} (requested={self._n_components}, "
+                f"n_samples={n_samples}, n_features={n_features})."
+            )
+
+        svd = TruncatedSVD(n_components=n_components, random_state=self._random_state)
+        x_dense = svd.fit_transform(x)
+        cache = _LsaIndexCache(lesson_ids=lesson_ids, x_dense=np.asarray(x_dense), svd=svd)
+        self._cache[key] = cache
+        return cache
+
+    @staticmethod
+    def _cosine_1_to_many(*, q: np.ndarray, x: np.ndarray) -> np.ndarray:
+        qn = np.linalg.norm(q)
+        xn = np.linalg.norm(x, axis=1)
+        denom = (qn * xn)
+        denom = np.where(denom == 0.0, 1.0, denom)
+        return (x @ q) / denom
+
+    def most_similar(
+        self,
+        *,
+        df: pd.DataFrame,
+        query_text: str,
+        transformer: LessonFeatureExtractor,
+        top_k: int,
+        min_score: float,
+        ranking: Optional[SimilarityRankingConfig] = None,
+    ) -> list[LessonSimilarityResult]:
+        if ranking is None:
+            ranking = SimilarityRankingConfig()
+
+        from scipy import sparse
+
+        cache = self._build_or_get_index(df=df, transformer=transformer)
+        query_df = pd.DataFrame({"text": [query_text]})
+        q = sparse.csr_matrix(transformer.transform(query_df))
+        q_dense = np.asarray(cache.svd.transform(q)).ravel()
+
+        scores = self._cosine_1_to_many(q=q_dense, x=cache.x_dense).ravel()
+        if min_score > 0.0:
+            mask = scores >= float(min_score)
+        else:
+            mask = np.ones_like(scores, dtype=bool)
+
+        scores_m = scores[mask]
+        lesson_ids_m = cache.lesson_ids[mask].astype(str)
+        order = np.lexsort((lesson_ids_m, -scores_m))
+        scores_sorted = scores_m[order]
+        lesson_ids_sorted = lesson_ids_m[order]
+
+        results: list[LessonSimilarityResult] = []
+        for lesson_id, score in zip(lesson_ids_sorted[:top_k], scores_sorted[:top_k]):
+            results.append(LessonSimilarityResult(lesson_id=str(lesson_id), score=float(score)))
+        return results
+
+    def most_similar_by_lesson_id(
+        self,
+        *,
+        df: pd.DataFrame,
+        lesson_id: str,
+        transformer: LessonFeatureExtractor,
+        top_k: int,
+        min_score: float,
+        ranking: Optional[SimilarityRankingConfig] = None,
+    ) -> list[LessonSimilarityResult]:
+        row = df[df["id"].astype(str) == str(lesson_id)]
+        if row.empty:
+            raise ValueError(f"Lesson id not found: {lesson_id}")
+        query_text = str(row.iloc[0]["text"])
+        results = self.most_similar(
+            df=df,
+            query_text=query_text,
+            transformer=transformer,
+            top_k=top_k + 1,
+            min_score=min_score,
+            ranking=ranking,
+        )
+        filtered = [r for r in results if str(r.lesson_id) != str(lesson_id)]
+        return filtered[:top_k]
 
 
 class TfidfSimilarityBackend:


### PR DESCRIPTION
Implements v2-18a (#69): adds opt-in LSA backend (TF-IDF + TruncatedSVD) with deterministic ranking; no API/CLI exposure yet.