### PR TITLE
feat: introduce projection storage abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Ogni volta che imparo qualcosa (da ChatGPT, da libri, da esperimenti), LeLe Mana
 - `scikit-learn` per ML classico (classificatori, KNN/similarity, ecc.)
 - (opzionale) piccolo **MLP** per migliorare embedding/scoring
 - **FastAPI + Uvicorn** per esporre API HTTP
-- Storage: **JSONL / SQLite** (a seconda della fase del progetto)
+- Storage: port di proiezione backend-neutral con adapter **JSONL** predefinito
+  (SQLite è una fase successiva; vedi `docs/projection-store.md`)
 
 ---
 

--- a/docs/projection-store.md
+++ b/docs/projection-store.md
@@ -1,0 +1,54 @@
+# Projection store
+
+LeLe Manager accesses its queryable lesson dataset through the typed port in
+`lele_manager.core.projection_store`. The boundary is intentionally small and
+backend-neutral:
+
+- open one coherent, immutable snapshot;
+- get a lesson by its canonical ID, including IDs containing `/`;
+- list and search with portable filters, deterministic ordering and limits;
+- obtain essential counts and a deterministic content generation from that
+  same snapshot;
+- validate and atomically publish a complete replacement snapshot.
+
+Lesson records retain fields unknown to the current application. The port does
+not expose JSONL, filesystem paths, Pandas objects, SQL, or backend-specific
+transactions. Pandas conversion for ML and analytics remains an application
+boundary, rather than part of the storage contract.
+
+## Current compatibility backend
+
+Backend composition occurs in `lele_manager.composition.projection_store`.
+Production readers and whole-snapshot publishers request the neutral
+`ProjectionStore` there; JSONL remains the default compatibility adapter.
+
+`JsonlProjectionStore` is the default adapter during the migration described by
+[ADR 0001](adr/0001-storage-backend.md). It reads existing UTF-8 JSONL files and
+publishes canonical JSONL ordered by lesson ID. Object keys are sorted and
+Unicode is emitted directly. Publication has stable bytes for equivalent
+content. On reads, `LessonOrder.SNAPSHOT` exposes physical record order, so the
+SHA-256 generation includes that order: different observable snapshot order
+means a different generation. Blank lines are accepted for compatibility.
+
+A read validates the complete file. Malformed JSON, non-object records, missing
+or empty IDs, invalid UTF-8, and duplicate IDs are explicit errors; they are not
+silently skipped. Each snapshot builds its ID lookup and essential statistics
+in that single validation pass.
+
+Whole-snapshot publication validates everything before touching the current
+file, writes and fsyncs a temporary file in the destination directory, then
+uses an atomic replace. A failure before replace leaves the previous snapshot
+readable and removes the temporary file.
+
+The historic `add_lesson` CLI and `POST /lessons` endpoint still append JSONL
+records because removing that behavior is outside issue #92. This is exposed
+only through the explicitly named `JsonlLegacyAppendFacade`, not through the
+common projection port. It validates the complete existing snapshot and rejects
+duplicate IDs before writing.
+
+Writers are assumed to be serialized by the local application. There is no
+cross-process transaction or locking: simultaneous whole-snapshot publishers
+are last-writer-wins, while simultaneous legacy append writers are unsupported.
+Vault rebuilds and directory imports use atomic whole-snapshot publication. No
+SQLite cutover occurred: SQLite remains a future adapter and is neither
+implemented nor selected by default here.

