### PR TITLE
Add read-only vault doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Convenzioni (soft):
 - directory = **topic** principale (`python`, `cpp`, `linux`, `writing`, …);
 - filename = `YYYY-MM-DD.slug.md` (senza underscore, usa `.` e `-`).
 
-### Frontmatter YAML: schema base
+### Frontmatter YAML: schema accettato dall'importer
 
 Ogni LeLe può avere in testa un frontmatter YAML:
 
@@ -161,7 +161,8 @@ title: "LL-5 — std::cin vs std::getline"
 ---
 ```
 
-Campi supportati (tutti opzionali, tranne `id` che viene generato se manca):
+L'importer accetta uno schema tollerante. I campi sono opzionali; quando `id`
+manca viene generato dal percorso:
 
 - `id` (str) → identità stabile della LeLe
   - se non presente, viene derivato dal path relativo, es. `cpp/2025-11-20.cin-vs-getline`;
@@ -174,6 +175,52 @@ Campi supportati (tutti opzionali, tranne `id` che viene generato se manca):
 - `title` (str) → titolo umano della LeLe (opzionale).
 
 Internamente LeLe Manager calcola anche un `frontmatter_hash` (hash del solo frontmatter) utile per debug/versioning, ma l’identità resta sempre `id`.
+
+Questo è lo schema di ingresso accettato dall'importer, non una garanzia che ogni
+file importabile superi anche i controlli canonici di `doctor`.
+
+### Schema canonico validato da doctor
+
+`lele doctor` applica uno schema distinto e rigoroso. Richiede tutti e sette i
+campi `id`, `topic`, `source`, `importance`, `tags`, `date` e `title`; `id`,
+`topic`, `source` e `title` devono essere stringhe non vuote, `importance` un
+intero tra 1 e 5, `date` una data valida `YYYY-MM-DD` e `tags` una lista non
+vuota composta da stringhe non vuote. Richiede inoltre un body Markdown non
+vuoto.
+
+Quando è disponibile un contesto vault, ogni file selezionato deve appartenere
+alla sua radice, anche dopo la risoluzione dei symlink. Nel vault canonico,
+`topic` deve corrispondere alla prima directory del percorso relativo e `id` al
+percorso relativo senza estensione `.md`. Di conseguenza, dopo aver spostato un
+file occorre riallineare anche il suo `id` (e il `topic`, se cambia directory)
+perché superi `doctor`. Soltanto la validazione locale senza alcun contesto vault
+omette i controlli basati sul percorso.
+
+### Controllo locale del vault
+
+`lele doctor` verifica i file Markdown localmente, senza richiedere il server API e
+senza scrivere o riserializzare i Markdown. Non modifica intenzionalmente
+contenuto, mtime o permessi; la lettura può però causare l'aggiornamento
+dell'access time da parte del filesystem.
+
+```bash
+# Controlla ricorsivamente il vault configurato in LELE_VAULT_DIR
+lele doctor
+
+# Controlla ricorsivamente un vault specifico
+lele doctor --vault /path/to/LeLeVault
+
+# Controlla soltanto uno o più file (usando il vault configurato come contesto)
+lele doctor "$LELE_VAULT_DIR/python/2026-07-13.example.md"
+
+# Produce un report JSON adatto agli script
+lele doctor --json
+```
+
+Il controllo valida frontmatter e body e cerca ID duplicati nell'intero vault
+disponibile. L'exit code è `0` per un report valido, `1` per errori di
+validazione e `2` per errori operativi o di utilizzo, inclusa la selezione di un
+file esterno al vault configurato.
 
 ### Import da vault Markdown → JSONL
 

--- a/src/lele_manager/cli/lele.py
+++ b/src/lele_manager/cli/lele.py
@@ -10,6 +10,14 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from lele_manager.core.doctor import (
+    DoctorOperationalError,
+    DoctorProblem,
+    DoctorReport,
+    check_markdown_files,
+)
+from lele_manager.core.vault import ENV_VAULT_DIR, resolve_vault_dir
+
 DEFAULT_BASE_URL = os.environ.get("LELE_API_URL", "http://127.0.0.1:8000")
 
 
@@ -278,6 +286,31 @@ def build_parser() -> argparse.ArgumentParser:
         "--json",
         action="store_true",
         help="Stampa la risposta come JSON invece che in formato umano.",
+    )
+
+    # ------------------------------------------------------------------
+    # lele doctor [FILE ...]
+    # ------------------------------------------------------------------
+    p_doctor = subparsers.add_parser(
+        "doctor",
+        help="Controlla localmente e senza modifiche le LeLe Markdown.",
+    )
+    p_doctor.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        metavar="FILE",
+        help="File Markdown da controllare (default: tutto il vault).",
+    )
+    p_doctor.add_argument(
+        "--vault",
+        type=Path,
+        help="Radice del vault e contesto per path e ID duplicati.",
+    )
+    p_doctor.add_argument(
+        "--json",
+        action="store_true",
+        help="Stampa un report JSON stabile.",
     )
 
     return parser
@@ -652,6 +685,61 @@ def cmd_timeline(base_url: str, args: argparse.Namespace) -> int:
     return 0
 
 
+def _print_human_doctor(report: DoctorReport) -> None:
+    problems_by_path: Dict[str, List[DoctorProblem]] = {}
+    for problem in report.problems:
+        problems_by_path.setdefault(problem.path, []).append(problem)
+
+    for path in report.checked_files:
+        file_problems = problems_by_path.get(path, [])
+        if not file_problems:
+            print(f"[ok] {path}")
+            continue
+        for problem in file_problems:
+            field = f" ({problem.field})" if problem.field else ""
+            print(f"[errore] {path}{field}: {problem.message}")
+
+    print(
+        f"[info] File controllati: {report.files_checked} | "
+        f"ID unici: {report.unique_ids} | Errori: {report.error_count}"
+    )
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    vault_dir: Optional[Path]
+    if args.vault is not None:
+        vault_dir = args.vault
+    elif not args.paths or os.environ.get(ENV_VAULT_DIR):
+        vault_dir = resolve_vault_dir()
+    else:
+        vault_dir = None
+
+    try:
+        report = check_markdown_files(args.paths, vault_dir=vault_dir)
+    except DoctorOperationalError as exc:
+        if args.json:
+            _print_json(
+                {
+                    "valid": False,
+                    "files_checked": 0,
+                    "checked_files": [],
+                    "unique_ids": 0,
+                    "error_count": 0,
+                    "problems": [],
+                    "operational_error": str(exc),
+                }
+            )
+        else:
+            print(f"[errore] {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        _print_json(report.to_dict())
+    else:
+        _print_human_doctor(report)
+    return 0 if report.valid else 1
+
+
 # ----------------------------------------------------------------------
 # main
 # ----------------------------------------------------------------------
@@ -677,6 +765,8 @@ def main(argv: Optional[List[str]] = None) -> None:
             code = cmd_stats(base_url, args)
         elif args.command == "timeline":
             code = cmd_timeline(base_url, args)
+        elif args.command == "doctor":
+            code = cmd_doctor(args)
         else:
             parser.error(f"Comando non riconosciuto: {args.command!r}")
             return

--- a/src/lele_manager/core/doctor.py
+++ b/src/lele_manager/core/doctor.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import datetime as dt
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
+
+import yaml
+
+
+REQUIRED_FIELDS = ("id", "topic", "source", "importance", "tags", "date", "title")
+NON_EMPTY_STRING_FIELDS = ("id", "topic", "source", "title")
+ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
+
+
+class _DiagnosticLoader(yaml.SafeLoader):
+    """Safe YAML loader that preserves date scalars for explicit validation."""
+
+
+_DiagnosticLoader.yaml_implicit_resolvers = {
+    key: [
+        (tag, regexp)
+        for tag, regexp in resolvers
+        if tag != "tag:yaml.org,2002:timestamp"
+    ]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+class DoctorOperationalError(Exception):
+    """An input or vault could not be inspected."""
+
+
+@dataclass(frozen=True)
+class DoctorProblem:
+    code: str
+    message: str
+    path: str
+    field: Optional[str] = None
+    severity: Literal["error"] = "error"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ParsedMarkdown:
+    frontmatter: Optional[Dict[str, Any]]
+    body: str
+    problem: Optional[Tuple[str, str]] = None
+
+
+@dataclass(frozen=True)
+class DoctorReport:
+    checked_files: Tuple[str, ...]
+    unique_ids: int
+    problems: Tuple[DoctorProblem, ...]
+
+    @property
+    def files_checked(self) -> int:
+        return len(self.checked_files)
+
+    @property
+    def error_count(self) -> int:
+        return sum(problem.severity == "error" for problem in self.problems)
+
+    @property
+    def valid(self) -> bool:
+        return self.error_count == 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "valid": self.valid,
+            "files_checked": self.files_checked,
+            "checked_files": list(self.checked_files),
+            "unique_ids": self.unique_ids,
+            "error_count": self.error_count,
+            "problems": [problem.to_dict() for problem in self.problems],
+        }
+
+
+def parse_markdown_diagnostic(content: str) -> ParsedMarkdown:
+    """Parse frontmatter while preserving diagnostically distinct failures."""
+    lines = content.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return ParsedMarkdown(
+            frontmatter=None,
+            body=content,
+            problem=("missing_frontmatter", "frontmatter YAML assente"),
+        )
+
+    end_idx = next(
+        (index for index, line in enumerate(lines[1:], start=1) if line.strip() == "---"),
+        None,
+    )
+    if end_idx is None:
+        return ParsedMarkdown(
+            frontmatter=None,
+            body="",
+            problem=("unclosed_frontmatter", "delimitatore finale del frontmatter assente"),
+        )
+
+    yaml_text = "\n".join(lines[1:end_idx])
+    body = "\n".join(lines[end_idx + 1 :]).lstrip("\n")
+    try:
+        loaded = yaml.load(yaml_text, Loader=_DiagnosticLoader)
+    except yaml.YAMLError as exc:
+        detail = str(exc).splitlines()[0]
+        return ParsedMarkdown(
+            frontmatter=None,
+            body=body,
+            problem=("invalid_yaml", f"YAML non valido: {detail}"),
+        )
+
+    if loaded is None:
+        loaded = {}
+    if not isinstance(loaded, dict):
+        return ParsedMarkdown(
+            frontmatter=None,
+            body=body,
+            problem=("frontmatter_not_mapping", "il frontmatter deve essere un mapping YAML"),
+        )
+    return ParsedMarkdown(frontmatter=loaded, body=body)
+
+
+def _display_path(path: Path, vault_dir: Optional[Path]) -> str:
+    if vault_dir is not None:
+        try:
+            return path.relative_to(vault_dir).as_posix()
+        except ValueError:
+            pass
+    return path.as_posix()
+
+
+def _problem(
+    problems: List[DoctorProblem],
+    *,
+    code: str,
+    message: str,
+    path: str,
+    field: Optional[str] = None,
+) -> None:
+    problems.append(DoctorProblem(code=code, message=message, path=path, field=field))
+
+
+def _valid_date(value: object) -> bool:
+    if isinstance(value, dt.datetime):
+        return False
+    if isinstance(value, dt.date):
+        return value.isoformat() == str(value)
+    if not isinstance(value, str) or ISO_DATE_RE.fullmatch(value) is None:
+        return False
+    try:
+        return dt.date.fromisoformat(value).isoformat() == value
+    except ValueError:
+        return False
+
+
+def _validate_frontmatter(
+    frontmatter: Dict[str, Any],
+    body: str,
+    *,
+    path: Path,
+    display_path: str,
+    vault_dir: Optional[Path],
+) -> List[DoctorProblem]:
+    problems: List[DoctorProblem] = []
+    for field in REQUIRED_FIELDS:
+        if field not in frontmatter:
+            _problem(
+                problems,
+                code="missing_field",
+                message=f"campo obbligatorio '{field}' assente",
+                path=display_path,
+                field=field,
+            )
+
+    for field in NON_EMPTY_STRING_FIELDS:
+        if field not in frontmatter:
+            continue
+        value = frontmatter[field]
+        if not isinstance(value, str) or not value.strip():
+            _problem(
+                problems,
+                code="invalid_non_empty_string",
+                message=f"{field} deve essere una stringa non vuota",
+                path=display_path,
+                field=field,
+            )
+
+    if "importance" in frontmatter:
+        importance = frontmatter["importance"]
+        if not isinstance(importance, int) or isinstance(importance, bool):
+            _problem(
+                problems,
+                code="invalid_importance_type",
+                message="importance deve essere un intero",
+                path=display_path,
+                field="importance",
+            )
+        elif not 1 <= importance <= 5:
+            _problem(
+                problems,
+                code="importance_out_of_range",
+                message="importance deve essere compresa tra 1 e 5",
+                path=display_path,
+                field="importance",
+            )
+
+    if "tags" in frontmatter:
+        tags = frontmatter["tags"]
+        if not isinstance(tags, list):
+            _problem(
+                problems,
+                code="invalid_tags_type",
+                message="tags deve essere una lista",
+                path=display_path,
+                field="tags",
+            )
+        elif not tags:
+            _problem(
+                problems,
+                code="invalid_tags",
+                message="tags deve contenere almeno una stringa non vuota",
+                path=display_path,
+                field="tags",
+            )
+        elif any(not isinstance(tag, str) or not tag.strip() for tag in tags):
+            _problem(
+                problems,
+                code="invalid_tag",
+                message="ogni tag deve essere una stringa non vuota",
+                path=display_path,
+                field="tags",
+            )
+
+    if "date" in frontmatter and not _valid_date(frontmatter["date"]):
+        _problem(
+            problems,
+            code="invalid_date",
+            message="date deve essere una data valida nel formato YYYY-MM-DD",
+            path=display_path,
+            field="date",
+        )
+
+    if not body.strip():
+        _problem(
+            problems,
+            code="empty_body",
+            message="il body Markdown non può essere vuoto",
+            path=display_path,
+        )
+
+    if vault_dir is not None:
+        relative = path.relative_to(vault_dir)
+        parts = relative.parts
+        expected_topic = parts[0] if len(parts) > 1 else None
+        topic = frontmatter.get("topic")
+        if expected_topic is None:
+            _problem(
+                problems,
+                code="missing_topic_directory",
+                message="il file deve trovarsi in una directory topic del vault",
+                path=display_path,
+                field="topic",
+            )
+        elif isinstance(topic, str) and topic.strip() and topic.strip() != expected_topic:
+            _problem(
+                problems,
+                code="topic_path_mismatch",
+                message=f"topic deve corrispondere alla directory '{expected_topic}'",
+                path=display_path,
+                field="topic",
+            )
+
+        expected_id = relative.with_suffix("").as_posix()
+        lesson_id = frontmatter.get("id")
+        if isinstance(lesson_id, str) and lesson_id.strip() and lesson_id.strip() != expected_id:
+            _problem(
+                problems,
+                code="id_path_mismatch",
+                message=f"id deve corrispondere al percorso '{expected_id}'",
+                path=display_path,
+                field="id",
+            )
+    return problems
+
+
+def _read_and_parse(path: Path) -> ParsedMarkdown:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return ParsedMarkdown(
+            frontmatter=None,
+            body="",
+            problem=("invalid_utf8", "il file non è leggibile come UTF-8"),
+        )
+    except OSError as exc:
+        raise DoctorOperationalError(f"impossibile leggere {path}: {exc}") from exc
+    return parse_markdown_diagnostic(content)
+
+
+def _markdown_files(vault_dir: Path) -> List[Path]:
+    try:
+        paths: List[Path] = []
+        for candidate in vault_dir.rglob("*.md"):
+            if not candidate.is_file():
+                continue
+            path = candidate.resolve()
+            try:
+                path.relative_to(vault_dir)
+            except ValueError as exc:
+                raise DoctorOperationalError(
+                    f"file Markdown fuori dalla radice del vault: {candidate} -> {path}"
+                ) from exc
+            paths.append(path)
+        return sorted(paths, key=lambda path: path.as_posix())
+    except OSError as exc:
+        raise DoctorOperationalError(f"impossibile scandire il vault {vault_dir}: {exc}") from exc
+
+
+def _resolve_inputs(paths: Sequence[Path], vault_dir: Optional[Path]) -> Tuple[List[Path], Optional[Path]]:
+    resolved_vault = vault_dir.expanduser().resolve() if vault_dir is not None else None
+    if resolved_vault is not None and not resolved_vault.is_dir():
+        raise DoctorOperationalError(f"vault non trovato: {resolved_vault}")
+
+    if not paths:
+        if resolved_vault is None:
+            raise DoctorOperationalError("vault non disponibile (usa --vault o LELE_VAULT_DIR)")
+        return _markdown_files(resolved_vault), resolved_vault
+
+    resolved_paths: List[Path] = []
+    for raw_path in paths:
+        path = raw_path.expanduser().resolve()
+        if not path.exists():
+            raise DoctorOperationalError(f"path non trovato: {path}")
+        if not path.is_file():
+            raise DoctorOperationalError(f"il path non è un file: {path}")
+        if resolved_vault is not None:
+            try:
+                path.relative_to(resolved_vault)
+            except ValueError as exc:
+                raise DoctorOperationalError(
+                    f"file selezionato fuori dalla radice del vault: {raw_path} -> {path}"
+                ) from exc
+        if path.suffix.lower() != ".md":
+            raise DoctorOperationalError(f"il file non è Markdown (.md): {path}")
+        resolved_paths.append(path)
+    return sorted(set(resolved_paths), key=lambda path: path.as_posix()), resolved_vault
+
+
+def check_markdown_files(
+    paths: Sequence[Path],
+    *,
+    vault_dir: Optional[Path] = None,
+) -> DoctorReport:
+    """Validate selected Markdown files, using a vault as global context when given."""
+    checked_paths, resolved_vault = _resolve_inputs(paths, vault_dir)
+    checked_set = set(checked_paths)
+    context_paths = _markdown_files(resolved_vault) if resolved_vault is not None else checked_paths
+    context_paths = sorted(set(context_paths) | checked_set, key=lambda path: path.as_posix())
+
+    parsed_by_path: Dict[Path, ParsedMarkdown] = {}
+    ids_to_paths: Dict[str, List[Path]] = {}
+    for path in context_paths:
+        parsed = _read_and_parse(path)
+        parsed_by_path[path] = parsed
+        if parsed.frontmatter is not None:
+            raw_id = parsed.frontmatter.get("id")
+            if isinstance(raw_id, str) and raw_id.strip():
+                ids_to_paths.setdefault(raw_id.strip(), []).append(path)
+
+    problems: List[DoctorProblem] = []
+    checked_display = tuple(_display_path(path, resolved_vault) for path in checked_paths)
+    for path in checked_paths:
+        display_path = _display_path(path, resolved_vault)
+        parsed = parsed_by_path[path]
+        if parsed.problem is not None:
+            code, message = parsed.problem
+            _problem(problems, code=code, message=message, path=display_path)
+            continue
+        assert parsed.frontmatter is not None
+        problems.extend(
+            _validate_frontmatter(
+                parsed.frontmatter,
+                parsed.body,
+                path=path,
+                display_path=display_path,
+                vault_dir=resolved_vault,
+            )
+        )
+
+        raw_id = parsed.frontmatter.get("id")
+        if isinstance(raw_id, str) and raw_id.strip():
+            duplicate_paths = ids_to_paths.get(raw_id.strip(), [])
+            if len(duplicate_paths) > 1:
+                locations = ", ".join(_display_path(item, resolved_vault) for item in duplicate_paths)
+                _problem(
+                    problems,
+                    code="duplicate_id",
+                    message=f"id '{raw_id.strip()}' condiviso da: {locations}",
+                    path=display_path,
+                    field="id",
+                )
+
+    problems.sort(key=lambda item: (item.path, item.code, item.field or "", item.message))
+    return DoctorReport(
+        checked_files=checked_display,
+        unique_ids=len(ids_to_paths),
+        problems=tuple(problems),
+    )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from lele_manager.cli import lele as lele_cli
+from lele_manager.core.doctor import (
+    DoctorOperationalError,
+    check_markdown_files,
+    parse_markdown_diagnostic,
+)
+
+
+def lesson_text(
+    lesson_id: str,
+    *,
+    topic: str = "python",
+    source: str = "note",
+    importance: object = 3,
+    tags: object = None,
+    date: str = "2026-07-13",
+    title: str = "Una lesson",
+    body: str = "Contenuto utile.",
+) -> str:
+    if tags is None:
+        tags = ["python", "test"]
+    tags_yaml = json.dumps(tags, ensure_ascii=False) if isinstance(tags, list) else str(tags)
+    return textwrap.dedent(
+        f"""\
+        ---
+        id: {lesson_id}
+        topic: {topic}
+        source: {source}
+        importance: {importance}
+        tags: {tags_yaml}
+        date: {date}
+        title: {title}
+        ---
+
+        {body}
+        """
+    )
+
+
+def write_valid(vault: Path, relative: str) -> Path:
+    path = vault / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        lesson_text(Path(relative).with_suffix("").as_posix(), topic=Path(relative).parts[0]),
+        encoding="utf-8",
+    )
+    return path
+
+
+def problem_codes(path: Path, vault: Path) -> set[str]:
+    report = check_markdown_files([path], vault_dir=vault)
+    return {problem.code for problem in report.problems}
+
+
+def run_cli(argv: list[str]) -> int:
+    with pytest.raises(SystemExit) as exc_info:
+        lele_cli.main(argv)
+    assert isinstance(exc_info.value.code, int)
+    return exc_info.value.code
+
+
+def test_completely_valid_lesson_passes(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    path = write_valid(vault, "python/2026-07-13.valid.md")
+
+    report = check_markdown_files([path], vault_dir=vault)
+
+    assert report.valid
+    assert report.files_checked == 1
+    assert report.unique_ids == 1
+    assert report.problems == ()
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_code"),
+    [
+        ("Solo body.\n", "missing_frontmatter"),
+        ("---\nid: broken\n", "unclosed_frontmatter"),
+        ("---\nid: [broken\n---\nBody\n", "invalid_yaml"),
+        ("---\n- one\n- two\n---\nBody\n", "frontmatter_not_mapping"),
+    ],
+)
+def test_frontmatter_diagnostics(
+    tmp_path: Path, content: str, expected_code: str
+) -> None:
+    vault = tmp_path / "vault"
+    path = vault / "python" / "broken.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(content, encoding="utf-8")
+
+    assert expected_code in problem_codes(path, vault)
+
+
+def test_valid_but_empty_yaml_frontmatter_is_distinct_from_parse_errors(
+    tmp_path: Path,
+) -> None:
+    content = "---\n---\nBody presente.\n"
+    parsed = parse_markdown_diagnostic(content)
+    vault = tmp_path / "vault"
+    path = vault / "python" / "empty-frontmatter.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(content, encoding="utf-8")
+
+    report = check_markdown_files([path], vault_dir=vault)
+
+    assert parsed.problem is None
+    assert parsed.frontmatter == {}
+    assert {problem.code for problem in report.problems} == {"missing_field"}
+    assert {problem.field for problem in report.problems} == {
+        "id",
+        "topic",
+        "source",
+        "importance",
+        "tags",
+        "date",
+        "title",
+    }
+
+
+def test_missing_required_field(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    path = write_valid(vault, "python/missing.md")
+    path.write_text(path.read_text(encoding="utf-8").replace("source: note\n", ""), encoding="utf-8")
+
+    report = check_markdown_files([path], vault_dir=vault)
+
+    assert any(p.code == "missing_field" and p.field == "source" for p in report.problems)
+
+
+@pytest.mark.parametrize("field", ["id", "topic", "source", "title"])
+def test_required_string_must_be_non_empty(tmp_path: Path, field: str) -> None:
+    vault = tmp_path / "vault"
+    path = write_valid(vault, "python/empty.md")
+    content = path.read_text(encoding="utf-8")
+    content = content.replace(f"{field}: {('python/empty' if field == 'id' else 'python' if field == 'topic' else 'note' if field == 'source' else 'Una lesson')}\n", f"{field}: '   '\n")
+    path.write_text(content, encoding="utf-8")
+
+    report = check_markdown_files([path], vault_dir=vault)
+
+    assert any(p.code == "invalid_non_empty_string" and p.field == field for p in report.problems)
+
+
+@pytest.mark.parametrize(
+    ("importance", "expected_code"),
+    [("high", "invalid_importance_type"), (0, "importance_out_of_range"), (6, "importance_out_of_range")],
+)
+def test_invalid_importance(tmp_path: Path, importance: object, expected_code: str) -> None:
+    vault = tmp_path / "vault"
+    path = vault / "python" / "importance.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(lesson_text("python/importance", importance=importance), encoding="utf-8")
+
+    assert expected_code in problem_codes(path, vault)
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected_code"),
+    [("python", "invalid_tags_type"), ([], "invalid_tags"), (["python", ""], "invalid_tag"), (["python", 3], "invalid_tag")],
+)
+def test_invalid_tags(tmp_path: Path, tags: object, expected_code: str) -> None:
+    vault = tmp_path / "vault"
+    path = vault / "python" / "tags.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(lesson_text("python/tags", tags=tags), encoding="utf-8")
+
+    assert expected_code in problem_codes(path, vault)
+
+
+@pytest.mark.parametrize("date", ["13-07-2026", "2026-02-30"])
+def test_date_must_be_iso_and_real(tmp_path: Path, date: str) -> None:
+    vault = tmp_path / "vault"
+    path = vault / "python" / "date.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(lesson_text("python/date", date=date), encoding="utf-8")
+
+    assert "invalid_date" in problem_codes(path, vault)
+
+
+def test_body_must_not_be_empty(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    path = vault / "python" / "empty-body.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(lesson_text("python/empty-body", body="   "), encoding="utf-8")
+
+    assert "empty_body" in problem_codes(path, vault)
+
+
+def test_topic_and_id_must_match_vault_path(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    path = vault / "python" / "actual.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(lesson_text("other/wrong", topic="other"), encoding="utf-8")
+
+    codes = problem_codes(path, vault)
+
+    assert "topic_path_mismatch" in codes
+    assert "id_path_mismatch" in codes
+
+
+def test_duplicate_id_is_found_in_whole_vault_for_selected_file(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    selected = write_valid(vault, "python/selected.md")
+    duplicate = vault / "other" / "duplicate.md"
+    duplicate.parent.mkdir(parents=True)
+    duplicate.write_text(lesson_text("python/selected", topic="other"), encoding="utf-8")
+
+    report = check_markdown_files([selected], vault_dir=vault)
+
+    duplicate_problem = next(problem for problem in report.problems if problem.code == "duplicate_id")
+    assert "python/selected.md" in duplicate_problem.message
+    assert "other/duplicate.md" in duplicate_problem.message
+    assert report.files_checked == 1
+
+
+def test_non_utf8_is_a_validation_problem(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    path = vault / "python" / "binary.md"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"\xff\xfe")
+
+    assert "invalid_utf8" in problem_codes(path, vault)
+
+
+def test_cli_multiple_explicit_files_and_exit_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    vault = tmp_path / "vault"
+    first = write_valid(vault, "python/first.md")
+    second = write_valid(vault, "linux/second.md")
+    monkeypatch.setenv("LELE_VAULT_DIR", str(vault))
+
+    code = run_cli(["doctor", str(second), str(first)])
+
+    output = capsys.readouterr()
+    assert code == 0
+    assert output.err == ""
+    assert "[ok] linux/second.md" in output.out
+    assert "[ok] python/first.md" in output.out
+    assert "File controllati: 2" in output.out
+
+
+def test_cli_scans_vault_recursively_and_returns_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault = tmp_path / "vault"
+    write_valid(vault, "python/good.md")
+    broken = vault / "nested" / "deeper" / "bad.md"
+    broken.parent.mkdir(parents=True)
+    broken.write_text("No frontmatter\n", encoding="utf-8")
+    monkeypatch.setenv("LELE_VAULT_DIR", str(vault))
+
+    code = run_cli(["doctor"])
+
+    output = capsys.readouterr()
+    assert code == 1
+    assert output.err == ""
+    assert "nested/deeper/bad.md" in output.out
+    assert "File controllati: 2" in output.out
+
+
+def test_cli_json_is_stable_and_contains_no_human_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    vault = tmp_path / "vault"
+    write_valid(vault, "python/valid.md")
+
+    code = run_cli(["doctor", "--vault", str(vault), "--json"])
+
+    output = capsys.readouterr()
+    payload = json.loads(output.out)
+    assert code == 0
+    assert output.err == ""
+    assert payload == {
+        "valid": True,
+        "files_checked": 1,
+        "checked_files": ["python/valid.md"],
+        "unique_ids": 1,
+        "error_count": 0,
+        "problems": [],
+    }
+
+
+def test_cli_returns_two_for_missing_input(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "missing.md"
+
+    code = run_cli(["doctor", str(missing)])
+
+    output = capsys.readouterr()
+    assert code == 2
+    assert output.out == ""
+    assert "path non trovato" in output.err
+
+
+def test_explicit_file_outside_vault_is_an_operational_error(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    external = tmp_path / "external.md"
+    external.write_text(lesson_text("external"), encoding="utf-8")
+
+    with pytest.raises(DoctorOperationalError, match="fuori dalla radice del vault"):
+        check_markdown_files([external], vault_dir=vault)
+
+
+def test_explicit_file_without_vault_context_uses_local_validation(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "standalone.md"
+    path.write_text(
+        lesson_text("stable-id", topic="not-derived-from-path"),
+        encoding="utf-8",
+    )
+
+    report = check_markdown_files([path])
+
+    assert report.valid
+    assert report.checked_files == (path.resolve().as_posix(),)
+
+
+def test_cli_json_for_file_outside_vault_is_only_stdout_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    external = tmp_path / "external.md"
+    external.write_text(lesson_text("external"), encoding="utf-8")
+
+    code = run_cli(
+        ["doctor", "--vault", str(vault), "--json", str(external)]
+    )
+
+    output = capsys.readouterr()
+    payload = json.loads(output.out)
+    assert code == 2
+    assert output.err == ""
+    assert payload["valid"] is False
+    assert payload["files_checked"] == 0
+    assert payload["problems"] == []
+    assert "fuori dalla radice del vault" in payload["operational_error"]
+
+
+def test_symlink_in_vault_pointing_outside_is_an_operational_error(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    topic_dir = vault / "python"
+    topic_dir.mkdir(parents=True)
+    external = tmp_path / "external.md"
+    external.write_text(lesson_text("python/external"), encoding="utf-8")
+    link = topic_dir / "external.md"
+    try:
+        link.symlink_to(external)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink non disponibili: {exc}")
+
+    with pytest.raises(DoctorOperationalError, match="fuori dalla radice del vault"):
+        check_markdown_files([link], vault_dir=vault)
+
+
+def test_recursive_vault_scan_rejects_symlink_pointing_outside(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    topic_dir = vault / "python"
+    topic_dir.mkdir(parents=True)
+    external = tmp_path / "external.md"
+    external.write_text(lesson_text("python/external"), encoding="utf-8")
+    link = topic_dir / "external.md"
+    try:
+        link.symlink_to(external)
+    except (NotImplementedError, OSError) as exc:
+        pytest.skip(f"symlink non disponibili: {exc}")
+
+    with pytest.raises(DoctorOperationalError, match="fuori dalla radice del vault"):
+        check_markdown_files([], vault_dir=vault)
+
+
+def test_empty_vault_is_valid(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    report = check_markdown_files([], vault_dir=vault)
+
+    assert report.valid
+    assert report.files_checked == 0
+    assert report.unique_ids == 0
+    assert report.problems == ()
+
+
+def test_doctor_does_not_write_or_change_mtime_and_mode(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    first = write_valid(vault, "python/first.md")
+    second = write_valid(vault, "linux/second.md")
+    os.chmod(first, 0o640)
+    before = {
+        path: (path.read_bytes(), path.stat().st_mtime_ns, path.stat().st_mode)
+        for path in (first, second)
+    }
+
+    report = check_markdown_files([], vault_dir=vault)
+
+    after = {
+        path: (path.read_bytes(), path.stat().st_mtime_ns, path.stat().st_mode)
+        for path in (first, second)
+    }
+    assert report.valid
+    assert after == before


### PR DESCRIPTION
## Summary

- add a local, read-only `lele doctor` command for validating Markdown lessons and whole vaults
- distinguish missing, unclosed, invalid, empty, and non-mapping YAML frontmatter
- validate canonical metadata, body content, topic/path coherence, ID/path coherence, and duplicate IDs
- support deterministic human-readable and JSON reports with reliable exit codes
- reject explicit files and Markdown symlinks that resolve outside the configured vault
- document the difference between the tolerant importer schema and the strict canonical doctor schema

## Usage

```text
lele doctor
lele doctor --vault /path/to/vault
lele doctor path/to/lesson.md path/to/other.md
lele doctor --json
```

## Exit codes

- `0`: all requested checks passed
- `1`: one or more validation errors
- `2`: operational or usage error

## Validation

- `python -m pytest -q tests/test_doctor.py` — 35 passed
- relevant CLI tests — 5 passed
- relevant importer tests — 10 passed
- `ruff check .` — passed
- `git diff --check` — passed

The complete local suite was also attempted with a timeout, but the existing `tests/test_api_basic.py::test_health_without_data_and_model` blocks at the first `TestClient` use in this environment; the same block reproduces in isolation and is outside this PR's modified areas.

Closes #84