### PR TITLE
feat(similarity): explain mode in GUI, API, and CLI (Fase 4.1)

### DIFF
--- a/docs/phase-4-issue.md
+++ b/docs/phase-4-issue.md
@@ -38,11 +38,11 @@ Questa fase porta la GUI da “funziona” a “mi fido mentre scrivo”: capire
 
 ### 4.1 Explain similarity in GUI (#90)
 
-- [ ] Usare `explain=true` su `/similar`, `/editor/suggest`, `/lessons/{id}/similar`
-- [ ] Pannello **“Perché simile?”** in `Detail` e `Editor` (rank, score, preview)
-- [ ] Mostrare metadati utili: topic, tag overlap (se disponibili in explain meta)
-- [ ] CLI: opzionale `lele similar --explain` / `lele suggest --explain`
-- [ ] Test API + snapshot minimi risposta explain
+- [x] Usare `explain=true` su `/similar`, `/editor/suggest`, `/lessons/{id}/similar`
+- [x] Pannello **“Perché simile?”** in `Detail` e `Editor` (rank, score, preview)
+- [x] Mostrare metadati utili: topic, tag overlap (se disponibili in explain meta)
+- [x] CLI: opzionale `lele similar --explain` / `lele suggest --explain`
+- [x] Test API + snapshot minimi risposta explain
 
 **Non in scope:** LLM/RAG per spiegazioni in linguaggio naturale.
 

--- a/frontend/src/components/SimilarPanel.svelte
+++ b/frontend/src/components/SimilarPanel.svelte
@@ -1,20 +1,24 @@
 <script lang="ts">
-  import type { SimilarItem } from '../lib/api'
+  import type { SimilarItem, SimilarMeta } from '../lib/api'
   import { navigate } from '../lib/router'
 
   interface Props {
     title?: string
     items: SimilarItem[]
+    meta?: SimilarMeta | null
     loading?: boolean
     error?: string
+    explain?: boolean
     onclickItem?: (id: string) => void
   }
 
   let {
     title = 'Simili',
     items,
+    meta = null,
     loading = false,
     error = '',
+    explain = true,
     onclickItem,
   }: Props = $props()
 
@@ -25,7 +29,19 @@
 </script>
 
 <section class="card similar-panel">
