### PR TITLE
Fix frontmatter rewriting during vault import

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ Cosa fa:
 - crea in RAM una mappa `id → record`;
 - scrive da zero `data/lessons.jsonl` con una riga per ogni `id` unico.
 
+Il flag `--write-missing-frontmatter` completa o ripara soltanto i campi mancanti o
+non validi nei file Markdown. Un frontmatter già completo e valido non viene
+riscritto: le normalizzazioni necessarie al JSONL avvengono esclusivamente in RAM.
+
 ### Gestione dei duplicati: `--on-duplicate`
 
 L’identità delle LeLe è l’`id` nel frontmatter.

--- a/src/lele_manager/cli/import_from_dir.py
+++ b/src/lele_manager/cli/import_from_dir.py
@@ -69,7 +69,7 @@ def parse_markdown_with_frontmatter(content: str) -> Tuple[Dict[str, object], st
 
 
 def render_markdown_with_frontmatter(frontmatter: Dict[str, object], body: str) -> str:
-    fm_text = yaml.safe_dump(frontmatter, sort_keys=False).rstrip()
+    fm_text = yaml.safe_dump(frontmatter, allow_unicode=True, sort_keys=False).rstrip()
     return f"---\n{fm_text}\n---\n\n{body.rstrip()}\n"
 
 
@@ -86,7 +86,8 @@ def derive_id_from_path(md_path: Path, root_dir: Path) -> str:
 def derive_topic(frontmatter: Dict[str, object], md_path: Path, default_topic: Optional[str]) -> Optional[str]:
     if "topic" in frontmatter and isinstance(frontmatter["topic"], str):
         t = frontmatter["topic"].strip()
-        return t or None
+        if t:
+            return t
     if default_topic:
         return default_topic
     parent = md_path.parent.name
@@ -176,8 +177,9 @@ def import_from_dir(
             print(f"[warn] Impossibile leggere {rel_path} come UTF-8, salto.")
             continue
 
-        frontmatter, body = parse_markdown_with_frontmatter(content)
-        original_fm = dict(frontmatter)
+        source_frontmatter, body = parse_markdown_with_frontmatter(content)
+        frontmatter = dict(source_frontmatter)
+        source_frontmatter_changed = False
 
         # ID
         raw_id = frontmatter.get("id")
@@ -186,19 +188,30 @@ def import_from_dir(
         else:
             lele_id = derive_id_from_path(md_path, input_dir)
             frontmatter["id"] = lele_id
+            if write_missing_frontmatter:
+                source_frontmatter["id"] = lele_id
+                source_frontmatter_changed = True
 
         # topic
         topic = derive_topic(frontmatter, md_path, default_topic)
-        if write_missing_frontmatter and ("topic" not in frontmatter) and topic is not None:
+        if topic is not None and not (
+            isinstance(frontmatter.get("topic"), str) and frontmatter["topic"].strip()
+        ):
             frontmatter["topic"] = topic
+            if write_missing_frontmatter:
+                source_frontmatter["topic"] = topic
+                source_frontmatter_changed = True
 
         # source
-        if "source" in frontmatter and isinstance(frontmatter["source"], str):
-            source = frontmatter["source"].strip() or None
+        if isinstance(frontmatter.get("source"), str) and frontmatter["source"].strip():
+            source = frontmatter["source"].strip()
         else:
             source = default_source
-            if write_missing_frontmatter and default_source is not None:
-                frontmatter.setdefault("source", default_source)
+            if default_source is not None:
+                frontmatter["source"] = default_source
+                if write_missing_frontmatter:
+                    source_frontmatter["source"] = default_source
+                    source_frontmatter_changed = True
 
         # importance
         if "importance" in frontmatter:
@@ -206,25 +219,32 @@ def import_from_dir(
                 importance = int(frontmatter["importance"])  # type: ignore[arg-type]
             except (TypeError, ValueError):
                 importance = default_importance
-                if write_missing_frontmatter and default_importance is not None:
+                if default_importance is not None:
                     frontmatter["importance"] = int(default_importance)
+                    if write_missing_frontmatter:
+                        source_frontmatter["importance"] = int(default_importance)
+                        source_frontmatter_changed = True
         else:
             importance = default_importance
-            if write_missing_frontmatter and default_importance is not None:
+            if default_importance is not None:
                 frontmatter["importance"] = int(default_importance)
+                if write_missing_frontmatter:
+                    source_frontmatter["importance"] = int(default_importance)
+                    source_frontmatter_changed = True
 
         # tags
         tags = normalize_tags(frontmatter.get("tags"))
 
         # date (normalizzata)
         date = derive_date(frontmatter, md_path)
-        if write_missing_frontmatter:
-            if "date" in frontmatter:
-                norm = _normalize_frontmatter_date(frontmatter.get("date"))
-                if norm and frontmatter.get("date") != norm:
-                    frontmatter["date"] = norm
-            if "date" not in frontmatter and date is not None:
-                frontmatter["date"] = date
+        normalized_date = _normalize_frontmatter_date(frontmatter.get("date"))
+        if normalized_date is not None:
+            frontmatter["date"] = normalized_date
+        elif date is not None:
+            frontmatter["date"] = date
+            if write_missing_frontmatter:
+                source_frontmatter["date"] = date
+                source_frontmatter_changed = True
 
         # title
         title = None
@@ -264,13 +284,9 @@ def import_from_dir(
         records_by_id[lele_id] = record
         first_path_by_id[lele_id] = md_path
 
-        # Riscrivi se il frontmatter è cambiato (non solo id)
-        if write_missing_frontmatter:
-            before = yaml.safe_dump(original_fm, sort_keys=True)
-            after = yaml.safe_dump(frontmatter, sort_keys=True)
-            if before != after:
-                new_content = render_markdown_with_frontmatter(frontmatter, body)
-                files_to_update.append((md_path, new_content))
+        if write_missing_frontmatter and source_frontmatter_changed:
+            new_content = render_markdown_with_frontmatter(source_frontmatter, body)
+            files_to_update.append((md_path, new_content))
 
     if files_to_update:
         print(f"[info] Aggiorno {len(files_to_update)} file per aggiungere/sincronizzare il frontmatter.")
@@ -317,7 +333,10 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--write-missing-frontmatter",
         action="store_true",
-        help="Se impostato, aggiunge/sincronizza il frontmatter (id incluso) nei file che ne sono sprovvisti.",
+        help=(
+            "Completa o ripara i campi mancanti/non validi del frontmatter sorgente; "
+            "i file già validi non vengono riscritti."
+        ),
     )
     return parser.parse_args(argv)
 

--- a/tests/test_import_from_dir.py
+++ b/tests/test_import_from_dir.py
@@ -52,7 +52,7 @@ def test_import_writes_missing_frontmatter_fields(tmp_path: Path) -> None:
     assert fm["date"] == "2025-11-20"
 
 
-def test_import_normalizes_yaml_date_type(tmp_path: Path) -> None:
+def test_import_normalizes_yaml_date_type_without_rewriting_source(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     vault.mkdir()
 
@@ -69,6 +69,7 @@ Body
 """,
         encoding="utf-8",
     )
+    original = md.read_bytes()
 
     records = import_from_dir(
         input_dir=vault,
@@ -81,8 +82,5 @@ Body
 
     rec = records["x/1"]
     assert rec.date == "2025-01-01"
-
-    updated = md.read_text(encoding="utf-8")
-    fm = _read_frontmatter(updated)
-    # dopo rewrite, deve essere stringa YYYY-MM-DD, non oggetto date
-    assert fm["date"] == "2025-01-01"
+    assert rec.frontmatter["date"] == "2025-01-01"
+    assert md.read_bytes() == original

--- a/tests/test_import_from_dir_cli.py
+++ b/tests/test_import_from_dir_cli.py
@@ -262,3 +262,165 @@ def test_import_from_dir_on_duplicate_skip_keeps_first(tmp_path: Path) -> None:
     record = json.loads(lines[0])
     assert "PRIMO" in record.get("text", "")
     assert "SECONDO" not in record.get("text", "")
+
+
+
+def test_valid_frontmatter_is_byte_for_byte_unchanged(tmp_path: Path) -> None:
+    vault_dir = tmp_path / "vault"
+    vault_dir.mkdir()
+    md_path = vault_dir / "valid.md"
+    original = textwrap.dedent(
+        """\
+        ---
+        id: test/valid
+        topic: scrittura
+        source: note
+        importance: 3
+        tags: [italiano, qualità]
+        date: 2025-12-05
+        title: "Perché — è importante"
+        ---
+
+        Testo già valido con accenti.
+        """
+    ).encode("utf-8")
+    md_path.write_bytes(original)
+
+    output_path = tmp_path / "lessons.jsonl"
+    result = run_cmd(
+        [
+            sys.executable,
+            "-m",
+            "lele_manager.cli.import_from_dir",
+            str(vault_dir),
+            str(output_path),
+            "--default-source",
+            "note",
+            "--default-importance",
+            "3",
+            "--write-missing-frontmatter",
+        ]
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert md_path.read_bytes() == original
+
+
+def test_required_rewrite_preserves_unicode_and_field_order(tmp_path: Path) -> None:
+    vault_dir = tmp_path / "vault"
+    vault_dir.mkdir()
+    md_path = vault_dir / "unicode.md"
+    md_path.write_text(
+        textwrap.dedent(
+            """\
+            ---
+            id: test/unicode
+            topic: qualità
+            source: note
+            title: "Perché — già così"
+            tags: [caffè, città]
+            ---
+
+            È un contenuto leggibile.
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    result = run_cmd(
+        [
+            sys.executable,
+            "-m",
+            "lele_manager.cli.import_from_dir",
+            str(vault_dir),
+            str(tmp_path / "lessons.jsonl"),
+            "--default-importance",
+            "3",
+            "--write-missing-frontmatter",
+        ]
+    )
+
+    assert result.returncode == 0, result.stderr
+    rewritten = md_path.read_text(encoding="utf-8")
+    assert "qualità" in rewritten
+    assert "Perché — già così" in rewritten
+    assert "caffè" in rewritten
+    assert "\\u" not in rewritten
+    assert "\\x" not in rewritten
+    assert rewritten.index("title:") < rewritten.index("tags:") < rewritten.index("importance:")
+    assert _parse_frontmatter(rewritten)["importance"] == 3
+
+
+def test_jsonl_normalizes_metadata_without_rewriting_source(tmp_path: Path) -> None:
+    vault_dir = tmp_path / "vault"
+    vault_dir.mkdir()
+    md_path = vault_dir / "normalized.md"
+    original = textwrap.dedent(
+        """\
+        ---
+        id: test/normalized
+        topic: test
+        source: note
+        importance: "4"
+        tags: "python, pytest"
+        date: 2025-12-05
+        ---
+        Body.
+        """
+    ).encode("utf-8")
+    md_path.write_bytes(original)
+    output_path = tmp_path / "lessons.jsonl"
+
+    result = run_cmd(
+        [
+            sys.executable,
+            "-m",
+            "lele_manager.cli.import_from_dir",
+            str(vault_dir),
+            str(output_path),
+            "--write-missing-frontmatter",
+        ]
+    )
+
+    assert result.returncode == 0, result.stderr
+    record = json.loads(output_path.read_text(encoding="utf-8"))
+    assert record["date"] == "2025-12-05"
+    assert record["importance"] == 4
+    assert record["tags"] == ["python", "pytest"]
+    assert record["frontmatter"]["date"] == "2025-12-05"
+    assert md_path.read_bytes() == original
+
+
+def test_valid_vault_import_does_not_modify_sources(tmp_path: Path) -> None:
+    vault_dir = tmp_path / "vault"
+    vault_dir.mkdir()
+    sources = {
+        "a.md": b"---\nid: vault/a\ntopic: alpha\nsource: note\nimportance: 3\ntags: [alpha]\ndate: 2025-01-01\ntitle: LeLe A\n---\nA\n",
+        "b.md": "---\nid: vault/b\ntopic: beta\nsource: note\nimportance: 5\ntags: [città]\ndate: 2025-01-02\ntitle: LeLe B\n---\nB — è valido\n".encode("utf-8"),
+    }
+    for name, content in sources.items():
+        (vault_dir / name).write_bytes(content)
+    output_path = tmp_path / "lessons.jsonl"
+
+    result = run_cmd(
+        [
+            sys.executable,
+            "-m",
+            "lele_manager.cli.import_from_dir",
+            str(vault_dir),
+            str(output_path),
+            "--default-source",
+            "note",
+            "--default-importance",
+            "3",
+            "--write-missing-frontmatter",
+        ]
+    )
+
+    assert result.returncode == 0, result.stderr
+    records = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert [(record["id"], record["date"]) for record in records] == [
+        ("vault/a", "2025-01-01"),
+        ("vault/b", "2025-01-02"),
+    ]
+    assert {name: (vault_dir / name).read_bytes() for name in sources} == sources


### PR DESCRIPTION
## Summary

- separate source frontmatter from in-memory normalized metadata
- rewrite Markdown only when a field is actually missing or invalid
- preserve readable Unicode and field order when a rewrite is required
- document the effective behavior of `--write-missing-frontmatter`
- add regression coverage for byte-for-byte source preservation and JSONL normalization

## Validation

- targeted tests: `10 passed`
- full suite: `95 passed, 3 skipped`
- Ruff: all checks passed
- `git diff --check`: clean
- real vault regression: 55 Markdown files imported, 55 JSONL records generated, vault remained unchanged

Closes #105