### PR TITLE
chore(release): v1.9.0 — Fase 4 complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ The format is based on **Keep a Changelog**.
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-05
+
+### Added
+- **Explain similarity (Fase 4.1, #90):** `explain=true` su `/similar`, `/editor/suggest`, `GET /lessons/{id}/similar` con rank, topic, `tags_shared` e meta query.
+- GUI: pannello **“Perché simile?”** in Detail e Editor (`SimilarPanel`).
+- CLI: `lele similar --explain`, `lele suggest --explain`.
+- **Export search → Markdown (Fase 4.2, #87):** `POST /export/search` (`text/markdown` o JSON), `core/export.py`.
+- GUI: **Esporta .md** in Browse; export per bucket in Timeline.
+- CLI: `lele export --search "…" --topic python -o results.md`.
+- **Playwright E2E smoke (Fase 4.3):** `npm run test:e2e`, fixture `scripts/e2e-prepare.py`, job CI `e2e`.
+- Test: `test_api_similar_explain.py`, `test_export_search.py`, `frontend/e2e/smoke.spec.ts`.
+
+### Changed
+- CI: tre job (`test`, `e2e`, `packaging-smoke`).
+
+### Docs
+- `docs/gui-design.md`: sezione Fase 4.
+- `docs/phase-4-issue.md`: tracking Fase 4 completo.
+- README: endpoint export, explain, Test E2E.
+
 ## [1.8.0] - 2026-07-05
 
 ### Added
@@ -164,7 +184,8 @@ _See [1.2.0] — same commit tag point; version marker for milestone tracking._
 - Date parsing (YAML → JSON).
 - NaN/NaT handling in the API layer.
 
-[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/gcomneno/lele-manager/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/gcomneno/lele-manager/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/gcomneno/lele-manager/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/gcomneno/lele-manager/compare/v1.5.0...v1.6.0

--- a/README.md
+++ b/README.md
@@ -466,10 +466,12 @@ Modalità “solo API” (dataset e modello già pronti):
 - `GET /health` → stato rapido del servizio (dati/modello presenti).
 - `GET /lessons` → lista/ricerca delle LeLe (query param base).
 - `GET /lessons/{id}` → dettaglio di una LeLe.
-- `GET /lessons/{id}/similar` → LeLe simili a quella indicata.
+- `GET /lessons/{id}/similar` → LeLe simili (`?explain=true` per rank, topic, tag overlap).
+- `POST /similar`, `POST /editor/suggest` → similarità da testo (`?explain=true` opzionale).
+- `POST /export/search` → export risultati ricerca in Markdown (`?format=markdown|json`).
+- `GET /stats/summary`, `GET /stats/timeline` → statistiche e timeline.
 - `POST /train/topic` → (ri)allena il topic model a partire da `data/lessons.jsonl`.
 - `POST /lessons/search` → ricerca avanzata con payload JSON (testo + filtri).
-- `POST /similar` → suggerisce LeLe simili a partire da testo libero (senza `lesson_id`).
 
 ---
 
@@ -488,14 +490,14 @@ Oltre alla CLI e al PoC legacy (`GET /ui`), LeLe Manager include una **GUI Svelt
 # http://127.0.0.1:8000/app/
 ```
 
-### Viste disponibili (Fase 1)
+### Viste disponibili
 
 | Vista | Cosa fa |
 |-------|---------|
-| **Browse** | Ricerca avanzata (`POST /lessons/search`) + filtri |
-| **Detail** | Lettura LeLe + pannello simili |
-| **Editor** | Scrittura con suggest live (`POST /editor/suggest`) |
-| **Timeline** | Acquisizione conoscenza per mese/anno/topic |
+| **Browse** | Ricerca avanzata + filtri + **Esporta .md** (v1.9) |
+| **Detail** | Lettura LeLe + pannello **“Perché simile?”** con explain (v1.9) |
+| **Editor** | Scrittura con suggest live + explain nel pannello simili |
+| **Timeline** | Acquisizione conoscenza + export per bucket (v1.9) |
 | **Stats** | Dashboard: conteggi, tag, topic, medie |
 | **Vault** | Albero filesystem reale (`GET /vault/tree`) + import |
 | **Ops** | Health + retrain + **import vault** + **refresh completo** |
@@ -669,6 +671,20 @@ Modalità watch (ogni 2 secondi):
 
 ```bash
 lele suggest --watch note.md --every 2
+```
+
+### 📤 Export ricerca in Markdown (v1.9)
+
+```bash
+lele export --search "pytest" --topic python -o results.md
+lele export --search "git" -o git-lessons.md --no-frontmatter
+```
+
+### 🔬 Explain similarity (v1.9)
+
+```bash
+lele similar "python/2025-01-01.slug" --explain
+lele suggest --text "pytest fixtures" --explain
 ```
 
 Opzioni principali:

--- a/docs/gui-design.md
+++ b/docs/gui-design.md
@@ -278,13 +278,13 @@ La GUI-alpha può usare solo API già presenti:
 
 ### Fase 3+
 
-| Endpoint | Issue correlata |
-|----------|-----------------|
-| `/stats/summary` | #88 |
-| `/lessons/timeline` | #89 |
-| `/export/search` | #87 |
-| `/similar/explain` (esteso) | #90 |
-| `/lessons/duplicates` | #85 |
+| Endpoint | Issue correlata | Stato |
+|----------|-----------------|-------|
+| `/stats/summary` | #88 | ✅ v1.8.0 |
+| `/stats/timeline` | #89 | ✅ v1.8.0 |
+| `/export/search` | #87 | ✅ v1.9.0 |
+| `explain=true` su similarità | #90 | ✅ v1.9.0 |
+| `/lessons/duplicates` | #85 | Fase 5 |
 
 ### Real-time suggest
 
@@ -399,3 +399,39 @@ lele-manager/
 - Epic GUI: [#95](https://github.com/gcomneno/lele-manager/issues/95)
 - Milestone: [v2.0](https://github.com/gcomneno/lele-manager/milestone/3)
 - Issue correlate: #88, #89, #87, #90, #85, #84, #92
+
+---
+
+## 11. Fase 4 — Explain, export, E2E ✅ (v1.9.0)
+
+| Blocco | Deliverable | Note |
+|--------|-------------|------|
+| 4.1 Explain | Pannello **“Perché simile?”** in Detail/Editor | `explain=true`: rank, topic, tag overlap, meta query |
+| 4.2 Export | `POST /export/search` + **Esporta .md** in Browse | Frontmatter YAML opzionale; export bucket in Timeline |
+| 4.3 E2E | Playwright smoke (3 test) | CI job `e2e`; `scripts/e2e-serve.sh` + fixture `.e2e-fixture/` |
+| 4.4 Release | CHANGELOG + bump `1.9.0` | Milestone GUI v2.0 — epic #95 |
+
+### Wireframe aggiornamenti
+
+**Detail / Editor — pannello destro:**
+```
+┌─ Perché simile? ─────────────────┐
+│ top_k=5, min_score=0.10           │
+│ #1  0.84  python                  │
+│ python/2025-01-01.slug            │
+│ tag in comune: pytest             │
+└───────────────────────────────────┘
+```
+
+**Browse — azioni:**
+```
+[Cerca] [Lista tutte] [Esporta .md] [Reset]
+```
+
+### CLI Fase 4
+
+```bash
+lele similar <id> --explain
+lele suggest --text "..." --explain
+lele export --search "pytest" --topic python -o results.md
+```

--- a/docs/phase-4-issue.md
+++ b/docs/phase-4-issue.md
@@ -68,9 +68,9 @@ Questa fase porta la GUI da “funziona” a “mi fido mentre scrivo”: capire
 
 ### 4.4 Documentazione & release
 
-- [ ] Aggiornare `docs/gui-design.md` (sezione Fase 4)
-- [ ] `CHANGELOG.md` + bump `1.9.0`
-- [ ] README: explain + export + E2E
+- [x] Aggiornare `docs/gui-design.md` (sezione Fase 4)
+- [x] `CHANGELOG.md` + bump `1.9.0`
+- [x] README: explain + export + E2E
 
 ---
 
@@ -86,11 +86,11 @@ Questa fase porta la GUI da “funziona” a “mi fido mentre scrivo”: capire
 
 ## Acceptance criteria (Fase 4 done)
 
-- [ ] In GUI vedo *perché* una LeLe è simile (non solo il numero)
-- [ ] Posso esportare una ricerca Browse in `.md` utilizzabile in Obsidian/vault
-- [ ] CI verde con smoke Playwright
-- [ ] `pytest` resta verde (nessuna regressione API)
-- [ ] Issue #90 e #87 chiudibili (o chiuse con riferimento a questa)
+- [x] In GUI vedo *perché* una LeLe è simile (non solo il numero)
+- [x] Posso esportare una ricerca Browse in `.md` utilizzabile in Obsidian/vault
+- [x] CI verde con smoke Playwright
+- [x] `pytest` resta verde (nessuna regressione API)
+- [x] Issue #90 e #87 chiudibili (o chiuse con riferimento a questa)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lele-manager"
-version = "1.8.0"
+version = "1.9.0"
 description = "Lesson Learned Manager: archivio intelligente di lesson learned testuali."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump version to **1.9.0** (`pyproject.toml`).
- `CHANGELOG.md`: Fase 4.1–4.3 (explain, export, E2E).
- `docs/gui-design.md` §11 + gap API aggiornati.
- README: endpoint export/explain, CLI export, viste GUI v1.9.
- `docs/phase-4-issue.md`: Fase 4.4 + acceptance criteria ✅.

## Test plan
- [x] Docs-only change
- [ ] CI green (test + e2e + packaging-smoke)


Made with [Cursor](https://cursor.com)