### PR TITLE
feat(export): search → Markdown API, GUI, CLI (Fase 4.2 #87)

### DIFF
--- a/docs/phase-4-issue.md
+++ b/docs/phase-4-issue.md
@@ -48,12 +48,12 @@ Questa fase porta la GUI da “funziona” a “mi fido mentre scrivo”: capire
 
 ### 4.2 Export search → Markdown (#87)
 
-- [ ] API: `POST /export/search` → contenuto Markdown
+- [x] API: `POST /export/search` → contenuto Markdown
   - input: stesso payload di `POST /lessons/search` (+ opzioni formato)
   - output: `text/markdown` o JSON `{ "markdown": "..." }`
-- [ ] GUI: bottone **Esporta** in Browse (e opz. Timeline)
-- [ ] CLI: `lele export --search "pytest" --topic python -o results.md`
-- [ ] Test: export con filtri, encoding UTF-8, frontmatter opzionale
+- [x] GUI: bottone **Esporta** in Browse (e opz. Timeline)
+- [x] CLI: `lele export --search "pytest" --topic python -o results.md`
+- [x] Test: export con filtri, encoding UTF-8, frontmatter opzionale
 
 ### 4.3 Playwright E2E smoke
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,16 @@ export interface LessonSearchRequest {
   limit?: number
 }
 
+export interface ExportSearchRequest extends LessonSearchRequest {
+  include_frontmatter?: boolean
+  ids_in?: string[] | null
+}
+
+export interface ExportSearchResponse {
+  markdown: string
+  n_lessons: number
+}
+
 export interface SimilarItem {
   id: string
   score: number
@@ -158,6 +168,32 @@ export const api = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
+
+  exportSearch: async (
+    body: ExportSearchRequest,
+    format: 'markdown' | 'json' = 'markdown',
+  ): Promise<string | ExportSearchResponse> => {
+    const resp = await fetch(`/export/search?format=${encodeURIComponent(format)}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}))
+      const detail = (data as { detail?: unknown }).detail
+      const msg =
+        typeof detail === 'string'
+          ? detail
+          : detail != null
+            ? JSON.stringify(detail)
+            : `HTTP ${resp.status}`
+      throw new Error(msg)
+    }
+    if (format === 'json') {
+      return (await resp.json()) as ExportSearchResponse
+    }
+    return resp.text()
+  },
 
   getLesson: (id: string) =>
     request<Lesson>(`/lessons/${encodeURIComponent(id)}`),

--- a/frontend/src/routes/Browse.svelte
+++ b/frontend/src/routes/Browse.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { api, type Lesson } from '../lib/api'
+  import { api, type ExportSearchRequest, type Lesson } from '../lib/api'
   import { navigate } from '../lib/router'
   import LessonCard from '../components/LessonCard.svelte'
 
@@ -13,23 +13,53 @@
 
   let lessons = $state<Lesson[]>([])
   let loading = $state(false)
+  let exporting = $state(false)
   let error = $state('')
   let status = $state('')
+
+  function buildSearchBody(): ExportSearchRequest {
+    return {
+      q: q.trim() || null,
+      topic_in: topic.trim() ? [topic.trim()] : null,
+      source_in: source.trim() ? [source.trim()] : null,
+      importance_gte: importanceGte ? Number(importanceGte) : null,
+      importance_lte: importanceLte ? Number(importanceLte) : null,
+      limit: Number(limit) || 20,
+      include_frontmatter: true,
+    }
+  }
+
+  function downloadMarkdown(content: string, filename: string) {
+    const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = filename
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  async function exportResults() {
+    exporting = true
+    error = ''
+    try {
+      const markdown = (await api.exportSearch(buildSearchBody(), 'markdown')) as string
+      const slug = q.trim().replace(/\s+/g, '-').slice(0, 40) || 'browse'
+      downloadMarkdown(markdown, `lele-export-${slug}.md`)
+      status = `Esportate ${lessons.length} LeLe → Markdown`
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e)
+    } finally {
+      exporting = false
+    }
+  }
 
   async function runSearch() {
     loading = true
     error = ''
     status = 'Ricerca…'
     try {
-      const body = {
-        q: q.trim() || null,
-        topic_in: topic.trim() ? [topic.trim()] : null,
-        source_in: source.trim() ? [source.trim()] : null,
-        importance_gte: importanceGte ? Number(importanceGte) : null,
-        importance_lte: importanceLte ? Number(importanceLte) : null,
-        limit: Number(limit) || 20,
-      }
-      lessons = await api.searchLessons(body)
+      lessons = await api.searchLessons(buildSearchBody())
       status = `${lessons.length} risultati`
     } catch (e) {
       lessons = []
@@ -101,6 +131,9 @@
     <div class="actions">
       <button class="btn btn-primary" onclick={runSearch} disabled={loading}>Cerca</button>
       <button class="btn" onclick={listAll} disabled={loading}>Lista tutte</button>
+      <button class="btn" onclick={exportResults} disabled={loading || exporting || lessons.length === 0}>
+        {exporting ? 'Esporto…' : 'Esporta .md'}
+      </button>
       <button class="btn" onclick={reset}>Reset</button>
     </div>
     {#if status}<p class="ok">{status}</p>{/if}

--- a/frontend/src/routes/Timeline.svelte
+++ b/frontend/src/routes/Timeline.svelte
@@ -5,7 +5,35 @@
   let groupBy = $state<'year' | 'month' | 'topic'>('month')
   let timeline = $state<TimelineResponse | null>(null)
   let loading = $state(false)
+  let exportingKey = $state('')
   let error = $state('')
+
+  function downloadMarkdown(content: string, filename: string) {
+    const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = filename
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  async function exportBucket(key: string, lessonIds: string[]) {
+    exportingKey = key
+    error = ''
+    try {
+      const markdown = (await api.exportSearch(
+        { ids_in: lessonIds, limit: lessonIds.length, include_frontmatter: true },
+        'markdown',
+      )) as string
+      const slug = key.replace(/[^\w.-]+/g, '-')
+      downloadMarkdown(markdown, `lele-timeline-${slug}.md`)
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e)
+    } finally {
+      exportingKey = ''
+    }
+  }
 
   async function load() {
     loading = true
@@ -55,6 +83,14 @@
             <div class="row">
               <strong>{bucket.key}</strong>
               <span class="meta">{bucket.count} LeLe</span>
+              <button
+                type="button"
+                class="export-btn"
+                disabled={!!exportingKey}
+                onclick={() => exportBucket(bucket.key, bucket.lesson_ids)}
+              >
+                {exportingKey === bucket.key ? '…' : 'Esporta'}
+              </button>
             </div>
             <div class="bar-wrap">
               <span
@@ -129,7 +165,19 @@
   .row {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    gap: 8px;
     margin-bottom: 8px;
+  }
+
+  .export-btn {
+    border: 1px solid var(--border);
+    background: white;
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    margin-left: auto;
   }
 
   .bar-wrap {

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -10,11 +10,12 @@ from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field
 from pathlib import Path
 from datetime import datetime, timezone
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi.responses import FileResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from threading import Lock
 
 from lele_manager.core.analytics import compute_stats_summary, compute_timeline
+from lele_manager.core.export import search_results_to_markdown
 from lele_manager.core.config import resolve_data_path, resolve_model_path
 from lele_manager.core.vault import (
     build_vault_tree,
@@ -149,6 +150,24 @@ class LessonSearchRequest(BaseModel):
         le=500,
         description="Numero massimo di risultati da restituire.",
     )
+
+
+class ExportSearchRequest(LessonSearchRequest):
+    """Payload per POST /export/search — stessi filtri di /lessons/search."""
+
+    include_frontmatter: bool = Field(
+        default=True,
+        description="Se true, ogni LeLe include frontmatter YAML (Obsidian-ready).",
+    )
+    ids_in: Optional[List[str]] = Field(
+        default=None,
+        description="Opzionale: limita l'export a questi ID (dopo gli altri filtri).",
+    )
+
+
+class ExportSearchResponse(BaseModel):
+    markdown: str
+    n_lessons: int
 
 
 class SimilarMeta(BaseModel):
@@ -707,6 +726,61 @@ def search_lessons(body: LessonSearchRequest) -> List[LessonSearchResult]:
     records = df.to_dict(orient="records")
     results: List[LessonSearchResult] = [_row_to_search_result(row) for row in records]
     return results
+
+
+def _export_filters_summary(body: ExportSearchRequest) -> str:
+    parts: List[str] = []
+    if body.q:
+        parts.append(f"q={body.q!r}")
+    if body.topic_in:
+        parts.append(f"topic_in={body.topic_in}")
+    if body.source_in:
+        parts.append(f"source_in={body.source_in}")
+    if body.importance_gte is not None:
+        parts.append(f"importance_gte={body.importance_gte}")
+    if body.importance_lte is not None:
+        parts.append(f"importance_lte={body.importance_lte}")
+    if body.ids_in:
+        parts.append(f"ids_in={len(body.ids_in)} ids")
+    parts.append(f"limit={body.limit}")
+    return ", ".join(parts) if parts else "(nessun filtro)"
+
+
+@app.post("/export/search")
+def export_search(
+    body: ExportSearchRequest,
+    format: Literal["markdown", "json"] = Query(
+        default="markdown",
+        description="markdown → text/markdown; json → {markdown, n_lessons}.",
+    ),
+):
+    """Esporta i risultati di una ricerca come documento Markdown."""
+    search_body = LessonSearchRequest(
+        q=body.q,
+        topic_in=body.topic_in,
+        source_in=body.source_in,
+        importance_gte=body.importance_gte,
+        importance_lte=body.importance_lte,
+        limit=body.limit,
+    )
+    results = search_lessons(search_body)
+    if body.ids_in:
+        allowed = {str(i) for i in body.ids_in}
+        results = [r for r in results if r.id in allowed]
+
+    markdown = search_results_to_markdown(
+        [r.model_dump() for r in results],
+        include_frontmatter=body.include_frontmatter,
+        filters_summary=_export_filters_summary(body),
+    )
+
+    if format == "json":
+        return ExportSearchResponse(markdown=markdown, n_lessons=len(results))
+
+    return Response(
+        content=markdown.encode("utf-8"),
+        media_type="text/markdown; charset=utf-8",
+    )
 
 
 @app.get("/lessons/{lesson_id:path}/similar", response_model=SimilarResponse, response_model_exclude_none=True)

--- a/src/lele_manager/cli/lele.py
+++ b/src/lele_manager/cli/lele.py
@@ -75,6 +75,65 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     # ------------------------------------------------------------------
+    # lele export
+    # ------------------------------------------------------------------
+    p_export = subparsers.add_parser(
+        "export",
+        help="Esporta risultati ricerca in Markdown (POST /export/search).",
+    )
+    p_export.add_argument(
+        "--search",
+        dest="q",
+        help="Testo da cercare (substring sul campo text).",
+    )
+    p_export.add_argument(
+        "--topic",
+        dest="topic_in",
+        action="append",
+        help="Filtra per uno o più topic (ripetibile).",
+    )
+    p_export.add_argument(
+        "--source",
+        dest="source_in",
+        action="append",
+        help="Filtra per una o più source (ripetibile).",
+    )
+    p_export.add_argument(
+        "--min-importance",
+        dest="importance_gte",
+        type=int,
+        help="Filtra per importance >= valore dato.",
+    )
+    p_export.add_argument(
+        "--max-importance",
+        dest="importance_lte",
+        type=int,
+        help="Filtra per importance <= valore dato.",
+    )
+    p_export.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Numero massimo di risultati (default: 50).",
+    )
+    p_export.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="File Markdown di destinazione.",
+    )
+    p_export.add_argument(
+        "--no-frontmatter",
+        action="store_true",
+        help="Esclude il frontmatter YAML (solo heading + body).",
+    )
+    p_export.add_argument(
+        "--json",
+        action="store_true",
+        help="Risposta API come JSON invece di salvare il file.",
+    )
+
+    # ------------------------------------------------------------------
     # lele show <id>
     # ------------------------------------------------------------------
     p_show = subparsers.add_parser(
@@ -345,6 +404,42 @@ def cmd_search(base_url: str, args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_export(base_url: str, args: argparse.Namespace) -> int:
+    payload: Dict[str, Any] = {
+        "q": args.q,
+        "topic_in": args.topic_in,
+        "source_in": args.source_in,
+        "importance_gte": args.importance_gte,
+        "importance_lte": args.importance_lte,
+        "limit": args.limit,
+        "include_frontmatter": not args.no_frontmatter,
+    }
+    payload = {k: v for k, v in payload.items() if v is not None}
+
+    params = {"format": "json" if args.json else "markdown"}
+
+    with httpx.Client(base_url=base_url, timeout=30.0) as client:
+        try:
+            resp = client.post("/export/search", json=payload, params=params)
+        except httpx.RequestError as exc:
+            print(f"[errore] Errore di rete verso {exc.request.url}: {exc}", file=sys.stderr)
+            return 1
+
+    if resp.status_code >= 400:
+        print(f"[errore] {resp.status_code} {resp.text}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        _print_json(resp.json())
+        return 0
+
+    markdown = resp.content.decode("utf-8")
+    out_path = Path(args.output)
+    out_path.write_text(markdown, encoding="utf-8")
+    print(f"[ok] Export salvato in {out_path} ({len(markdown)} caratteri UTF-8)")
+    return 0
+
+
 def cmd_show(base_url: str, args: argparse.Namespace) -> int:
     lesson_id = args.lesson_id
 
@@ -568,6 +663,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     try:
         if args.command == "search":
             code = cmd_search(base_url, args)
+        elif args.command == "export":
+            code = cmd_export(base_url, args)
         elif args.command == "show":
             code = cmd_show(base_url, args)
         elif args.command == "similar":

--- a/src/lele_manager/core/export.py
+++ b/src/lele_manager/core/export.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+from lele_manager.cli.import_from_dir import (
+    parse_markdown_with_frontmatter,
+    render_markdown_with_frontmatter,
+)
+
+
+def _lesson_body(text: str) -> str:
+    stripped = (text or "").lstrip()
+    if stripped.startswith("---"):
+        _, body = parse_markdown_with_frontmatter(text)
+        return body.strip()
+    return (text or "").strip()
+
+
+def lesson_to_markdown_block(lesson: Mapping[str, Any], *, include_frontmatter: bool) -> str:
+    """Render a single lesson as an Obsidian-friendly markdown block."""
+    text = str(lesson.get("text") or "")
+    lesson_id = str(lesson.get("id") or "")
+
+    if include_frontmatter:
+        if text.lstrip().startswith("---"):
+            return text.rstrip() + "\n"
+
+        frontmatter: dict[str, object] = {"id": lesson_id}
+        if lesson.get("topic"):
+            frontmatter["topic"] = lesson["topic"]
+        if lesson.get("source"):
+            frontmatter["source"] = lesson["source"]
+        if lesson.get("importance") is not None:
+            frontmatter["importance"] = int(lesson["importance"])
+        tags = lesson.get("tags")
+        if isinstance(tags, list) and tags:
+            frontmatter["tags"] = [str(t) for t in tags]
+        if lesson.get("date"):
+            frontmatter["date"] = lesson["date"]
+        if lesson.get("title"):
+            frontmatter["title"] = lesson["title"]
+
+        return render_markdown_with_frontmatter(frontmatter, _lesson_body(text))
+
+    title = lesson.get("title") or lesson_id
+    body = _lesson_body(text)
+    return f"## {title}\n\n**id:** `{lesson_id}`\n\n{body}\n"
+
+
+def search_results_to_markdown(
+    results: Sequence[Mapping[str, Any]],
+    *,
+    include_frontmatter: bool,
+    filters_summary: str | None = None,
+) -> str:
+    """Combine search hits into one markdown document."""
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    header_lines = [
+        "# LeLe export",
+        "",
+        f"_Generated: {generated}_",
+        f"_Lessons: {len(results)}_",
+    ]
+    if filters_summary:
+        header_lines.append(f"_Filters: {filters_summary}_")
+    header_lines.append("")
+
+    if not results:
+        header_lines.append("_Nessuna LeLe corrisponde ai filtri._")
+        return "\n".join(header_lines) + "\n"
+
+    blocks = [lesson_to_markdown_block(row, include_frontmatter=include_frontmatter) for row in results]
+    return "\n".join(header_lines) + "\n---\n\n".join(blocks) + "\n"

--- a/tests/test_export_search.py
+++ b/tests/test_export_search.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from fastapi.testclient import TestClient
+
+from lele_manager.api import server
+from lele_manager.core.export import lesson_to_markdown_block, search_results_to_markdown
+
+
+def _write_jsonl(path: Path, records: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+def test_lesson_to_markdown_with_frontmatter() -> None:
+    lesson = {
+        "id": "python/2025-01-01.pytest",
+        "text": "Corpo con emoji: caffè ☕",
+        "topic": "python",
+        "source": "note",
+        "importance": 4,
+        "tags": ["pytest", "python"],
+        "date": "2025-01-01",
+        "title": "Pytest tips",
+    }
+    md = lesson_to_markdown_block(lesson, include_frontmatter=True)
+    assert md.startswith("---\n")
+    assert "id: python/2025-01-01.pytest" in md
+    assert "tags:" in md
+    assert "caffè ☕" in md
+
+
+def test_lesson_to_markdown_without_frontmatter() -> None:
+    lesson = {"id": "x", "text": "solo body", "title": "Titolo"}
+    md = lesson_to_markdown_block(lesson, include_frontmatter=False)
+    assert md.startswith("## Titolo")
+    assert "solo body" in md
+    assert not md.startswith("---")
+
+
+def test_export_search_markdown_and_json(tmp_path, monkeypatch) -> None:
+    data_path = tmp_path / "lessons.jsonl"
+    records = [
+        {
+            "id": "1",
+            "text": "LeLe su pytest e Python",
+            "topic": "python",
+            "source": "note",
+            "importance": 4,
+            "tags": ["python", "pytest"],
+        },
+        {
+            "id": "2",
+            "text": "LeLe su Git",
+            "topic": "git",
+            "source": "note",
+            "importance": 3,
+            "tags": ["git"],
+        },
+    ]
+    _write_jsonl(data_path, records)
+    monkeypatch.setattr(server, "DATA_PATH", data_path, raising=False)
+
+    client = TestClient(server.app)
+
+    r_md = client.post(
+        "/export/search",
+        params={"format": "markdown"},
+        json={"q": "pytest", "limit": 10, "include_frontmatter": True},
+    )
+    assert r_md.status_code == 200
+    assert r_md.headers["content-type"].startswith("text/markdown")
+    text = r_md.content.decode("utf-8")
+    assert "# LeLe export" in text
+    assert "pytest" in text
+    assert "id: 1" in text or 'id: "1"' in text or "id: '1'" in text
+
+    r_json = client.post(
+        "/export/search",
+        params={"format": "json"},
+        json={"q": "pytest", "limit": 10},
+    )
+    assert r_json.status_code == 200
+    payload = r_json.json()
+    assert payload["n_lessons"] == 1
+    assert "pytest" in payload["markdown"]
+
+
+def test_export_search_ids_in_filter(tmp_path, monkeypatch) -> None:
+    data_path = tmp_path / "lessons.jsonl"
+    records = [
+        {"id": "a", "text": "alpha", "topic": "t"},
+        {"id": "b", "text": "beta", "topic": "t"},
+    ]
+    _write_jsonl(data_path, records)
+    monkeypatch.setattr(server, "DATA_PATH", data_path, raising=False)
+
+    client = TestClient(server.app)
+    r = client.post(
+        "/export/search",
+        params={"format": "json"},
+        json={"limit": 10, "ids_in": ["b"]},
+    )
+    assert r.status_code == 200
+    assert r.json()["n_lessons"] == 1
+    assert "beta" in r.json()["markdown"]
+
+
+def test_search_results_to_markdown_empty() -> None:
+    md = search_results_to_markdown([], include_frontmatter=True, filters_summary="q='x'")
+    assert "Nessuna LeLe" in md


### PR DESCRIPTION
## Summary
- Add `POST /export/search` with same filters as `/lessons/search`, plus `include_frontmatter` and `ids_in`.
- Output as `text/markdown` or JSON `{ markdown, n_lessons }`.
- GUI: **Esporta .md** in Browse; per-bucket export in Timeline.
- CLI: `lele export --search "pytest" --topic python -o results.md`.
- Mark Fase 4.2 checklist complete in `docs/phase-4-issue.md`.

## Test plan
- [x] `pytest tests/test_export_search.py` (5 tests)
- [x] Full suite: 94 passed, ruff clean
- [ ] CI green
- [ ] Manual: Browse → Cerca → Esporta .md opens valid Obsidian markdown


Made with [Cursor](https://cursor.com)