--- a/src/lele_manager/adapters/__init__.py
+++ b/src/lele_manager/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Persistence adapters for application ports."""

--- a/src/lele_manager/adapters/jsonl_projection_store.py
+++ b/src/lele_manager/adapters/jsonl_projection_store.py
@@ -1,0 +1,251 @@
+"""JSONL compatibility adapter for the projection-store port."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import tempfile
+import stat
+from typing import Any
+
+from lele_manager.core.projection_store import (
+    DuplicateLessonIdError,
+    LessonOrder,
+    LessonQuery,
+    LessonRecord,
+    MalformedProjectionError,
+    ProjectionStatistics,
+)
+
+
+def _canonical_json(record: LessonRecord) -> str:
+    try:
+        return json.dumps(
+            record, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+        )
+    except (TypeError, ValueError) as exc:
+        raise MalformedProjectionError(f"lesson record is not JSON serializable: {exc}") from exc
+
+
+def _generation(records: Sequence[LessonRecord]) -> str:
+    digest = hashlib.sha256()
+    # SNAPSHOT order is observable, so it is part of the generation.
+    for record in records:
+        digest.update(_canonical_json(record).encode("utf-8"))
+        digest.update(b"\n")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _record_id(record: LessonRecord, position: int) -> str:
+    if "id" not in record or record["id"] is None:
+        raise MalformedProjectionError(f"record {position} has no id")
+    lesson_id = str(record["id"])
+    if not lesson_id:
+        raise MalformedProjectionError(f"record {position} has an empty id")
+    return lesson_id
+
+
+def _as_optional_number(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(number) else number
+
+
+def _created_at(value: object) -> float | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.timestamp()
+    except (ValueError, OSError):
+        return None
+
+
+def _importance_sort_value(record: LessonRecord) -> float:
+    value = _as_optional_number(record.get("importance"))
+    return value if value is not None else float("-inf")
+
+
+@dataclass(frozen=True)
+class JsonlProjectionSnapshot:
+    _records: tuple[dict[str, Any], ...]
+    _by_id: dict[str, dict[str, Any]]
+    generation: str
+    statistics: ProjectionStatistics
+
+    def get(self, lesson_id: str) -> LessonRecord | None:
+        record = self._by_id.get(lesson_id)
+        return deepcopy(record) if record is not None else None
+
+    def list(self, query: LessonQuery = LessonQuery()) -> tuple[LessonRecord, ...]:
+        topics = set(query.topics) if query.topics is not None else None
+        sources = set(query.sources) if query.sources is not None else None
+        required_tags = set(query.tags) if query.tags is not None else None
+        needle = query.text.casefold() if query.text else None
+        matches: list[dict[str, Any]] = []
+        for record in self._records:
+            if needle and needle not in str(record.get("text") or "").casefold():
+                continue
+            if topics is not None and str(record.get("topic") or "") not in topics:
+                continue
+            if sources is not None and str(record.get("source") or "") not in sources:
+                continue
+            raw_tags = record.get("tags")
+            record_tags = {str(tag) for tag in raw_tags} if isinstance(raw_tags, list) else set()
+            if required_tags is not None and not required_tags.issubset(record_tags):
+                continue
+            importance = _as_optional_number(record.get("importance"))
+            if query.importance_gte is not None and (
+                importance is None or importance < query.importance_gte
+            ):
+                continue
+            if query.importance_lte is not None and (
+                importance is None or importance > query.importance_lte
+            ):
+                continue
+            matches.append(record)
+
+        if query.order is LessonOrder.ID:
+            matches.sort(key=lambda row: str(row["id"]))
+        elif query.order is LessonOrder.CREATED_AT_DESC:
+            matches.sort(key=lambda row: str(row["id"]))
+            matches.sort(
+                key=lambda row: _created_at(row.get("created_at")) or float("-inf"),
+                reverse=True,
+            )
+        elif query.order is LessonOrder.RELEVANCE:
+            matches.sort(key=lambda row: str(row["id"]))
+            matches.sort(
+                key=lambda row: _created_at(row.get("created_at")) or float("-inf"),
+                reverse=True,
+            )
+            matches.sort(
+                key=_importance_sort_value,
+                reverse=True,
+            )
+        if query.limit is not None:
+            matches = matches[: query.limit]
+        return tuple(deepcopy(record) for record in matches)
+
+
+def _make_snapshot(records: Sequence[LessonRecord]) -> JsonlProjectionSnapshot:
+    copied: list[dict[str, Any]] = []
+    by_id: dict[str, dict[str, Any]] = {}
+    topics: set[str] = set()
+    tags: set[str] = set()
+    for position, raw_record in enumerate(records, start=1):
+        if not isinstance(raw_record, Mapping):
+            raise MalformedProjectionError(f"record {position} is not an object")
+        record = deepcopy(dict(raw_record))
+        lesson_id = _record_id(record, position)
+        if lesson_id in by_id:
+            raise DuplicateLessonIdError(f"duplicate lesson id {lesson_id!r}")
+        # Validate serializability before any publication can begin.
+        _canonical_json(record)
+        copied.append(record)
+        by_id[lesson_id] = record
+        topic = record.get("topic")
+        if topic is not None and str(topic):
+            topics.add(str(topic))
+        raw_tags = record.get("tags")
+        if isinstance(raw_tags, list):
+            tags.update(str(tag) for tag in raw_tags if str(tag))
+    immutable_records = tuple(copied)
+    return JsonlProjectionSnapshot(
+        _records=immutable_records,
+        _by_id=by_id,
+        generation=_generation(immutable_records),
+        statistics=ProjectionStatistics(len(copied), len(topics), len(tags)),
+    )
+
+
+class JsonlProjectionStore:
+    """A UTF-8 JSONL projection with atomic whole-snapshot publication."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def snapshot(self) -> JsonlProjectionSnapshot:
+        if not self._path.exists():
+            return _make_snapshot(())
+        records: list[LessonRecord] = []
+        try:
+            with self._path.open("r", encoding="utf-8") as source:
+                for line_number, line in enumerate(source, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        raise MalformedProjectionError(
+                            f"malformed JSONL record at line {line_number}: {exc.msg}"
+                        ) from exc
+                    if not isinstance(record, dict):
+                        raise MalformedProjectionError(
+                            f"JSONL record at line {line_number} is not an object"
+                        )
+                    records.append(record)
+        except UnicodeDecodeError as exc:
+            raise MalformedProjectionError(f"projection is not valid UTF-8: {exc}") from exc
+        return _make_snapshot(records)
+
+    def publish(self, records: Sequence[LessonRecord]) -> JsonlProjectionSnapshot:
+        # ID ordering makes both bytes and generation independent of input order.
+        snapshot = _make_snapshot(records)
+        ordered = sorted(snapshot.list(), key=lambda row: str(row["id"]))
+        snapshot = _make_snapshot(ordered)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w", encoding="utf-8", dir=self._path.parent, prefix=f".{self._path.name}.",
+                suffix=".tmp", delete=False
+            ) as target:
+                temporary_path = Path(target.name)
+                for record in snapshot.list():
+                    target.write(_canonical_json(record) + "\n")
+                target.flush()
+                os.fsync(target.fileno())
+            if self._path.exists():
+                os.chmod(temporary_path, stat.S_IMODE(self._path.stat().st_mode))
+            os.replace(temporary_path, self._path)
+            temporary_path = None
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+        return snapshot
+
+
+class JsonlLegacyAppendFacade:
+    """JSONL-only compatibility API, deliberately outside ProjectionStore."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def append(self, record: LessonRecord) -> None:
+        incoming = _make_snapshot((record,)).list()[0]
+        existing = JsonlProjectionStore(self._path).snapshot()
+        lesson_id = str(incoming["id"])
+        if existing.get(lesson_id) is not None:
+            raise DuplicateLessonIdError(f"duplicate lesson id {lesson_id!r}")
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        needs_separator = self._path.exists() and self._path.stat().st_size > 0
+        if needs_separator:
+            with self._path.open("rb") as source:
+                source.seek(-1, os.SEEK_END)
+                needs_separator = source.read(1) not in (b"\n", b"\r")
+        with self._path.open("a", encoding="utf-8") as target:
+            if needs_separator:
+                target.write("\n")
+            target.write(json.dumps(incoming, ensure_ascii=False, default=str) + "\n")

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import uuid
 import pandas as pd
 
@@ -15,6 +14,9 @@ from fastapi.staticfiles import StaticFiles
 from threading import Lock
 
 from lele_manager.core.analytics import compute_stats_summary, compute_timeline
+from lele_manager.application.dataframes import records_to_legacy_dataframe
+from lele_manager.composition import legacy_jsonl_append_facade, projection_store
+from lele_manager.core.projection_store import DuplicateLessonIdError, ProjectionStoreError
 from lele_manager.core.deduplication import DEFAULT_MIN_SCORE, find_duplicates
 from lele_manager.core.export import search_results_to_markdown
 from lele_manager.core.config import resolve_data_path, resolve_model_path
@@ -325,10 +327,6 @@ class TimelineResponse(BaseModel):
 # -----------------------------------------------------------------------------
 # Helper di I/O
 # -----------------------------------------------------------------------------
-def _ensure_data_dir() -> None:
-    get_data_path().parent.mkdir(parents=True, exist_ok=True)
-
-
 def _ensure_model_dir() -> None:
     get_model_path().parent.mkdir(parents=True, exist_ok=True)
 
@@ -339,18 +337,14 @@ def load_lessons_df() -> pd.DataFrame:
     Se il file non esiste, restituisce un DataFrame vuoto con colonne standard.
     Gestisce errori di parsing in modo esplicito.
     """
-    data_path = get_data_path()
-    if not data_path.exists():
-        return pd.DataFrame(columns=["id", "text", "topic", "source", "importance", "tags", "date", "title", "created_at"])
-
     try:
-        df = pd.read_json(data_path, lines=True)
-    except ValueError as e:
-        # Errore di parsing: JSONL corrotto o riga invalida
+        records = projection_store(get_data_path()).snapshot().list()
+        df = records_to_legacy_dataframe(records)
+    except ProjectionStoreError as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Errore nel parsing di {data_path}: {e}",
-        )
+            detail=f"Errore nel parsing di {get_data_path()}: {e}",
+        ) from e
 
     # Assicuriamoci che almeno queste colonne esistano
     for col in ["id", "text", "topic", "source", "importance", "tags", "date", "title", "created_at"]:
@@ -378,11 +372,16 @@ def append_lesson_to_jsonl(lesson: Lesson) -> None:
     """
     Appende una singola LeLe al file JSONL.
     """
-    _ensure_data_dir()
     record = lesson.dict()
-    data_path = get_data_path()
-    with data_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    try:
+        legacy_jsonl_append_facade(get_data_path()).append(record)
+    except DuplicateLessonIdError as exc:
+        raise HTTPException(status_code=409, detail=f"Lesson ID già esistente: {lesson.id}") from exc
+    except ProjectionStoreError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Dataset esistente non valido; append annullato: {exc}",
+        ) from exc
 
 
 def _file_mtime_ns(path: Path) -> int:

--- a/src/lele_manager/application/__init__.py
+++ b/src/lele_manager/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application-boundary helpers."""

--- a/src/lele_manager/application/dataframes.py
+++ b/src/lele_manager/application/dataframes.py
@@ -1,0 +1,27 @@
+"""Pandas conversion at the application/ML boundary."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from io import StringIO
+import json
+
+import pandas as pd
+
+from lele_manager.core.projection_store import LessonRecord
+
+
+def records_to_legacy_dataframe(records: Sequence[LessonRecord]) -> pd.DataFrame:
+    """Match the DataFrame inference historically produced by ``read_json``.
+
+    Round-tripping the already validated records through Pandas' JSON reader is
+    intentional: its date conversion, null representation, mixed-type and
+    leading-zero handling are externally observable by the API and ML callers.
+    Pandas remains outside the projection-store contract.
+    """
+    if not records:
+        return pd.DataFrame()
+    payload = "".join(
+        json.dumps(record, ensure_ascii=False, default=str) + "\n" for record in records
+    )
+    return pd.read_json(StringIO(payload), lines=True)

--- a/src/lele_manager/cli/add_lesson.py
+++ b/src/lele_manager/cli/add_lesson.py
@@ -8,6 +8,7 @@ from typing import Sequence
 
 from lele_manager.core.model import Lesson
 from lele_manager.core.storage import append_lesson, default_db_path
+from lele_manager.core.projection_store import ProjectionStoreError
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -80,7 +81,10 @@ def main(argv: Sequence[str] | None = None) -> None:
         tags=tags,
     )
 
-    append_lesson(lesson, args.db)
+    try:
+        append_lesson(lesson, args.db)
+    except ProjectionStoreError as exc:
+        raise SystemExit(f"Impossibile aggiungere la lesson: {exc}") from exc
 
     print(f"Lesson salvata con id={lesson.id} in {args.db}")
 

--- a/src/lele_manager/cli/import_from_dir.py
+++ b/src/lele_manager/cli/import_from_dir.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import hashlib
-import json
 import yaml
 
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Tuple, Union
+
+from lele_manager.composition import projection_store
 
 DuplicatePolicy = Literal["overwrite", "skip", "error"]
 
@@ -360,13 +361,10 @@ def main(argv: Optional[List[str]] = None) -> None:
         print("[info] Nessuna LeLe importata, nessun file scritto.")
         return
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-
     print(f"[info] Scrivo {len(records_by_id)} LeLe in formato JSONL -> {output_path}")
-    with output_path.open("w", encoding="utf-8") as f:
-        for rec in records_by_id.values():
-            line = json.dumps(asdict(rec), ensure_ascii=False, default=str)
-            f.write(line + "\n")
+    projection_store(output_path).publish(
+        [asdict(record) for record in records_by_id.values()]
+    )
 
     print("[ok] Import completato.")
 

--- a/src/lele_manager/cli/suggest_similar.py
+++ b/src/lele_manager/cli/suggest_similar.py
@@ -6,6 +6,9 @@ from typing import List, Optional
 
 import pandas as pd
 
+from lele_manager.application.dataframes import records_to_legacy_dataframe
+from lele_manager.composition import projection_store
+from lele_manager.core.projection_store import ProjectionStoreError
 from lele_manager.core.config import default_data_path
 from lele_manager.ml.similarity import LessonSimilarityIndex
 from lele_manager.ml.similarity_service import similar_by_lesson_id, similar_by_text
@@ -73,7 +76,10 @@ def _load_dataset(dataset_path: Path, text_column: str) -> pd.DataFrame:
     if not dataset_path.exists():
         raise SystemExit(f"[err] Dataset non trovato: {dataset_path}")
 
-    df = pd.read_json(dataset_path, lines=True)
+    try:
+        df = records_to_legacy_dataframe(projection_store(dataset_path).snapshot().list())
+    except (ProjectionStoreError, ValueError) as exc:
+        raise SystemExit(f"[err] JSONL non valido o non leggibile: {exc}") from exc
     if df.empty:
         raise SystemExit("[err] Dataset vuoto: nessuna lesson disponibile.")
 

--- a/src/lele_manager/cli/train_topic_model.py
+++ b/src/lele_manager/cli/train_topic_model.py
@@ -4,8 +4,9 @@ import argparse
 from pathlib import Path
 from typing import List, Optional
 
-import pandas as pd
-
+from lele_manager.application.dataframes import records_to_legacy_dataframe
+from lele_manager.composition import projection_store
+from lele_manager.core.projection_store import ProjectionStoreError
 from lele_manager.ml.topic_model import load_topic_model, save_topic_model, train_topic_model
 from lele_manager.core.config import default_data_path
 
@@ -68,8 +69,8 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     print(f"[info] Carico dataset da: {input_path}")
     try:
-        df = pd.read_json(input_path, lines=True)
-    except ValueError as exc:
+        df = records_to_legacy_dataframe(projection_store(input_path).snapshot().list())
+    except (ProjectionStoreError, ValueError) as exc:
         raise SystemExit(f"[errore] JSONL non valido o non leggibile: {exc}")
 
     # Normalizza nomi colonne per il modello

--- a/src/lele_manager/composition.py
+++ b/src/lele_manager/composition.py
@@ -1,0 +1,23 @@
+"""Application composition for projection persistence.
+
+JSONL remains the default compatibility adapter.  Consumers should request the
+neutral port here instead of constructing an adapter themselves.
+"""
+
+from pathlib import Path
+
+from lele_manager.adapters.jsonl_projection_store import (
+    JsonlLegacyAppendFacade,
+    JsonlProjectionStore,
+)
+from lele_manager.core.projection_store import ProjectionStore
+
+
+def projection_store(path: Path) -> ProjectionStore:
+    """Return the configured projection store (JSONL during issue #92)."""
+    return JsonlProjectionStore(path)
+
+
+def legacy_jsonl_append_facade(path: Path) -> JsonlLegacyAppendFacade:
+    """Return the explicitly JSONL-specific legacy append compatibility API."""
+    return JsonlLegacyAppendFacade(path)

--- a/src/lele_manager/core/projection_store.py
+++ b/src/lele_manager/core/projection_store.py
@@ -1,0 +1,91 @@
+"""Backend-neutral port for the queryable lesson projection.
+
+The types in this module are deliberately domain-facing: consumers see lesson
+records, query criteria, aggregate statistics and a content generation.  They
+do not see paths, JSONL, pandas, SQL, or backend transactions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Protocol, Sequence, TypeAlias
+
+LessonRecord: TypeAlias = Mapping[str, Any]
+
+
+class ProjectionStoreError(Exception):
+    """Base class for projection-store failures."""
+
+
+class MalformedProjectionError(ProjectionStoreError):
+    """The published projection cannot be decoded as valid lesson records."""
+
+
+class DuplicateLessonIdError(ProjectionStoreError):
+    """A snapshot contains more than one record with the same lesson ID."""
+
+
+class LessonOrder(str, Enum):
+    """Portable deterministic orderings supported by every backend."""
+
+    SNAPSHOT = "snapshot"
+    ID = "id"
+    RELEVANCE = "relevance"
+    CREATED_AT_DESC = "created_at_desc"
+
+
+@dataclass(frozen=True)
+class LessonQuery:
+    """Filters for listing/searching the projection.
+
+    Text matching is a case-insensitive substring of ``text``.  Empty filter
+    sequences mean that no record can match.  A limit, when supplied, must be
+    positive.
+    """
+
+    text: str | None = None
+    topics: Sequence[str] | None = None
+    sources: Sequence[str] | None = None
+    tags: Sequence[str] | None = None
+    importance_gte: int | None = None
+    importance_lte: int | None = None
+    order: LessonOrder = LessonOrder.SNAPSHOT
+    limit: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.limit is not None and self.limit < 1:
+            raise ValueError("limit must be positive")
+
+
+@dataclass(frozen=True)
+class ProjectionStatistics:
+    lesson_count: int
+    topic_count: int
+    unique_tag_count: int
+
+
+class ProjectionSnapshot(Protocol):
+    """One coherent, immutable view of a published generation."""
+
+    @property
+    def generation(self) -> str: ...
+
+    @property
+    def statistics(self) -> ProjectionStatistics: ...
+
+    def get(self, lesson_id: str) -> LessonRecord | None: ...
+
+    def list(self, query: LessonQuery = LessonQuery()) -> tuple[LessonRecord, ...]: ...
+
+
+class ProjectionStore(Protocol):
+    """Minimum common port implemented by projection backends.
+
+    ``snapshot`` performs a coherent read. ``publish`` validates and atomically
+    replaces the complete projection; it is not an authoring/upsert API.
+    """
+
+    def snapshot(self) -> ProjectionSnapshot: ...
+
+    def publish(self, records: Sequence[LessonRecord]) -> ProjectionSnapshot: ...

--- a/src/lele_manager/core/storage.py
+++ b/src/lele_manager/core/storage.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, List
-import json
 
+from lele_manager.composition import legacy_jsonl_append_facade, projection_store
 from .model import Lesson
 from .paths import lessons_path
 
@@ -18,11 +18,7 @@ def append_lesson(lesson: Lesson, db_path: Path | None = None) -> None:
     if db_path is None:
         db_path = default_db_path()
 
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-
-    line = json.dumps(lesson.to_dict(), ensure_ascii=False)
-    with db_path.open("a", encoding="utf-8") as f:
-        f.write(line + "\n")
+    legacy_jsonl_append_facade(db_path).append(lesson.to_dict())
 
 
 def load_lessons(db_path: Path | None = None) -> List[Lesson]:
@@ -30,18 +26,7 @@ def load_lessons(db_path: Path | None = None) -> List[Lesson]:
     if db_path is None:
         db_path = default_db_path()
 
-    if not db_path.exists():
-        return []
-
-    lessons: List[Lesson] = []
-    with db_path.open("r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            data = json.loads(line)
-            lessons.append(Lesson.from_dict(data))
-    return lessons
+    return [Lesson.from_dict(dict(row)) for row in projection_store(db_path).snapshot().list()]
 
 
 def iter_lessons(db_path: Path | None = None) -> Iterable[Lesson]:
@@ -49,13 +34,5 @@ def iter_lessons(db_path: Path | None = None) -> Iterable[Lesson]:
     if db_path is None:
         db_path = default_db_path()
 
-    if not db_path.exists():
-        return
-
-    with db_path.open("r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            data = json.loads(line)
-            yield Lesson.from_dict(data)
+    for row in projection_store(db_path).snapshot().list():
+        yield Lesson.from_dict(dict(row))

--- a/src/lele_manager/core/vault.py
+++ b/src/lele_manager/core/vault.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import json
 import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
+from lele_manager.composition import projection_store
 from lele_manager.cli.import_from_dir import (
     compute_frontmatter_hash,
     derive_id_from_path,
@@ -210,10 +210,7 @@ def import_vault_to_jsonl(
         default_topic=None,
         write_missing_frontmatter=write_missing_frontmatter,
     )
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as f:
-        for rec in records.values():
-            f.write(json.dumps(rec.__dict__, ensure_ascii=False, default=str) + "\n")
+    projection_store(output_path).publish([rec.__dict__ for rec in records.values()])
     topics = sorted({str(r.topic) for r in records.values() if r.topic})
     return {
         "n_lessons": len(records),
@@ -228,18 +225,7 @@ def upsert_jsonl_lesson(
 ) -> None:
     """Replace a lesson row by id or append if new."""
     lesson_id = str(record["id"])
-    rows: List[Dict[str, Any]] = []
-    if output_path.is_file():
-        with output_path.open("r", encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                data = json.loads(line)
-                if str(data.get("id")) != lesson_id:
-                    rows.append(data)
+    store = projection_store(output_path)
+    rows = [row for row in store.snapshot().list() if str(row["id"]) != lesson_id]
     rows.append(record)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as f:
-        for row in rows:
-            f.write(json.dumps(row, ensure_ascii=False, default=str) + "\n")
+    store.publish(rows)

--- a/tests/test_legacy_jsonl_append.py
+++ b/tests/test_legacy_jsonl_append.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from lele_manager.api import server
+from lele_manager.cli import add_lesson
+from lele_manager.composition import legacy_jsonl_append_facade, projection_store
+from lele_manager.core.model import Lesson
+from lele_manager.core.projection_store import DuplicateLessonIdError, MalformedProjectionError
+
+
+def test_duplicate_append_rejected_without_changing_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_bytes(b'{"id":"same","text":"old"}\n')
+    before = path.read_bytes()
+    with pytest.raises(DuplicateLessonIdError, match="same"):
+        legacy_jsonl_append_facade(path).append({"id": "same", "text": "new"})
+    assert path.read_bytes() == before
+
+
+def test_malformed_existing_dataset_rejected_without_changing_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_bytes(b'{"id":"ok"}\nnot-json\n')
+    before = path.read_bytes()
+    with pytest.raises(MalformedProjectionError, match="line 2"):
+        legacy_jsonl_append_facade(path).append({"id": "new"})
+    assert path.read_bytes() == before
+
+
+def test_append_after_valid_final_line_without_newline_stays_readable(tmp_path: Path) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_bytes(b'{"id":"old"}')
+    facade = legacy_jsonl_append_facade(path)
+    facade.append({"id": "new"})
+    assert [row["id"] for row in projection_store(path).snapshot().list()] == ["old", "new"]
+
+
+def test_api_duplicate_append_is_conflict(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_text('{"id":"same","text":"old"}\n', encoding="utf-8")
+    monkeypatch.setattr(server, "DATA_PATH", path)
+    with pytest.raises(HTTPException) as raised:
+        server.add_lesson(server.LessonCreate(id="same", text="new"))
+    assert raised.value.status_code == 409
+    assert raised.value.detail == "Lesson ID già esistente: same"
+
+
+def test_api_malformed_dataset_is_actionable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_text("not-json\n", encoding="utf-8")
+    monkeypatch.setattr(server, "DATA_PATH", path)
+    with pytest.raises(HTTPException) as raised:
+        server.add_lesson(server.LessonCreate(id="new", text="new"))
+    assert raised.value.status_code == 409
+    assert "append annullato" in str(raised.value.detail)
+    assert "line 1" in str(raised.value.detail)
+
+
+def test_legacy_cli_reports_malformed_dataset(tmp_path: Path) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_text("not-json\n", encoding="utf-8")
+    with pytest.raises(SystemExit, match="Impossibile aggiungere.*line 1"):
+        add_lesson.main(["--text", "new", "--db", str(path)])
+
+
+def test_legacy_cli_reports_duplicate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "lessons.jsonl"
+    existing = Lesson.new(source="note", topic="misc", importance=3, text="old", tags=[])
+    path.write_text(json.dumps(existing.to_dict()) + "\n", encoding="utf-8")
+    monkeypatch.setattr(add_lesson.Lesson, "new", lambda **kwargs: existing)
+    with pytest.raises(SystemExit, match="duplicate lesson id"):
+        add_lesson.main(["--text", "new", "--db", str(path)])

--- a/tests/test_projection_dataframe_compat.py
+++ b/tests/test_projection_dataframe_compat.py
@@ -1,0 +1,23 @@
+from io import StringIO
+import json
+
+import pandas as pd
+import pandas.testing as pdt
+
+from lele_manager.application.dataframes import records_to_legacy_dataframe
+
+
+def test_records_to_dataframe_has_golden_read_json_parity() -> None:
+    records = [
+        {"id": "001", "text": "Perché Unicode ☕", "date": "2025-02-01",
+         "created_at": "2025-02-01T10:11:12Z", "title": None, "importance": 3,
+         "metadata": {"unknown": "kept"}, "mixed": 7},
+        {"id": "abc", "text": "日本語", "date": None, "created_at": None,
+         "title": "present", "importance": None,
+         "metadata": {"future": [1, "due"]}, "mixed": "007"},
+    ]
+    payload = "".join(json.dumps(row, ensure_ascii=False) + "\n" for row in records)
+    legacy = pd.read_json(StringIO(payload), lines=True)
+    actual = records_to_legacy_dataframe(records)
+    pdt.assert_frame_equal(actual, legacy)
+    assert actual.loc[0, "id"] == "001"

--- a/tests/test_projection_store_contract.py
+++ b/tests/test_projection_store_contract.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from collections.abc import Callable
+
+import pytest
+
+from lele_manager.adapters import jsonl_projection_store as jsonl_adapter
+from lele_manager.adapters.jsonl_projection_store import JsonlProjectionStore
+from lele_manager.core.projection_store import (
+    DuplicateLessonIdError,
+    LessonOrder,
+    LessonQuery,
+    MalformedProjectionError,
+    ProjectionStore,
+)
+
+
+@pytest.fixture(params=["jsonl"])
+def store_factory(request: pytest.FixtureRequest) -> Callable[[Path], ProjectionStore]:
+    assert request.param == "jsonl"
+    return JsonlProjectionStore
+
+
+def complete_records() -> list[dict[str, object]]:
+    return [
+        {
+            "id": "writing/caffè-☕",
+            "text": "Usa Unicode: perché è parte del contenuto.",
+            "topic": "writing",
+            "source": "note",
+            "importance": 4,
+            "tags": ["unicode", "caffè"],
+            "created_at": "2025-02-01T10:00:00+00:00",
+            "title": "Accenti",
+            "date": "2025-02-01",
+            "frontmatter": {"unknown_future_field": "preserved"},
+        },
+        {
+            "id": "python/atomic-files",
+            "text": "Replace files atomically",
+            "topic": "python",
+            "source": "book",
+            "importance": 5,
+            "tags": ["filesystem", "python"],
+            "created_at": "2025-03-01T10:00:00Z",
+        },
+        {
+            "id": "misc/minimal",
+            "text": "Optional fields may be absent",
+            "importance": None,
+        },
+    ]
+
+
+def test_complete_optional_unicode_tags_and_canonical_ids(
+    tmp_path: Path, store_factory: Callable[[Path], ProjectionStore]
+) -> None:
+    store = store_factory(tmp_path / "lessons.jsonl")
+    published = store.publish(complete_records())
+
+    assert published.statistics.lesson_count == 3
+    assert published.statistics.topic_count == 2
+    assert published.statistics.unique_tag_count == 4
+    assert published.get("writing/caffè-☕") == complete_records()[0]
+    assert published.get("missing") is None
+    assert store.snapshot().get("misc/minimal") == complete_records()[2]
+
+
+def test_filters_order_limits_and_returned_records_are_isolated(
+    tmp_path: Path, store_factory: Callable[[Path], ProjectionStore]
+) -> None:
+    store = store_factory(tmp_path / "lessons.jsonl")
+    snapshot = store.publish(complete_records())
+
+    result = snapshot.list(
+        LessonQuery(
+            text="FILE",
+            topics=["python"],
+            sources=["book"],
+            tags=["filesystem"],
+            importance_gte=5,
+            importance_lte=5,
+            order=LessonOrder.RELEVANCE,
+            limit=1,
+        )
+    )
+    assert [row["id"] for row in result] == ["python/atomic-files"]
+    assert [row["id"] for row in snapshot.list(LessonQuery(order=LessonOrder.ID, limit=2))] == [
+        "misc/minimal",
+        "python/atomic-files",
+    ]
+    assert snapshot.list(LessonQuery(topics=[])) == ()
+
+    mutable_result = dict(snapshot.get("writing/caffè-☕") or {})
+    mutable_result["text"] = "changed by caller"
+    assert snapshot.get("writing/caffè-☕")["text"] != "changed by caller"  # type: ignore[index]
+
+
+def test_contract_rejects_duplicate_publication_and_tracks_content_generation(
+    tmp_path: Path, store_factory: Callable[[Path], ProjectionStore]
+) -> None:
+    store = store_factory(tmp_path / "lessons.jsonl")
+    first = store.publish([{"id": "one", "text": "before"}])
+    changed = store.publish([{"id": "one", "text": "after"}])
+    assert changed.generation != first.generation
+    with pytest.raises(DuplicateLessonIdError, match="one"):
+        store.publish([{"id": "one"}, {"id": "one"}])
+
+
+def test_serialization_and_generation_are_deterministic(tmp_path: Path) -> None:
+    first_path = tmp_path / "first.jsonl"
+    second_path = tmp_path / "second.jsonl"
+    records = complete_records()
+    first = JsonlProjectionStore(first_path).publish(records)
+    second = JsonlProjectionStore(second_path).publish(list(reversed(records)))
+
+    assert first_path.read_bytes() == second_path.read_bytes()
+    assert first.generation == second.generation
+    assert "caffè-☕" in first_path.read_text(encoding="utf-8")
+
+    same = JsonlProjectionStore(first_path).publish(complete_records())
+    assert same.generation == first.generation
+    changed_records = complete_records()
+    changed_records[0]["text"] = "Changed"
+    changed = JsonlProjectionStore(first_path).publish(changed_records)
+    assert changed.generation != first.generation
+
+
+def test_duplicate_ids_and_malformed_records_are_explicit(tmp_path: Path) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_text('{"id":"same"}\n{"id":"same"}\n', encoding="utf-8")
+    with pytest.raises(DuplicateLessonIdError, match="same"):
+        JsonlProjectionStore(path).snapshot()
+
+    path.write_text('{"id":"ok"}\nnot-json\n', encoding="utf-8")
+    with pytest.raises(MalformedProjectionError, match="line 2"):
+        JsonlProjectionStore(path).snapshot()
+
+    path.write_text(json.dumps(["not", "an", "object"]) + "\n", encoding="utf-8")
+    with pytest.raises(MalformedProjectionError, match="not an object"):
+        JsonlProjectionStore(path).snapshot()
+
+
+def test_atomic_replacement_keeps_existing_snapshot_coherent(tmp_path: Path) -> None:
+    store = JsonlProjectionStore(tmp_path / "lessons.jsonl")
+    old = store.publish([{"id": "old", "text": "old"}])
+    new = store.publish([{"id": "new", "text": "new"}])
+
+    assert old.get("old") is not None
+    assert old.get("new") is None
+    assert new.get("old") is None
+    assert store.snapshot().get("new") is not None
+
+
+def test_manual_snapshot_order_changes_generation(tmp_path: Path) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_text('{"id":"a"}\n{"id":"b"}\n', encoding="utf-8")
+    first = JsonlProjectionStore(path).snapshot()
+    path.write_text('{"id":"b"}\n{"id":"a"}\n', encoding="utf-8")
+    second = JsonlProjectionStore(path).snapshot()
+    assert [row["id"] for row in first.list()] == ["a", "b"]
+    assert [row["id"] for row in second.list()] == ["b", "a"]
+    assert first.generation != second.generation
+
+
+def test_publish_preserves_existing_permissions(tmp_path: Path) -> None:
+    path = tmp_path / "lessons.jsonl"
+    path.write_text('{"id":"old"}\n', encoding="utf-8")
+    os.chmod(path, 0o640)
+    JsonlProjectionStore(path).publish([{"id": "new"}])
+    assert path.stat().st_mode & 0o777 == 0o640
+
+
+def test_failed_publication_retains_previous_readable_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "lessons.jsonl"
+    store = JsonlProjectionStore(path)
+    previous = store.publish([{"id": "old", "text": "still readable"}])
+
+    def fail_replace(source: Path, destination: Path) -> None:
+        raise OSError("interrupted before replace")
+
+    monkeypatch.setattr(jsonl_adapter.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="interrupted"):
+        store.publish([{"id": "new", "text": "not published"}])
+
+    current = store.snapshot()
+    assert current.generation == previous.generation
+    assert current.get("old") is not None
+    assert current.get("new") is None
+    assert list(tmp_path.glob(".lessons.jsonl.*.tmp")) == []


### PR DESCRIPTION
## Summary

Introduces the backend-neutral projection storage abstraction defined by ADR 0001 while keeping JSONL as the default compatibility backend.

The implementation adds:

- a typed `ProjectionStore` port;
- a JSONL adapter with deterministic snapshots and fingerprints;
- atomic complete-snapshot publication;
- explicit composition boundaries;
- an isolated legacy JSONL append facade;
- migration of API, vault, import and ML readers to the storage boundary;
- deliberate compatibility with historical Pandas JSON-lines inference;
- reusable projection-store contract tests.

## Compatibility

- JSONL remains the default backend.
- Existing API schemas and successful CLI behavior are preserved.
- Historical append behavior remains available outside the common port.
- Duplicate appends and malformed existing projections now fail deterministically without modifying the dataset.
- Existing destination permissions are preserved during atomic replacement.
- No SQLite cutover or schema work is included.

## Validation

- Focused issue suite: **32 passed**
- Legacy append/API-function tests: **7 passed**
- Ruff: passed
- `compileall`: passed
- `git diff --check`: passed

The local FastAPI `TestClient` suite still exhibits the known environment-specific hang and was only executed with bounded timeouts. Focused direct API-function tests pass; CI should provide the authoritative full-suite result.

## Scope exclusions

This PR deliberately does not implement:

- SQLite storage or migrations;
- TritaLeLe candidate staging;
- import dry-run;
- external quiz/review contracts;
- GUI changes.

Refs #92
