### PR TITLE
test(e2e): Playwright GUI smoke + CI job (Fase 4.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,47 @@ jobs:
       - name: Pytest
         run: pytest -q
 
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build GUI
+        run: ./scripts/build-gui.sh
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright E2E smoke
+        working-directory: frontend
+        run: npm run test:e2e
+        env:
+          CI: "true"
+
   packaging-smoke:
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,10 @@ vault/
 # Frontend / GUI build artifacts
 frontend/node_modules/
 frontend/dist/
+frontend/playwright-report/
+frontend/test-results/
 src/lele_manager/gui/static/*
 !src/lele_manager/gui/static/.gitkeep
+
+# E2E fixture (generated locally / in CI)
+.e2e-fixture/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Ogni volta che imparo qualcosa (da ChatGPT, da libri, da esperimenti), LeLe Mana
 
 ## ✅ Quality gates (quick scan)
 
-- **CI**: `ruff check .` + `pytest` (GitHub Actions, Python 3.12)
+- **CI**: `ruff check .` + `pytest` + Playwright E2E smoke (GitHub Actions, Python 3.12 + Node 22)
 - **Security**: `pip-audit` + `bandit` (GitHub Actions)
 - **pre-commit**: whitespace/end-of-file, `check-yaml`, `ruff`
 
@@ -516,6 +516,23 @@ npm install
 npm run dev
 # apri l'URL indicato da Vite (proxy verso :8000 se configurato)
 ```
+
+### Test E2E (Playwright)
+
+Smoke test sulla GUI servita dall'API (fixture JSONL + topic model dedicati):
+
+```bash
+# prerequisiti: Python venv con pip install -e ".[dev]", GUI buildata
+./scripts/build-gui.sh
+
+cd frontend
+npm install
+npx playwright install chromium   # prima volta
+npm run test:e2e
+```
+
+Lo script `scripts/e2e-serve.sh` avvia uvicorn su `:8765` con dataset `.e2e-fixture/`.
+In CI il job `e2e` esegue gli stessi test dopo build GUI + `pytest`.
 
 ---
 

--- a/docs/phase-4-issue.md
+++ b/docs/phase-4-issue.md
@@ -57,12 +57,12 @@ Questa fase porta la GUI da “funziona” a “mi fido mentre scrivo”: capire
 
 ### 4.3 Playwright E2E smoke
 
-- [ ] Setup `frontend/` — `@playwright/test`, script `npm run test:e2e`
-- [ ] CI: avvia API test fixture + build GUI + 3 smoke:
-  - [ ] browse → click risultato → detail
-  - [ ] editor: digita testo → suggest panel risponde (mock o dataset fixture)
-  - [ ] stats/timeline caricano senza 500
-- [ ] Documentare in README sezione “Test E2E”
+- [x] Setup `frontend/` — `@playwright/test`, script `npm run test:e2e`
+- [x] CI: avvia API test fixture + build GUI + 3 smoke:
+  - [x] browse → click risultato → detail
+  - [x] editor: digita testo → suggest panel risponde (mock o dataset fixture)
+  - [x] stats/timeline caricano senza 500
+- [x] Documentare in README sezione “Test E2E”
 
 **Non in scope:** copertura E2E completa di ogni vista.
 

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('GUI smoke', () => {
+  test('browse → click risultato → detail', async ({ page }) => {
+    await page.goto('/app/#/')
+    await expect(page.getByRole('heading', { name: 'Browse' })).toBeVisible()
+
+    const firstCard = page.locator('.lesson-card').first()
+    await expect(firstCard).toBeVisible({ timeout: 15_000 })
+    const lessonId = (await firstCard.locator('strong').textContent())?.trim()
+    expect(lessonId).toBeTruthy()
+
+    await firstCard.click()
+    await expect(page.getByRole('heading', { level: 2 })).toContainText(lessonId!)
+    await expect(page.getByRole('heading', { name: 'Perché simile?' })).toBeVisible()
+  })
+
+  test('editor: suggest panel risponde', async ({ page }) => {
+    await page.goto('/app/#/editor')
+    await page.getByPlaceholder('Scrivi la lesson learned…').fill(
+      'python pytest workflow con abbastanza testo per attivare il debounce del suggest live',
+    )
+    await page.waitForTimeout(800)
+
+    const panel = page.locator('.similar-panel')
+    await expect(panel).toBeVisible()
+    await expect(panel.getByRole('heading', { name: 'Perché simile?' })).toBeVisible()
+    await expect(panel.locator('.error')).toHaveCount(0)
+    await expect(panel.getByText('Caricamento…')).toHaveCount(0, { timeout: 15_000 })
+  })
+
+  test('stats e timeline caricano senza errori', async ({ page }) => {
+    await page.goto('/app/#/stats')
+    await expect(page.getByRole('heading', { name: 'Statistiche' })).toBeVisible()
+    await expect(page.locator('.stats .error')).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.locator('.kpi').first()).toBeVisible()
+
+    await page.getByRole('link', { name: 'Timeline' }).click()
+    await expect(page.getByRole('heading', { name: 'Timeline' })).toBeVisible()
+    await expect(page.locator('.timeline .error')).toHaveCount(0, { timeout: 15_000 })
+    await expect(page.locator('.bucket').first()).toBeVisible()
+  })
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "marked": "^18.0.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.51.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tsconfig/svelte": "^5.0.8",
         "@types/dompurify": "^3.0.5",
@@ -133,6 +134,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1005,6 +1022,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,9 +7,11 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"
+    "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.51.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tsconfig/svelte": "^5.0.8",
     "@types/dompurify": "^3.0.5",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: 'list',
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://127.0.0.1:8765',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'bash ../scripts/e2e-serve.sh',
+    url: 'http://127.0.0.1:8765/health',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/scripts/e2e-prepare.py
+++ b/scripts/e2e-prepare.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Prepare JSONL + topic model for Playwright E2E smoke tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_DIR = ROOT / ".e2e-fixture"
+DATA_PATH = FIXTURE_DIR / "lessons.jsonl"
+MODEL_PATH = FIXTURE_DIR / "topic_model.joblib"
+
+RECORDS = [
+    {
+        "id": "e2e/python-lesson",
+        "text": "python pytest testing workflow and fixtures",
+        "topic": "python",
+        "source": "note",
+        "importance": 4,
+        "tags": ["python", "pytest"],
+        "date": "2025-01-01",
+        "title": "Pytest workflow",
+        "created_at": "2025-01-01T10:00:00+00:00",
+    },
+    {
+        "id": "e2e/git-lesson",
+        "text": "git branching merge rebase strategies",
+        "topic": "git",
+        "source": "note",
+        "importance": 3,
+        "tags": ["git"],
+        "date": "2025-02-01",
+        "title": "Git branching",
+        "created_at": "2025-02-01T10:00:00+00:00",
+    },
+    {
+        "id": "e2e/linux-lesson",
+        "text": "linux networking iptables basics",
+        "topic": "linux",
+        "source": "note",
+        "importance": 2,
+        "tags": ["linux"],
+        "date": "2025-03-01",
+        "title": "Linux net",
+        "created_at": "2025-03-01T10:00:00+00:00",
+    },
+]
+
+
+def main() -> int:
+    sys.path.insert(0, str(ROOT / "src"))
+    from lele_manager.ml.features import TextFeatureConfig
+    from lele_manager.ml.topic_model import TopicModelConfig, save_topic_model, train_topic_model
+
+    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    with DATA_PATH.open("w", encoding="utf-8") as f:
+        for rec in RECORDS:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+    df = pd.read_json(DATA_PATH, lines=True)
+    cfg = TopicModelConfig(text_features=TextFeatureConfig(min_df=1))
+    pipeline = train_topic_model(df, config=cfg)
+    save_topic_model(pipeline, MODEL_PATH)
+    print(f"E2E fixture ready: {DATA_PATH} ({len(RECORDS)} lessons), {MODEL_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-serve.sh
+++ b/scripts/e2e-serve.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PYTHON_BIN="python"
+if ! command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+fi
+
+if [[ ! -f src/lele_manager/gui/static/index.html ]]; then
+  ./scripts/build-gui.sh
+fi
+
+"$PYTHON_BIN" scripts/e2e-prepare.py
+
+export LELE_DATA_PATH="$ROOT/.e2e-fixture/lessons.jsonl"
+export LELE_MODEL_PATH="$ROOT/.e2e-fixture/topic_model.joblib"
+
+exec "$PYTHON_BIN" -m uvicorn lele_manager.api.server:app --host 127.0.0.1 --port 8765


### PR DESCRIPTION
## Summary
- Add `@playwright/test` with `npm run test:e2e` and three smoke tests (browse→detail, editor suggest, stats/timeline).
- Fixture server (`scripts/e2e-prepare.py` + `e2e-serve.sh`) with dedicated JSONL + topic model.
- New CI job `e2e` (build GUI, Playwright chromium, smoke).
- README Test E2E section; Fase 4.3 checklist complete.

## Test plan
- [x] `npm run test:e2e` — 3 passed locally
- [x] `pytest` — 94 passed
- [ ] CI: test + e2e + packaging-smoke green


Made with [Cursor](https://cursor.com)