### PR TITLE
Detect duplicate and near-duplicate lessons

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,8 @@ Modalità “solo API” (dataset e modello già pronti):
 - `GET /lessons` → lista/ricerca delle LeLe (query param base).
 - `GET /lessons/{id}` → dettaglio di una LeLe.
 - `GET /lessons/{id}/similar` → LeLe simili (`?explain=true` per rank, topic, tag overlap).
+- `GET /duplicates` → report read-only di duplicati esatti e quasi-duplicati
+  (`min_score`, `limit`, `exact_only`).
 - `POST /similar`, `POST /editor/suggest` → similarità da testo (`?explain=true` opzionale).
 - `POST /export/search` → export risultati ricerca in Markdown (`?format=markdown|json`).
 - `GET /stats/summary`, `GET /stats/timeline` → statistiche e timeline.
@@ -730,6 +732,30 @@ lele suggest --watch note.md --every 2
 lele export --search "pytest" --topic python -o results.md
 lele export --search "git" -o git-lessons.md --no-frontmatter
 ```
+
+### 🧬 Rilevare duplicati e quasi-duplicati
+
+`lele duplicates` analizza globalmente il dataset tramite l'API, senza modificare
+JSONL, vault o modelli:
+
+```bash
+lele duplicates
+lele duplicates --min-score 0.90 --limit 100
+lele duplicates --exact-only
+lele duplicates --json
+```
+
+I duplicati `exact` comprendono ID ripetuti e testi uguali dopo una
+normalizzazione prudente di Unicode, line ending e spazi finali. I candidati
+`near` sono invece coppie non esatte il cui punteggio cosine, calcolato con lo
+stesso estrattore fittato usato dalla similarità esistente, raggiunge
+`--min-score`. Topic, titolo, fonte, data e tag condivisi sono segnali
+esplicativi: da soli non rendono una coppia `near`.
+
+La soglia predefinita `0.85` è euristica e configurabile. Il modello addestrato
+è necessario per i `near`; `--exact-only` funziona senza modello. Il confronto
+globale usa tempo e memoria quadratici rispetto al numero di lesson ed è
+destinato all'attuale dataset personale, non a collezioni molto grandi.
 
 ### 🔬 Explain similarity (v1.9)
 

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -15,6 +15,7 @@ from fastapi.staticfiles import StaticFiles
 from threading import Lock
 
 from lele_manager.core.analytics import compute_stats_summary, compute_timeline
+from lele_manager.core.deduplication import DEFAULT_MIN_SCORE, find_duplicates
 from lele_manager.core.export import search_results_to_markdown
 from lele_manager.core.config import resolve_data_path, resolve_model_path
 from lele_manager.core.vault import (
@@ -212,6 +213,29 @@ class SimilarBatchRequest(BaseModel):
 
 class SimilarBatchResponse(BaseModel):
     items: List[SimilarResponse]
+
+
+class DuplicatePairResponse(BaseModel):
+    left_id: str
+    right_id: str
+    left_position: int
+    right_position: int
+    left_path: Optional[str] = None
+    right_path: Optional[str] = None
+    kind: Literal["exact", "near"]
+    score: float
+    reasons: List[str]
+    shared_tags: List[str]
+
+
+class DuplicateReportResponse(BaseModel):
+    lessons_analyzed: int
+    total_pairs: int
+    exact_pairs: int
+    near_pairs: int
+    min_score: float
+    exact_only: bool
+    pairs: List[DuplicatePairResponse]
 
 
 class TrainResponse(BaseModel):
@@ -597,6 +621,44 @@ def health() -> HealthResponse:
         has_data=has_data,
         has_model=has_model,
     )
+
+
+@app.get("/duplicates", response_model=DuplicateReportResponse)
+def duplicates(
+    min_score: float = Query(
+        default=DEFAULT_MIN_SCORE,
+        ge=0.0,
+        le=1.0,
+        description="Soglia euristica minima per le coppie near.",
+    ),
+    limit: Optional[int] = Query(
+        default=None,
+        ge=1,
+        le=10_000,
+        description="Numero massimo di coppie restituite, dopo l'ordinamento.",
+    ),
+    exact_only: bool = Query(
+        default=False,
+        description="Rileva solo duplicati esatti senza richiedere il modello.",
+    ),
+) -> DuplicateReportResponse:
+    """Analizza globalmente il dataset senza modificarlo."""
+    df = load_lessons_df()
+    transformer = None
+    feature_matrix = None
+    if not exact_only and len(df) > 1:
+        index = build_similarity_index(df)
+        transformer = index.transformer
+        feature_matrix = index.feature_matrix
+    report = find_duplicates(
+        df,
+        transformer=transformer,
+        feature_matrix=feature_matrix,
+        min_score=min_score,
+        exact_only=exact_only,
+        limit=limit,
+    )
+    return DuplicateReportResponse(**report.to_dict())
 
 
 @app.get("/lessons", response_model=List[LessonSearchResult])

--- a/src/lele_manager/cli/lele.py
+++ b/src/lele_manager/cli/lele.py
@@ -192,6 +192,35 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include rank, topic e meta di debug (explain=true).",
     )
 
+    # ------------------------------------------------------------------
+    # lele duplicates
+    # ------------------------------------------------------------------
+    p_duplicates = subparsers.add_parser(
+        "duplicates",
+        help="Rileva duplicati esatti e quasi-duplicati (GET /duplicates).",
+    )
+    p_duplicates.add_argument(
+        "--min-score",
+        type=float,
+        default=0.85,
+        help="Soglia euristica per i quasi-duplicati (default: 0.85).",
+    )
+    p_duplicates.add_argument(
+        "--limit",
+        type=int,
+        help="Numero massimo di coppie restituite.",
+    )
+    p_duplicates.add_argument(
+        "--exact-only",
+        action="store_true",
+        help="Cerca solo duplicati esatti; non richiede il modello.",
+    )
+    p_duplicates.add_argument(
+        "--json",
+        action="store_true",
+        help="Stampa il report JSON senza testo aggiuntivo.",
+    )
+
 
     # ------------------------------------------------------------------
     # lele suggest
@@ -403,6 +432,32 @@ def _print_human_similar(results: List[Dict[str, Any]], query: str, meta: Dict[s
         print(f"  {text_preview}")
 
 
+def _print_human_duplicates(report: Dict[str, Any]) -> None:
+    print(
+        f"[info] LeLe analizzate: {report.get('lessons_analyzed', 0)} | "
+        f"Coppie: {report.get('total_pairs', 0)} | "
+        f"Exact: {report.get('exact_pairs', 0)} | Near: {report.get('near_pairs', 0)} | "
+        f"Soglia: {report.get('min_score', 0.85)}"
+    )
+    pairs = report.get("pairs") or []
+    if not pairs:
+        print("[info] Nessun duplicato o quasi-duplicato trovato.")
+        return
+    for pair in pairs:
+        left = f"{pair.get('left_id', '')} (riga {int(pair.get('left_position', 0)) + 1})"
+        right = f"{pair.get('right_id', '')} (riga {int(pair.get('right_position', 0)) + 1})"
+        print(
+            f"- [{str(pair.get('kind', '')).upper()}] {left} ↔ {right} | "
+            f"score={float(pair.get('score', 0.0)):.4f}"
+        )
+        reasons = pair.get("reasons") or []
+        if reasons:
+            print(f"  motivi: {', '.join(str(reason) for reason in reasons)}")
+        shared_tags = pair.get("shared_tags") or []
+        if shared_tags:
+            print(f"  tag condivisi: {', '.join(str(tag) for tag in shared_tags)}")
+
+
 # ----------------------------------------------------------------------
 # Command handlers
 # ----------------------------------------------------------------------
@@ -532,6 +587,46 @@ def cmd_similar(base_url: str, args: argparse.Namespace) -> int:
         _print_json(data)
     else:
         _print_human_similar(results, query_text, meta)
+    return 0
+
+
+def cmd_duplicates(base_url: str, args: argparse.Namespace) -> int:
+    if not 0.0 <= args.min_score <= 1.0:
+        print("[errore] --min-score deve essere compreso tra 0 e 1.", file=sys.stderr)
+        return 2
+    if args.limit is not None and not 1 <= args.limit <= 10_000:
+        print("[errore] --limit deve essere compreso tra 1 e 10000.", file=sys.stderr)
+        return 2
+
+    params: Dict[str, Any] = {
+        "min_score": args.min_score,
+        "exact_only": args.exact_only,
+    }
+    if args.limit is not None:
+        params["limit"] = args.limit
+    with httpx.Client(base_url=base_url, timeout=60.0) as client:
+        try:
+            resp = client.get("/duplicates", params=params)
+        except httpx.RequestError as exc:
+            print(f"[errore] Errore di rete verso {exc.request.url}: {exc}", file=sys.stderr)
+            return 1
+
+    if resp.status_code == 503:
+        print(
+            "[errore] Modello mancante. Allena prima con: lele train-topic, "
+            "oppure usa --exact-only.",
+            file=sys.stderr,
+        )
+        return 1
+    if resp.status_code >= 400:
+        print(f"[errore] {resp.status_code} {resp.text}", file=sys.stderr)
+        return 1
+
+    data = resp.json()
+    if args.json:
+        _print_json(data)
+    else:
+        _print_human_duplicates(data)
     return 0
 
 def _read_text_or_stdin(args: argparse.Namespace) -> str:
@@ -757,6 +852,8 @@ def main(argv: Optional[List[str]] = None) -> None:
             code = cmd_show(base_url, args)
         elif args.command == "similar":
             code = cmd_similar(base_url, args)
+        elif args.command == "duplicates":
+            code = cmd_duplicates(base_url, args)
         elif args.command == "suggest":
             code = cmd_suggest(base_url, args)
         elif args.command == "train-topic":

--- a/src/lele_manager/core/deduplication.py
+++ b/src/lele_manager/core/deduplication.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import math
+import unicodedata
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+from sklearn.metrics.pairwise import cosine_similarity
+
+from lele_manager.ml.features import LessonFeatureExtractor
+
+
+DEFAULT_MIN_SCORE = 0.85
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicatePair:
+    left_id: str
+    right_id: str
+    left_position: int
+    right_position: int
+    kind: Literal["exact", "near"]
+    score: float
+    reasons: tuple[str, ...]
+    shared_tags: tuple[str, ...]
+    left_path: str | None = None
+    right_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["reasons"] = list(self.reasons)
+        result["shared_tags"] = list(self.shared_tags)
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicateReport:
+    lessons_analyzed: int
+    total_pairs: int
+    exact_pairs: int
+    near_pairs: int
+    min_score: float
+    exact_only: bool
+    pairs: tuple[DuplicatePair, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lessons_analyzed": self.lessons_analyzed,
+            "total_pairs": self.total_pairs,
+            "exact_pairs": self.exact_pairs,
+            "near_pairs": self.near_pairs,
+            "min_score": self.min_score,
+            "exact_only": self.exact_only,
+            "pairs": [pair.to_dict() for pair in self.pairs],
+        }
+
+
+def _value(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    return str(value)
+
+
+def _normalize_short(value: Any) -> str:
+    return " ".join(unicodedata.normalize("NFC", _value(value)).strip().split()).casefold()
+
+
+def _normalize_text(value: Any) -> str:
+    text = unicodedata.normalize("NFC", _value(value)).replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.rstrip() for line in text.split("\n")]
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    return "\n".join(lines)
+
+
+def _tags(value: Any) -> dict[str, str]:
+    if not isinstance(value, (list, tuple, set)):
+        return {}
+    displays = (
+        " ".join(unicodedata.normalize("NFC", _value(tag)).strip().split())
+        for tag in value
+    )
+    normalized: dict[str, str] = {}
+    for display in sorted(filter(None, displays), key=lambda item: (item.casefold(), item)):
+        normalized.setdefault(display.casefold(), display)
+    return normalized
+
+
+def _metadata_reasons(left: pd.Series, right: pd.Series) -> tuple[list[str], list[str]]:
+    reasons: list[str] = []
+    for field, reason in (
+        ("title", "same_title"),
+        ("topic", "same_topic"),
+        ("source", "same_source"),
+        ("date", "same_date"),
+    ):
+        left_value = _normalize_short(left.get(field))
+        if left_value and left_value == _normalize_short(right.get(field)):
+            reasons.append(reason)
+
+    left_tags = _tags(left.get("tags"))
+    right_tags = _tags(right.get("tags"))
+    shared_keys = sorted(left_tags.keys() & right_tags.keys())
+    shared = [left_tags[key] for key in shared_keys]
+    if shared:
+        reasons.append("shared_tags")
+    return reasons, shared
+
+
+def _stable_metadata_equal(left: pd.Series, right: pd.Series) -> bool:
+    fields = ("title", "topic", "source", "date", "importance")
+    values_left = tuple(_normalize_short(left.get(field)) for field in fields)
+    values_right = tuple(_normalize_short(right.get(field)) for field in fields)
+    return values_left == values_right and sorted(_tags(left.get("tags"))) == sorted(_tags(right.get("tags")))
+
+
+def _has_significant_metadata(lesson: pd.Series) -> bool:
+    fields = ("title", "topic", "source", "date", "importance")
+    return any(_normalize_short(lesson.get(field)) for field in fields) or bool(_tags(lesson.get("tags")))
+
+
+def _sort_key(pair: DuplicatePair) -> tuple[Any, ...]:
+    return (
+        0 if pair.kind == "exact" else 1,
+        -pair.score,
+        pair.left_id,
+        pair.right_id,
+        pair.left_position,
+        pair.right_position,
+    )
+
+
+def find_duplicates(
+    lessons: pd.DataFrame,
+    *,
+    transformer: LessonFeatureExtractor | None = None,
+    feature_matrix: sparse.spmatrix | np.ndarray | None = None,
+    min_score: float = DEFAULT_MIN_SCORE,
+    exact_only: bool = False,
+    limit: int | None = None,
+) -> DuplicateReport:
+    """Find exact and semantic duplicate candidates without mutating inputs."""
+    if not math.isfinite(min_score) or not 0.0 <= min_score <= 1.0:
+        raise ValueError("min_score must be between 0 and 1")
+    if limit is not None and limit < 1:
+        raise ValueError("limit must be at least 1")
+    if not exact_only and len(lessons) > 1 and transformer is None and feature_matrix is None:
+        raise ValueError("a fitted transformer or feature matrix is required for near-duplicate detection")
+
+    df = lessons.reset_index(drop=True)
+    if not exact_only and feature_matrix is not None and feature_matrix.shape[0] != len(df):
+        raise ValueError("feature matrix must have the same number of rows as lessons")
+    scores = None
+    if not exact_only and len(df) > 1:
+        matrix = feature_matrix
+        if matrix is None:
+            matrix = transformer.transform(df)  # type: ignore[union-attr]
+        matrix = sparse.csr_matrix(matrix)
+        scores = cosine_similarity(matrix)
+
+    pairs: list[DuplicatePair] = []
+    for left_pos in range(len(df)):
+        left = df.iloc[left_pos]
+        for right_pos in range(left_pos + 1, len(df)):
+            right = df.iloc[right_pos]
+            left_id = _value(left.get("id"))
+            right_id = _value(right.get("id"))
+            reasons, shared_tags = _metadata_reasons(left, right)
+
+            exact_reasons: list[str] = []
+            if left_id and left_id == right_id:
+                exact_reasons.append("duplicate_id")
+            left_text = _normalize_text(left.get("text"))
+            text_equal = bool(left_text) and left_text == _normalize_text(right.get("text"))
+            if text_equal:
+                exact_reasons.append("exact_text")
+                if _stable_metadata_equal(left, right) and (
+                    _has_significant_metadata(left) or _has_significant_metadata(right)
+                ):
+                    exact_reasons.append("equivalent_metadata")
+
+            if exact_reasons:
+                kind: Literal["exact", "near"] = "exact"
+                score = 1.0
+                all_reasons = exact_reasons + reasons
+            else:
+                if exact_only:
+                    continue
+                score = float(scores[left_pos, right_pos])  # type: ignore[index]
+                if min_score > 0.0 and score < min_score:
+                    continue
+                kind = "near"
+                all_reasons = reasons
+
+            pairs.append(
+                DuplicatePair(
+                    left_id=left_id,
+                    right_id=right_id,
+                    left_position=left_pos,
+                    right_position=right_pos,
+                    kind=kind,
+                    score=score,
+                    reasons=tuple(all_reasons),
+                    shared_tags=tuple(shared_tags),
+                    left_path=_value(left.get("path")) or None,
+                    right_path=_value(right.get("path")) or None,
+                )
+            )
+
+    pairs.sort(key=_sort_key)
+    exact_count = sum(pair.kind == "exact" for pair in pairs)
+    near_count = len(pairs) - exact_count
+    total_count = len(pairs)
+    if limit is not None:
+        pairs = pairs[:limit]
+    return DuplicateReport(
+        lessons_analyzed=len(df),
+        total_pairs=total_count,
+        exact_pairs=exact_count,
+        near_pairs=near_count,
+        min_score=min_score,
+        exact_only=exact_only,
+        pairs=tuple(pairs),
+    )

--- a/tests/test_api_duplicates.py
+++ b/tests/test_api_duplicates.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+from fastapi.testclient import TestClient
+
+from lele_manager.api import server
+
+
+class Transformer:
+    def transform(self, df: pd.DataFrame) -> np.ndarray:
+        return np.asarray([[1.0, 0.0], [0.9, 0.1]])[: len(df)]
+
+
+def test_duplicates_function_exact_only_without_model(monkeypatch) -> None:
+    monkeypatch.setattr(server, "load_lessons_df", lambda: pd.DataFrame([{"id": "a", "text": "same"}, {"id": "b", "text": "same"}]))
+    monkeypatch.setattr(server, "build_similarity_index", lambda _df: (_ for _ in ()).throw(AssertionError("model used")))
+    report = server.duplicates(min_score=0.85, limit=None, exact_only=True)
+    assert report.exact_pairs == 1
+
+
+def test_duplicates_function_full_report_with_controlled_transformer(monkeypatch) -> None:
+    df = pd.DataFrame([{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}])
+
+    class FailingTransformer:
+        def transform(self, _df: pd.DataFrame) -> np.ndarray:
+            raise AssertionError("precomputed matrix was not used")
+
+    monkeypatch.setattr(server, "load_lessons_df", lambda: df)
+    monkeypatch.setattr(
+        server,
+        "build_similarity_index",
+        lambda _df: SimpleNamespace(
+            transformer=FailingTransformer(),
+            feature_matrix=np.asarray([[1.0, 0.0], [0.9, 0.1]]),
+        ),
+    )
+    report = server.duplicates(min_score=0.8, limit=1, exact_only=False)
+    assert report.near_pairs == 1
+    assert report.pairs[0].kind == "near"
+
+
+def test_duplicates_function_single_lesson_without_model(monkeypatch) -> None:
+    monkeypatch.setattr(server, "load_lessons_df", lambda: pd.DataFrame([{"id": "a", "text": "only"}]))
+    monkeypatch.setattr(server, "build_similarity_index", lambda _df: (_ for _ in ()).throw(AssertionError("model used")))
+    report = server.duplicates(min_score=0.85, limit=None, exact_only=False)
+    assert report.lessons_analyzed == 1
+    assert report.pairs == []
+
+
+def test_exact_only_works_without_model(monkeypatch) -> None:
+    monkeypatch.setattr(server, "load_lessons_df", lambda: pd.DataFrame([{"id": "a", "text": "same"}, {"id": "b", "text": "same"}]))
+    monkeypatch.setattr(server, "build_similarity_index", lambda _df: (_ for _ in ()).throw(AssertionError("model used")))
+    response = TestClient(server.app).get("/duplicates", params={"exact_only": "true"})
+    assert response.status_code == 200
+    assert response.json()["exact_pairs"] == 1
+
+
+def test_full_report_requires_model(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(server, "load_lessons_df", lambda: pd.DataFrame([{"id": "a", "text": "a"}, {"id": "b", "text": "b"}]))
+    monkeypatch.setattr(server, "MODEL_PATH", tmp_path / "missing.joblib")
+    response = TestClient(server.app).get("/duplicates")
+    assert response.status_code == 503
+    assert "Modello" in response.json()["detail"]
+
+
+def test_full_report_uses_fitted_transformer(monkeypatch) -> None:
+    df = pd.DataFrame([{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}])
+    monkeypatch.setattr(server, "load_lessons_df", lambda: df)
+    monkeypatch.setattr(
+        server,
+        "build_similarity_index",
+        lambda _df: SimpleNamespace(
+            transformer=Transformer(),
+            feature_matrix=np.asarray([[1.0, 0.0], [0.9, 0.1]]),
+        ),
+    )
+    response = TestClient(server.app).get("/duplicates", params={"min_score": 0.8, "limit": 1})
+    assert response.status_code == 200
+    assert response.json()["pairs"][0]["kind"] == "near"
+
+
+def test_invalid_parameters_are_422() -> None:
+    client = TestClient(server.app)
+    assert client.get("/duplicates", params={"min_score": 1.2}).status_code == 422
+    assert client.get("/duplicates", params={"limit": 0}).status_code == 422
+
+
+def test_empty_dataset_is_valid_without_model(monkeypatch) -> None:
+    monkeypatch.setattr(server, "load_lessons_df", lambda: pd.DataFrame())
+    response = TestClient(server.app).get("/duplicates")
+    assert response.status_code == 200
+    assert response.json()["lessons_analyzed"] == 0
+    assert response.json()["pairs"] == []

--- a/tests/test_cli_duplicates.py
+++ b/tests/test_cli_duplicates.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from lele_manager.cli import lele
+
+
+REPORT = {
+    "lessons_analyzed": 2,
+    "total_pairs": 1,
+    "exact_pairs": 0,
+    "near_pairs": 1,
+    "min_score": 0.85,
+    "exact_only": False,
+    "pairs": [{"left_id": "a", "right_id": "b", "left_position": 0, "right_position": 1, "kind": "near", "score": 0.91, "reasons": ["same_topic", "shared_tags"], "shared_tags": ["python"]}],
+}
+
+EXACT_REPORT = {
+    **REPORT,
+    "exact_pairs": 1,
+    "near_pairs": 0,
+    "exact_only": True,
+    "pairs": [
+        {
+            "left_id": "same",
+            "right_id": "same",
+            "left_position": 0,
+            "right_position": 1,
+            "kind": "exact",
+            "score": 1.0,
+            "reasons": ["duplicate_id"],
+            "shared_tags": [],
+        }
+    ],
+}
+
+
+class Response:
+    def __init__(self, status_code: int = 200, data=REPORT) -> None:
+        self.status_code = status_code
+        self.data = data
+        self.text = json.dumps(data)
+
+    def json(self):
+        return self.data
+
+
+def install_client(monkeypatch, calls, response=Response()) -> None:
+    class Client:
+        def __init__(self, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def get(self, path, params=None):
+            calls.append((path, params))
+            return response
+
+    monkeypatch.setattr(lele, "httpx", SimpleNamespace(Client=Client, RequestError=Exception))
+
+
+def run(argv):
+    with pytest.raises(SystemExit) as exc:
+        lele.main(argv)
+    return exc.value.code
+
+
+def test_parameters(monkeypatch) -> None:
+    calls = []
+    install_client(monkeypatch, calls, Response(data=EXACT_REPORT))
+    assert run(["duplicates", "--min-score", "0.8", "--limit", "10", "--exact-only"]) == 0
+    assert calls == [("/duplicates", {"min_score": 0.8, "exact_only": True, "limit": 10})]
+
+
+def test_human_output_uses_one_based_rows(monkeypatch, capsys) -> None:
+    install_client(monkeypatch, [], Response(data=EXACT_REPORT))
+    assert run(["duplicates", "--exact-only"]) == 0
+    output = capsys.readouterr().out
+    assert "[EXACT] same (riga 1) ↔ same (riga 2)" in output
+
+
+def test_human_output_metadata(monkeypatch, capsys) -> None:
+    install_client(monkeypatch, [])
+    assert run(["duplicates"]) == 0
+    output = capsys.readouterr().out
+    assert "tag condivisi: python" in output
+
+
+def test_json_has_no_extra_text(monkeypatch, capsys) -> None:
+    install_client(monkeypatch, [])
+    assert run(["duplicates", "--json"]) == 0
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == REPORT
+    assert captured.err == ""
+
+
+def test_no_candidates_message(monkeypatch, capsys) -> None:
+    empty = {**REPORT, "total_pairs": 0, "near_pairs": 0, "pairs": []}
+    install_client(monkeypatch, [], Response(data=empty))
+    assert run(["duplicates"]) == 0
+    assert "Nessun duplicato" in capsys.readouterr().out
+
+
+def test_api_error_is_nonzero(monkeypatch, capsys) -> None:
+    install_client(monkeypatch, [], Response(status_code=500, data={"detail": "boom"}))
+    assert run(["duplicates"]) == 1
+    assert "500" in capsys.readouterr().err
+
+
+def test_model_unavailable_has_actionable_error(monkeypatch, capsys) -> None:
+    install_client(monkeypatch, [], Response(status_code=503, data={"detail": "missing"}))
+    assert run(["duplicates"]) == 1
+    assert "--exact-only" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        (["--min-score", "nan"], "min-score"),
+        (["--limit", "0"], "limit"),
+        (["--limit", "10001"], "limit"),
+    ],
+)
+def test_invalid_parameters_are_rejected_locally(monkeypatch, capsys, arguments, message) -> None:
+    calls = []
+    install_client(monkeypatch, calls)
+    assert run(["duplicates", *arguments]) == 2
+    assert message in capsys.readouterr().err
+    assert calls == []

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lele_manager.core.deduplication import find_duplicates
+
+
+class ControlledTransformer:
+    def __init__(self, matrix: list[list[float]]) -> None:
+        self.matrix = np.asarray(matrix, dtype=float)
+        self.calls = 0
+
+    def transform(self, df: pd.DataFrame) -> np.ndarray:
+        self.calls += 1
+        assert len(df) == len(self.matrix)
+        return self.matrix
+
+
+def test_empty_and_single_lesson_reports() -> None:
+    empty = find_duplicates(pd.DataFrame(), exact_only=True)
+    single = find_duplicates(pd.DataFrame([{"id": "a", "text": "one"}]), exact_only=False)
+    assert empty.lessons_analyzed == empty.total_pairs == 0
+    assert single.lessons_analyzed == 1
+    assert single.pairs == ()
+
+
+def test_duplicate_id_keeps_both_positions() -> None:
+    df = pd.DataFrame([{"id": "same", "text": "alpha"}, {"id": "same", "text": "beta"}])
+    report = find_duplicates(df, exact_only=True)
+    assert report.pairs[0].reasons == ("duplicate_id",)
+    assert (report.pairs[0].left_position, report.pairs[0].right_position) == (0, 1)
+
+
+def test_exact_text_uses_prudent_normalization() -> None:
+    df = pd.DataFrame(
+        [
+            {"id": "a", "text": "\nCaffé  \r\nbody\t \r\n"},
+            {"id": "b", "text": "Caffé\nbody"},
+        ]
+    )
+    pair = find_duplicates(df, exact_only=True).pairs[0]
+    assert pair.kind == "exact"
+    assert "exact_text" in pair.reasons
+
+
+def test_exact_text_without_metadata_is_not_marked_equivalent_metadata() -> None:
+    df = pd.DataFrame([{"id": "a", "text": "same"}, {"id": "b", "text": "same"}])
+    pair = find_duplicates(df, exact_only=True).pairs[0]
+    assert pair.reasons == ("exact_text",)
+
+
+def test_exact_text_with_equal_significant_metadata_is_marked_equivalent() -> None:
+    df = pd.DataFrame(
+        [
+            {"id": "a", "text": "same", "topic": " Python "},
+            {"id": "b", "text": "same", "topic": "python"},
+        ]
+    )
+    pair = find_duplicates(df, exact_only=True).pairs[0]
+    assert "equivalent_metadata" in pair.reasons
+
+
+def test_same_title_with_different_text_is_not_exact() -> None:
+    df = pd.DataFrame(
+        [{"id": "a", "title": " Same title ", "text": "alpha"}, {"id": "b", "title": "same  TITLE", "text": "beta"}]
+    )
+    assert find_duplicates(df, exact_only=True).pairs == ()
+
+
+def test_near_threshold_transform_once_and_no_mirror_or_self() -> None:
+    df = pd.DataFrame([{"id": "a", "text": "a"}, {"id": "b", "text": "b"}, {"id": "c", "text": "c"}])
+    transformer = ControlledTransformer([[1, 0], [0.9, 0.1], [0, 1]])
+    report = find_duplicates(df, transformer=transformer, min_score=0.8)
+    assert transformer.calls == 1
+    assert [(p.left_id, p.right_id) for p in report.pairs] == [("a", "b")]
+
+
+def test_below_threshold_is_excluded() -> None:
+    df = pd.DataFrame([{"id": "a", "text": "a"}, {"id": "b", "text": "b"}])
+    report = find_duplicates(df, transformer=ControlledTransformer([[1, 0], [0.5, 0.5]]), min_score=0.8)
+    assert report.pairs == ()
+
+
+def test_zero_min_score_keeps_negative_cosine() -> None:
+    df = pd.DataFrame([{"id": "a", "text": "a"}, {"id": "b", "text": "b"}])
+    matrix = np.asarray([[1.0, 0.0], [-1.0, 0.0]])
+    report = find_duplicates(
+        df,
+        transformer=ControlledTransformer(matrix.tolist()),
+        min_score=0.0,
+    )
+    assert len(report.pairs) == 1
+    assert report.pairs[0].score == pytest.approx(-1.0)
+    assert find_duplicates(df, feature_matrix=matrix, min_score=0.1).pairs == ()
+
+
+def test_precomputed_feature_matrix_is_used_and_validated() -> None:
+    df = pd.DataFrame([{"id": "a", "text": "a"}, {"id": "b", "text": "b"}])
+    transformer = ControlledTransformer([[0.0, 1.0], [0.0, 1.0]])
+    report = find_duplicates(
+        df,
+        transformer=transformer,
+        feature_matrix=np.asarray([[1.0, 0.0], [0.9, 0.1]]),
+        min_score=0.8,
+    )
+    assert transformer.calls == 0
+    assert report.near_pairs == 1
+
+    with pytest.raises(ValueError, match="same number of rows"):
+        find_duplicates(df, feature_matrix=np.asarray([[1.0, 0.0]]))
+
+
+def test_exact_only_ignores_transformer_and_feature_matrix() -> None:
+    class FailingTransformer:
+        def transform(self, df: pd.DataFrame) -> np.ndarray:
+            raise AssertionError("transformer used")
+
+    df = pd.DataFrame([{"id": "a", "text": "same"}, {"id": "b", "text": "same"}])
+    report = find_duplicates(
+        df,
+        transformer=FailingTransformer(),  # type: ignore[arg-type]
+        feature_matrix=np.asarray([[1.0, 0.0]]),
+        exact_only=True,
+    )
+    assert report.exact_pairs == 1
+
+
+def test_exact_pair_is_not_repeated_as_near() -> None:
+    df = pd.DataFrame([{"id": "a", "text": "same"}, {"id": "b", "text": "same"}])
+    report = find_duplicates(df, transformer=ControlledTransformer([[1, 0], [1, 0]]), min_score=0.0)
+    assert len(report.pairs) == 1
+    assert report.pairs[0].kind == "exact"
+
+
+def test_metadata_signals_and_shared_tags() -> None:
+    base = {"topic": "Python", "source": "Book", "date": "2026-01-01", "title": "Fixtures"}
+    df = pd.DataFrame(
+        [
+            {"id": "a", "text": "alpha", "tags": ["Testing", "pytest"], **base},
+            {"id": "b", "text": "beta", "tags": ["testing", "mock"], **base},
+        ]
+    )
+    pair = find_duplicates(df, transformer=ControlledTransformer([[1, 0], [1, 0]]), min_score=0.8).pairs[0]
+    assert pair.reasons == ("same_title", "same_topic", "same_source", "same_date", "shared_tags")
+    assert pair.shared_tags == ("Testing",)
+
+
+def test_set_tag_display_is_deterministic() -> None:
+    df = pd.DataFrame(
+        [
+            {"id": "a", "text": "alpha", "tags": {"python", "Python"}},
+            {"id": "b", "text": "beta", "tags": {"PYTHON"}},
+        ]
+    )
+    pair = find_duplicates(df, feature_matrix=np.asarray([[1, 0], [1, 0]]), min_score=0.8).pairs[0]
+    assert pair.shared_tags == ("Python",)
+
+
+def test_deterministic_order_and_limit_preserve_full_counts() -> None:
+    df = pd.DataFrame(
+        [{"id": "z", "text": "same"}, {"id": "a", "text": "same"}, {"id": "b", "text": "different"}]
+    )
+    report = find_duplicates(
+        df,
+        transformer=ControlledTransformer([[1, 0], [1, 0], [0.9, 0.1]]),
+        min_score=0.8,
+        limit=1,
+    )
+    assert report.total_pairs == 3
+    assert len(report.pairs) == 1
+    assert report.pairs[0].kind == "exact"
+
+
+def test_three_duplicate_ids_do_not_lose_records() -> None:
+    df = pd.DataFrame([{"id": "x", "text": str(i)} for i in range(3)])
+    report = find_duplicates(df, exact_only=True)
+    assert len(report.pairs) == 3
+    assert {(p.left_position, p.right_position) for p in report.pairs} == {(0, 1), (0, 2), (1, 2)}
+
+
+@pytest.mark.parametrize("score", [-0.1, 1.1, float("nan")])
+def test_invalid_min_score(score: float) -> None:
+    with pytest.raises(ValueError, match="min_score"):
+        find_duplicates(pd.DataFrame(), exact_only=True, min_score=score)


### PR DESCRIPTION
## Summary

- add a pure read-only deduplication core for exact and near-duplicate lessons
- detect duplicate IDs, normalized exact text, equivalent stable metadata, and explanatory metadata signals
- reuse the existing similarity model for near-duplicate scoring without transforming the dataset twice
- preserve duplicate rows by position instead of assuming IDs are unique
- add deterministic ordering, stable JSON output, configurable thresholds, limits, and exact-only mode
- add `GET /duplicates` and the `lele duplicates` CLI command
- document behavior, heuristics, read-only guarantees, and quadratic complexity

## Exact vs near

Exact candidates include duplicate IDs and prudently normalized identical text. Equivalent metadata is reported only when at least one stable metadata field is meaningfully present. Near candidates are non-exact pairs whose cosine similarity meets the configured threshold.

## Validation

Passed locally:

- 26 core and CLI tests
- 3 direct endpoint tests
- 19 additional core tests after the precomputed-matrix fix
- `ruff check .`
- `git diff --check`

The local environment still hangs in FastAPI `TestClient` tests, including a pre-existing similarity API test. The new endpoint logic is covered directly without `TestClient`; GitHub Actions remains the authoritative integration check.

## Limits

- global pairwise comparison is quadratic in time and memory
- near-duplicate detection requires the fitted similarity model
- exact-only mode does not require the model
- no lessons are modified, merged, or deleted

Closes #85