-  <h3>{title}</h3>
+  <h3>{explain ? 'Perché simile?' : title}</h3>
+
+  {#if explain && meta}
+    <p class="explain-meta">
+      top_k={meta.top_k}, min_score={meta.min_score.toFixed(2)}
+      {#if meta.query_topic}
+        · query topic: <strong>{meta.query_topic}</strong>
+      {/if}
+      {#if meta.query_tags?.length}
+        · tag query: {meta.query_tags.join(', ')}
+      {/if}
+    </p>
+  {/if}
 
   {#if loading}
     <p class="meta">Caricamento…</p>
@@ -38,9 +54,20 @@
       {#each items as item}
         <li>
           <button type="button" class="item" onclick={() => handleClick(item.id)}>
-            <span class="score">{item.score.toFixed(2)}</span>
+            <div class="row-top">
+              {#if explain && item.rank != null}
+                <span class="rank">#{item.rank}</span>
+              {/if}
+              <span class="score">{item.score.toFixed(2)}</span>
+              {#if explain && item.topic}
+                <span class="topic">{item.topic}</span>
+              {/if}
+            </div>
             <span class="id">{item.id}</span>
             <span class="preview">{item.text_preview}</span>
+            {#if explain && item.tags_shared?.length}
+              <span class="tags-shared">tag in comune: {item.tags_shared.join(', ')}</span>
+            {/if}
           </button>
         </li>
       {/each}
@@ -51,6 +78,13 @@
 <style>
   h3 {
     margin: 0 0 12px;
+  }
+
+  .explain-meta {
+    margin: 0 0 12px;
+    font-size: 0.8rem;
+    color: var(--muted);
+    line-height: 1.4;
   }
 
   ul {
@@ -72,10 +106,31 @@
     gap: 4px;
   }
 
+  .row-top {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .rank {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--muted);
+  }
+
   .score {
     color: var(--accent);
     font-weight: 700;
     font-size: 0.85rem;
+  }
+
+  .topic {
+    font-size: 0.75rem;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: #f0ebe3;
+    color: var(--text);
   }
 
   .id {
@@ -86,5 +141,10 @@
   .preview {
     color: var(--muted);
     font-size: 0.85rem;
+  }
+
+  .tags-shared {
+    font-size: 0.75rem;
+    color: var(--accent);
   }
 </style>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,11 +24,23 @@ export interface SimilarItem {
   score: number
   text_preview: string
   rank?: number | null
+  topic?: string | null
+  tags_shared?: string[] | null
+}
+
+export interface SimilarMeta {
+  data_mtime_ns: number
+  model_mtime_ns: number
+  top_k: number
+  min_score: number
+  query_topic?: string | null
+  query_tags?: string[] | null
 }
 
 export interface SimilarResponse {
   query: string
   results: SimilarItem[]
+  meta?: SimilarMeta | null
 }
 
 export interface HealthResponse {
@@ -150,20 +162,20 @@ export const api = {
   getLesson: (id: string) =>
     request<Lesson>(`/lessons/${encodeURIComponent(id)}`),
 
-  similarById: (id: string, topK = 5, minScore = 0) =>
+  similarById: (id: string, topK = 5, minScore = 0, explain = false) =>
     request<SimilarResponse>(
-      `/lessons/${encodeURIComponent(id)}/similar?top_k=${topK}&min_score=${minScore}`,
+      `/lessons/${encodeURIComponent(id)}/similar?top_k=${topK}&min_score=${minScore}&explain=${explain ? 'true' : 'false'}`,
     ),
 
-  similarByText: (text: string, topK = 5, minScore = 0.1) =>
-    request<SimilarResponse>('/similar', {
+  similarByText: (text: string, topK = 5, minScore = 0.1, explain = false) =>
+    request<SimilarResponse>(`/similar?explain=${explain ? 'true' : 'false'}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, top_k: topK, min_score: minScore }),
     }),
 
-  editorSuggest: (text: string, topK = 5, minScore = 0.1) =>
-    request<SimilarResponse>('/editor/suggest', {
+  editorSuggest: (text: string, topK = 5, minScore = 0.1, explain = false) =>
+    request<SimilarResponse>(`/editor/suggest?explain=${explain ? 'true' : 'false'}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, top_k: topK, min_score: minScore }),

--- a/frontend/src/routes/Detail.svelte
+++ b/frontend/src/routes/Detail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { api, type Lesson, type SimilarItem } from '../lib/api'
+  import { api, type Lesson, type SimilarItem, type SimilarMeta } from '../lib/api'
   import { navigate } from '../lib/router'
   import { renderMarkdown } from '../lib/markdown'
   import SimilarPanel from '../components/SimilarPanel.svelte'
@@ -12,6 +12,7 @@
 
   let lesson = $state<Lesson | null>(null)
   let similar = $state<SimilarItem[]>([])
+  let similarMeta = $state<SimilarMeta | null>(null)
   let loading = $state(true)
   let similarLoading = $state(false)
   let error = $state('')
@@ -34,8 +35,9 @@
     similarLoading = true
     similarError = ''
     try {
-      const resp = await api.similarById(id, 8, 0.05)
+      const resp = await api.similarById(id, 8, 0.05, true)
       similar = resp.results
+      similarMeta = resp.meta ?? null
     } catch (e) {
       similar = []
       similarError = e instanceof Error ? e.message : String(e)
@@ -92,6 +94,8 @@
     <SimilarPanel
       title="LeLe simili"
       items={similar}
+      meta={similarMeta}
+      explain={true}
       loading={similarLoading}
       error={similarError}
     />

--- a/frontend/src/routes/Editor.svelte
+++ b/frontend/src/routes/Editor.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { api, type Lesson, type SimilarItem } from '../lib/api'
+  import { api, type Lesson, type SimilarItem, type SimilarMeta } from '../lib/api'
   import { stripFrontmatter } from '../lib/markdown'
   import { navigate } from '../lib/router'
   import SimilarPanel from '../components/SimilarPanel.svelte'
@@ -20,6 +20,7 @@
   let lessonId = $state('')
 
   let similar = $state<SimilarItem[]>([])
+  let similarMeta = $state<SimilarMeta | null>(null)
   let similarLoading = $state(false)
   let similarError = $state('')
   let loadError = $state('')
@@ -63,8 +64,9 @@
     similarLoading = true
     similarError = ''
     try {
-      const resp = await api.editorSuggest(text, topK, minScore)
+      const resp = await api.editorSuggest(text, topK, minScore, true)
       similar = resp.results
+      similarMeta = resp.meta ?? null
     } catch (e) {
       similar = []
       similarError = e instanceof Error ? e.message : String(e)
@@ -200,6 +202,8 @@
   <SimilarPanel
     title="Simili live"
     items={similar}
+    meta={similarMeta}
+    explain={true}
     loading={similarLoading}
     error={similarError}
   />

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -156,6 +156,8 @@ class SimilarMeta(BaseModel):
     model_mtime_ns: int
     top_k: int
     min_score: float
+    query_topic: Optional[str] = None
+    query_tags: Optional[List[str]] = None
 
 
 class SimilarItem(BaseModel):
@@ -163,6 +165,8 @@ class SimilarItem(BaseModel):
     score: float
     text_preview: str
     rank: Optional[int] = None
+    topic: Optional[str] = None
+    tags_shared: Optional[List[str]] = None
 
 
 class SimilarResponse(BaseModel):
@@ -347,6 +351,102 @@ def _file_mtime_ns(path: Path) -> int:
 
 def _similarity_cache_key(data_path: Path, model_path: Path) -> tuple[int, int]:
     return (_file_mtime_ns(data_path), _file_mtime_ns(model_path))
+
+
+def _normalize_tags(raw: object) -> set[str]:
+    if isinstance(raw, list):
+        return {str(t).strip() for t in raw if str(t).strip()}
+    return set()
+
+
+def _parse_frontmatter_tags(text: str) -> set[str]:
+    """Estrae tag dal frontmatter YAML (editor / testo con ---)."""
+    import re
+
+    stripped = text.lstrip()
+    if not stripped.startswith("---"):
+        return set()
+    m = re.match(r"---\s*\n(.*?)\n---", stripped, re.DOTALL)
+    if not m:
+        return set()
+    fm = m.group(1)
+    tm = re.search(r"^tags:\s*(.+)$", fm, re.MULTILINE)
+    if not tm:
+        return set()
+    raw = tm.group(1).strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        raw = raw[1:-1]
+    return {t.strip().strip('"').strip("'") for t in raw.split(",") if t.strip()}
+
+
+def _text_preview(text: str, max_len: int = 120) -> str:
+    preview = text.replace("\n", " ")
+    if len(preview) > max_len:
+        return preview[: max_len - 3] + "..."
+    return preview
+
+
+def _build_similar_items(
+    df: pd.DataFrame,
+    results_raw: list,
+    *,
+    explain: bool,
+    query_tags: set[str] | None = None,
+) -> List[SimilarItem]:
+    df_indexed = df.set_index("id")
+    text_map = df_indexed["text"].fillna("").astype(str).to_dict()
+    topic_map = (
+        df_indexed["topic"].fillna("").astype(str).to_dict() if "topic" in df_indexed.columns else {}
+    )
+    tags_series = df_indexed["tags"] if "tags" in df_indexed.columns else None
+
+    items: List[SimilarItem] = []
+    for i, r in enumerate(results_raw, start=1):
+        lesson_id = str(r.lesson_id)
+        topic_val: Optional[str] = None
+        tags_shared: Optional[List[str]] = None
+        if explain:
+            raw_topic = topic_map.get(lesson_id, "")
+            topic_val = raw_topic if raw_topic else None
+            if query_tags and tags_series is not None:
+                row_tags = _normalize_tags(tags_series.get(lesson_id))
+                shared = sorted(query_tags & row_tags)
+                if shared:
+                    tags_shared = shared
+        items.append(
+            SimilarItem(
+                id=lesson_id,
+                score=float(r.score),
+                text_preview=_text_preview(text_map.get(lesson_id, "")),
+                rank=i if explain else None,
+                topic=topic_val if explain else None,
+                tags_shared=tags_shared if explain else None,
+            )
+        )
+    return items
+
+
+def _build_similar_meta(
+    *,
+    explain: bool,
+    top_k: int,
+    min_score: float,
+    query_topic: Optional[str] = None,
+    query_tags: set[str] | None = None,
+) -> Optional[SimilarMeta]:
+    if not explain:
+        return None
+    data_path = get_data_path()
+    model_path = get_model_path()
+    data_mtime_ns, model_mtime_ns = _similarity_cache_key(data_path=data_path, model_path=model_path)
+    return SimilarMeta(
+        data_mtime_ns=int(data_mtime_ns),
+        model_mtime_ns=int(model_mtime_ns),
+        top_k=top_k,
+        min_score=min_score,
+        query_topic=query_topic or None,
+        query_tags=sorted(query_tags) if query_tags else None,
+    )
 
 
 def invalidate_similarity_cache() -> None:
@@ -644,30 +744,18 @@ def similar_lessons(
     # Togli eventuale self-match se costruito usando il testo della stessa LeLe
     filtered = [r for r in results_raw if r.lesson_id != lesson_id]
 
-    # Mappa id -> text per anteprima
-    df_map = df.set_index("id")["text"].fillna("").astype(str).to_dict()
+    query_row = matches.iloc[0]
+    query_topic = _to_optional_str(query_row.get("topic"))
+    query_tags = _normalize_tags(query_row.get("tags"))
 
-    items: List[SimilarItem] = []
-    for i, r in enumerate(filtered, start=1):
-        text = df_map.get(r.lesson_id, "")
-        preview = text.replace("\n", " ")
-        if len(preview) > 120:
-            preview = preview[:117] + "..."
-        items.append(
-                SimilarItem(
-                    id=str(r.lesson_id),
-                    score=float(r.score),
-                    text_preview=preview,
-                    rank=i if explain else None,
-                )
-            )
-
-    meta = None
-    if explain:
-        data_path = get_data_path()
-        model_path = get_model_path()
-        data_mtime_ns, model_mtime_ns = _similarity_cache_key(data_path=data_path, model_path=model_path)
-        meta = SimilarMeta(data_mtime_ns=int(data_mtime_ns), model_mtime_ns=int(model_mtime_ns), top_k=top_k, min_score=min_score)
+    items = _build_similar_items(df, filtered, explain=explain, query_tags=query_tags if explain else None)
+    meta = _build_similar_meta(
+        explain=explain,
+        top_k=top_k,
+        min_score=min_score,
+        query_topic=query_topic if explain else None,
+        query_tags=query_tags if explain else None,
+    )
 
     return SimilarResponse(
         query=query_text,
@@ -759,28 +847,19 @@ def similar_from_text(body: SimilarTextRequest, explain: bool = Query(default=Fa
         min_score=body.min_score,
     )
 
-    df_map = df.set_index("id")["text"].fillna("").astype(str).to_dict()
-
-    items: List[SimilarItem] = []
-    for i, r in enumerate(results_raw, start=1):
-        preview = df_map.get(r.lesson_id, "").replace("\n", " ")
-        if len(preview) > 120:
-            preview = preview[:117] + "..."
-        items.append(
-                SimilarItem(
-                    id=str(r.lesson_id),
-                    score=float(r.score),
-                    text_preview=preview,
-                    rank=i if explain else None,
-                )
-            )
-
-    meta = None
-    if explain:
-        data_path = get_data_path()
-        model_path = get_model_path()
-        data_mtime_ns, model_mtime_ns = _similarity_cache_key(data_path=data_path, model_path=model_path)
-        meta = SimilarMeta(data_mtime_ns=int(data_mtime_ns), model_mtime_ns=int(model_mtime_ns), top_k=body.top_k, min_score=body.min_score)
+    query_tags = _parse_frontmatter_tags(text) if explain else None
+    items = _build_similar_items(
+        df,
+        results_raw,
+        explain=explain,
+        query_tags=query_tags if explain and query_tags else None,
+    )
+    meta = _build_similar_meta(
+        explain=explain,
+        top_k=body.top_k,
+        min_score=body.min_score,
+        query_tags=query_tags if explain and query_tags else None,
+    )
 
     return SimilarResponse(query=text, results=items, meta=meta)
 
@@ -1043,9 +1122,6 @@ def similar_from_text_batch(body: SimilarBatchRequest, explain: bool = Query(def
 
     index = build_similarity_index(df)  # cached
 
-    # Precalcola mappa id -> text per anteprime (una volta sola)
-    df_map = df.set_index("id")["text"].fillna("").astype(str).to_dict()
-
     out_items: List[SimilarResponse] = []
     for req in body.items:
         text = req.text.strip()
@@ -1060,28 +1136,19 @@ def similar_from_text_batch(body: SimilarBatchRequest, explain: bool = Query(def
             min_score=req.min_score,
         )
 
-        items: List[SimilarItem] = []
-        for i, r in enumerate(results_raw, start=1):
-            t = df_map.get(r.lesson_id, "")
-            preview = t.replace("\n", " ")
-            if len(preview) > 120:
-                preview = preview[:117] + "..."
-            items.append(
-                SimilarItem(
-                    id=str(r.lesson_id),
-                    score=float(r.score),
-                    text_preview=preview,
-                    rank=i if explain else None,
-                )
-            )
-
-        meta = None
-        if explain:
-            data_path = get_data_path()
-            model_path = get_model_path()
-            data_mtime_ns, model_mtime_ns = _similarity_cache_key(data_path=data_path, model_path=model_path)
-            meta = SimilarMeta(data_mtime_ns=int(data_mtime_ns), model_mtime_ns=int(model_mtime_ns), top_k=req.top_k, min_score=req.min_score)
-
+        query_tags = _parse_frontmatter_tags(text) if explain else None
+        items = _build_similar_items(
+            df,
+            results_raw,
+            explain=explain,
+            query_tags=query_tags if explain and query_tags else None,
+        )
+        meta = _build_similar_meta(
+            explain=explain,
+            top_k=req.top_k,
+            min_score=req.min_score,
+            query_tags=query_tags if explain and query_tags else None,
+        )
         out_items.append(SimilarResponse(query=text, results=items, meta=meta))
 
     return SimilarBatchResponse(items=out_items)

--- a/src/lele_manager/cli/lele.py
+++ b/src/lele_manager/cli/lele.py
@@ -119,6 +119,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Stampa la risposta come JSON invece che in formato umano.",
     )
+    p_similar.add_argument(
+        "--explain",
+        action="store_true",
+        help="Include rank, topic e meta di debug (explain=true).",
+    )
 
 
     # ------------------------------------------------------------------
@@ -165,6 +170,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         help="Stampa la risposta come JSON invece che in formato umano.",
+    )
+    p_suggest.add_argument(
+        "--explain",
+        action="store_true",
+        help="Include rank, topic e meta di debug (explain=true).",
     )
     # ------------------------------------------------------------------
     # lele train-topic
@@ -267,12 +277,19 @@ def _print_human_lesson(item: Dict[str, Any]) -> None:
     print(item.get("text") or "")
 
 
-def _print_human_similar(results: List[Dict[str, Any]], query: str) -> None:
+def _print_human_similar(results: List[Dict[str, Any]], query: str, meta: Dict[str, Any] | None = None) -> None:
     print("=== Query ===")
     q = query.replace("\n", " ")
     if len(q) > 140:
         q = q[:137] + "..."
     print(q)
+    if meta:
+        parts = [f"top_k={meta.get('top_k')}", f"min_score={meta.get('min_score')}"]
+        if meta.get("query_topic"):
+            parts.append(f"query_topic={meta['query_topic']}")
+        if meta.get("query_tags"):
+            parts.append(f"query_tags={','.join(meta['query_tags'])}")
+        print(f"[meta] {', '.join(str(p) for p in parts)}")
     print("")
     if not results:
         print("[info] Nessuna lesson simile trovata.")
@@ -282,8 +299,15 @@ def _print_human_similar(results: List[Dict[str, Any]], query: str) -> None:
     for r in results:
         lesson_id = r.get("id", "")
         score = r.get("score", 0.0)
+        rank = r.get("rank")
+        topic = r.get("topic")
         text_preview = r.get("text_preview", "")
-        print(f"- {lesson_id} | score={score:.3f}")
+        rank_prefix = f"#{rank} " if rank is not None else ""
+        topic_suffix = f" | topic={topic}" if topic else ""
+        print(f"- {rank_prefix}{lesson_id} | score={score:.3f}{topic_suffix}")
+        tags_shared = r.get("tags_shared") or []
+        if tags_shared:
+            print(f"  tag in comune: {', '.join(str(t) for t in tags_shared)}")
         print(f"  {text_preview}")
 
 
@@ -353,6 +377,8 @@ def cmd_similar(base_url: str, args: argparse.Namespace) -> int:
         "top_k": args.top_k,
         "min_score": args.min_score,
     }
+    if getattr(args, "explain", False):
+        params["explain"] = True
 
     with httpx.Client(base_url=base_url, timeout=10.0) as client:
         try:
@@ -372,11 +398,12 @@ def cmd_similar(base_url: str, args: argparse.Namespace) -> int:
     data = resp.json()
     query_text = data.get("query", "")
     results = data.get("results", [])
+    meta = data.get("meta")
 
     if args.json:
         _print_json(data)
     else:
-        _print_human_similar(results, query_text)
+        _print_human_similar(results, query_text, meta)
     return 0
 
 def _read_text_or_stdin(args: argparse.Namespace) -> str:
@@ -405,7 +432,10 @@ def cmd_suggest(base_url: str, args: argparse.Namespace) -> int:
 
         with httpx.Client(base_url=base_url, timeout=10.0) as client:
             try:
-                resp = client.post("/similar", json=payload)
+                post_kwargs: Dict[str, Any] = {"json": payload}
+                if getattr(args, "explain", False):
+                    post_kwargs["params"] = {"explain": "true"}
+                resp = client.post("/similar", **post_kwargs)
             except httpx.RequestError as exc:
                 print(f"[errore] Errore di rete verso {exc.request.url}: {exc}", file=sys.stderr)
                 return 1
@@ -424,7 +454,8 @@ def cmd_suggest(base_url: str, args: argparse.Namespace) -> int:
         else:
             query_text = data.get("query", "")
             results = data.get("results", [])
-            _print_human_similar(results, query_text)
+            meta = data.get("meta")
+            _print_human_similar(results, query_text, meta)
         return 0
 
     watch = getattr(args, "watch", None)

--- a/tests/test_api_similar_explain.py
+++ b/tests/test_api_similar_explain.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import lele_manager.api.server as server_mod
-import pandas as pd
 from fastapi.testclient import TestClient
 
 from lele_manager.api.server import app

--- a/tests/test_api_similar_explain.py
+++ b/tests/test_api_similar_explain.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import lele_manager.api.server as server_mod
+import pandas as pd
+from fastapi.testclient import TestClient
+
+from lele_manager.api.server import app
+
+
+def _train_fixture(monkeypatch, tmp_path: Path) -> TestClient:
+    data_path = tmp_path / "lessons.jsonl"
+    model_path = tmp_path / "topic_model.joblib"
+    data_path.write_text(
+        "\n".join(
+            [
+                '{"id":"python/a","text":"python pandas pytest tips","topic":"python","tags":["python","pytest"]}',
+                '{"id":"python/b","text":"python sklearn pytest models","topic":"python","tags":["python","pytest","ml"]}',
+                '{"id":"linux/c","text":"linux kernel networking","topic":"linux","tags":["linux"]}',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(server_mod, "DATA_PATH", data_path)
+    monkeypatch.setattr(server_mod, "MODEL_PATH", model_path)
+    client = TestClient(app)
+    r_train = client.post("/train/topic")
+    assert r_train.status_code == 200, r_train.text
+    return client
+
+
+def test_similar_explain_false_omits_debug_fields(monkeypatch, tmp_path) -> None:
+    client = _train_fixture(monkeypatch, tmp_path)
+    r = client.post("/similar", json={"text": "python pytest", "top_k": 3, "min_score": 0.0})
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload.get("meta") is None
+    for item in payload["results"]:
+        assert "rank" not in item or item.get("rank") is None
+        assert "topic" not in item or item.get("topic") is None
+
+
+def test_similar_explain_true_includes_rank_topic_meta(monkeypatch, tmp_path) -> None:
+    client = _train_fixture(monkeypatch, tmp_path)
+    r = client.post(
+        "/similar",
+        params={"explain": "true"},
+        json={"text": "python pytest", "top_k": 3, "min_score": 0.0},
+    )
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    meta = payload["meta"]
+    assert meta["top_k"] == 3
+    assert meta["min_score"] == 0.0
+    assert isinstance(meta["data_mtime_ns"], int)
+    assert isinstance(meta["model_mtime_ns"], int)
+    assert payload["results"]
+    first = payload["results"][0]
+    assert first["rank"] == 1
+    assert first["topic"] in {"python", "linux"}
+
+
+def test_get_similar_by_id_explain_tag_overlap(monkeypatch, tmp_path) -> None:
+    client = _train_fixture(monkeypatch, tmp_path)
+    r = client.get("/lessons/python/a/similar", params={"top_k": 5, "min_score": 0.0, "explain": True})
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["meta"]["query_topic"] == "python"
+    assert "pytest" in (payload["meta"].get("query_tags") or [])
+    shared_hits = [item for item in payload["results"] if item.get("tags_shared")]
+    assert shared_hits, "expected at least one result with shared tags"
+    assert "pytest" in shared_hits[0]["tags_shared"]
+
+
+def test_editor_suggest_explain_matches_similar(monkeypatch, tmp_path) -> None:
+    client = _train_fixture(monkeypatch, tmp_path)
+    fm_text = (
+        "---\n"
+        "topic: python\n"
+        "tags: [python, pytest]\n"
+        "---\n\n"
+        "python pytest workflow"
+    )
+    payload = {"text": fm_text, "top_k": 3, "min_score": 0.0}
+    r1 = client.post("/similar", params={"explain": "true"}, json=payload)
+    r2 = client.post("/editor/suggest", params={"explain": "true"}, json=payload)
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r2.json() == r1.json()
+    assert r1.json()["meta"].get("query_tags") == ["pytest", "python"]
+
+
+def test_parse_frontmatter_tags_helper() -> None:
+    from lele_manager.api.server import _parse_frontmatter_tags
+
+    text = "---\ntopic: t\ntags: [a, b]\n---\n\nbody"
+    assert _parse_frontmatter_tags(text) == {"a", "b"}


### PR DESCRIPTION
## Summary
- Extend similarity API `explain=true` with rank, topic, `tags_shared`, and query meta (`query_topic`, `query_tags`).
- GUI Detail/Editor use explain mode via refreshed **“Perché simile?”** panel (`SimilarPanel`).
- CLI: `lele similar --explain` and `lele suggest --explain`.
- Mark Fase 4.1 checklist complete in `docs/phase-4-issue.md`.

## Test plan
- [x] `pytest tests/test_api_similar_explain.py` (5 tests)
- [x] Full suite: 89 passed
- [ ] Merge → CI green
- [ ] Manual: open `/app/#/lesson/<id>` and confirm rank/topic/tag overlap in sidebar


Made with [Cursor](https://cursor.com)