### PR TITLE
chore: establish Mypy baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Ruff (lint)
         run: ruff check .
 
+      - name: Mypy (type check)
+        run: mypy src/lele_manager
+
       - name: Pytest
         run: pytest -q
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ source .venv/bin/activate  # su Windows: .venv\Scripts\activate
 pip install -e .[dev]
 ```
 
+Verifica statica dell'intero package Python usando Python 3.12,
+la stessa versione adottata dalla CI:
+
+```bash
+mypy src/lele_manager
+```
+
 ---
 
 ## 🛠️ Primi tool CLI (palestra)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,27 @@ dev = [
     "pre-commit",
     "bandit",
     "pip-audit",
+    "mypy",
+    "pandas-stubs",
+    "types-PyYAML",
+    "scipy-stubs; python_version >= '3.12'",
 ]
+
+[tool.mypy]
+python_version = "3.12"
+files = ["src/lele_manager"]
+check_untyped_defs = true
+no_implicit_optional = true
+show_error_codes = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = [
+    "joblib",
+    "sklearn.*",
+]
+ignore_missing_imports = true
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,7 @@ scikit-learn
 fastapi
 uvicorn[standard]
 pytest
+mypy
+pandas-stubs
+types-PyYAML
+scipy-stubs; python_version >= "3.12"

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -1219,7 +1219,8 @@ def root_redirect() -> RedirectResponse:
 
 
 if GUI_DIR is not None:
-    _assets_dir = GUI_DIR / "assets"
+    _gui_dir = GUI_DIR
+    _assets_dir = _gui_dir / "assets"
     if _assets_dir.is_dir():
         app.mount("/app/assets", StaticFiles(directory=_assets_dir), name="gui-assets")
 
@@ -1227,7 +1228,7 @@ if GUI_DIR is not None:
     @app.get("/app/", include_in_schema=False)
     @app.get("/app/{full_path:path}", include_in_schema=False)
     def gui_app(full_path: str = "") -> FileResponse:
-        index = GUI_DIR / "index.html"
+        index = _gui_dir / "index.html"
         return FileResponse(index)
 else:
 

--- a/src/lele_manager/cli/import_from_dir.py
+++ b/src/lele_manager/cli/import_from_dir.py
@@ -7,7 +7,7 @@ import yaml
 
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple
 
 from lele_manager.composition import projection_store
 
@@ -95,7 +95,7 @@ def derive_topic(frontmatter: Dict[str, object], md_path: Path, default_topic: O
     return parent or None
 
 
-def normalize_tags(value: Union[str, List[str], None]) -> List[str]:
+def normalize_tags(value: object) -> List[str]:
     if value is None:
         return []
     if isinstance(value, list):
@@ -104,6 +104,18 @@ def normalize_tags(value: Union[str, List[str], None]) -> List[str]:
     if "," in txt:
         return [part.strip() for part in txt.split(",") if part.strip()]
     return [txt.strip()] if txt.strip() else []
+
+
+def _normalize_importance(
+    value: object,
+    default: Optional[int],
+) -> Tuple[Optional[int], bool]:
+    if isinstance(value, (str, bytes, bytearray, int, float)):
+        try:
+            return int(value), False
+        except (TypeError, ValueError):
+            pass
+    return default, True
 
 
 def _normalize_frontmatter_date(value: object) -> Optional[str]:
@@ -195,17 +207,18 @@ def import_from_dir(
 
         # topic
         topic = derive_topic(frontmatter, md_path, default_topic)
-        if topic is not None and not (
-            isinstance(frontmatter.get("topic"), str) and frontmatter["topic"].strip()
-        ):
+        raw_topic = frontmatter.get("topic")
+        if topic is not None and not (isinstance(raw_topic, str) and raw_topic.strip()):
             frontmatter["topic"] = topic
             if write_missing_frontmatter:
                 source_frontmatter["topic"] = topic
                 source_frontmatter_changed = True
 
         # source
-        if isinstance(frontmatter.get("source"), str) and frontmatter["source"].strip():
-            source = frontmatter["source"].strip()
+        source: Optional[str]
+        raw_source = frontmatter.get("source")
+        if isinstance(raw_source, str) and raw_source.strip():
+            source = raw_source.strip()
         else:
             source = default_source
             if default_source is not None:
@@ -216,15 +229,15 @@ def import_from_dir(
 
         # importance
         if "importance" in frontmatter:
-            try:
-                importance = int(frontmatter["importance"])  # type: ignore[arg-type]
-            except (TypeError, ValueError):
-                importance = default_importance
-                if default_importance is not None:
-                    frontmatter["importance"] = int(default_importance)
-                    if write_missing_frontmatter:
-                        source_frontmatter["importance"] = int(default_importance)
-                        source_frontmatter_changed = True
+            importance, used_default_importance = _normalize_importance(
+                frontmatter["importance"],
+                default_importance,
+            )
+            if used_default_importance and default_importance is not None:
+                frontmatter["importance"] = int(default_importance)
+                if write_missing_frontmatter:
+                    source_frontmatter["importance"] = int(default_importance)
+                    source_frontmatter_changed = True
         else:
             importance = default_importance
             if default_importance is not None:
@@ -350,7 +363,7 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     records_by_id = import_from_dir(
         input_dir=input_dir,
-        on_duplicate=args.on_duplicate,  # type: ignore[arg-type]
+        on_duplicate=args.on_duplicate,
         default_source=args.default_source,
         default_importance=args.default_importance,
         default_topic=args.default_topic,

--- a/src/lele_manager/core/analytics.py
+++ b/src/lele_manager/core/analytics.py
@@ -86,17 +86,17 @@ def compute_timeline(df: pd.DataFrame, group_by: GroupBy = "month") -> Dict[str,
             buckets.setdefault(key, []).append(str(row["id"]))
     else:
         dates = _date_series(work)
-        for idx, row in work.iterrows():
-            dt = dates.loc[idx]
+        lesson_ids = work["id"].astype(str).tolist()
+        for lesson_id, dt in zip(lesson_ids, dates.tolist()):
             if pd.isna(dt):
                 key = "(senza data)"
             elif group_by == "year":
                 key = f"{dt.year:04d}"
             else:
                 key = f"{dt.year:04d}-{dt.month:02d}"
-            buckets.setdefault(key, []).append(str(row["id"]))
+            buckets.setdefault(key, []).append(lesson_id)
 
-    bucket_list = [
+    bucket_list: List[Dict[str, Any]] = [
         {"key": key, "count": len(ids), "lesson_ids": ids}
         for key, ids in buckets.items()
     ]

--- a/src/lele_manager/core/deduplication.py
+++ b/src/lele_manager/core/deduplication.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 import math
 import unicodedata
-from typing import Any, Literal
+from typing import Any, Literal, Protocol, cast
 
 import numpy as np
 import pandas as pd
@@ -14,6 +14,11 @@ from lele_manager.ml.features import LessonFeatureExtractor
 
 
 DEFAULT_MIN_SCORE = 0.85
+
+
+class _SupportsToCsr(Protocol):
+    def tocsr(self) -> sparse.csr_matrix:
+        ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,12 +165,18 @@ def find_duplicates(
     df = lessons.reset_index(drop=True)
     if not exact_only and feature_matrix is not None and feature_matrix.shape[0] != len(df):
         raise ValueError("feature matrix must have the same number of rows as lessons")
-    scores = None
+    scores: np.ndarray | None = None
     if not exact_only and len(df) > 1:
-        matrix = feature_matrix
-        if matrix is None:
-            matrix = transformer.transform(df)  # type: ignore[union-attr]
-        matrix = sparse.csr_matrix(matrix)
+        matrix_input = feature_matrix
+        if matrix_input is None:
+            assert transformer is not None
+            matrix_input = transformer.transform(df)
+
+        if isinstance(matrix_input, np.ndarray):
+            matrix = sparse.csr_matrix(matrix_input)
+        else:
+            matrix = cast(_SupportsToCsr, matrix_input).tocsr()
+
         scores = cosine_similarity(matrix)
 
     pairs: list[DuplicatePair] = []
@@ -196,7 +207,8 @@ def find_duplicates(
             else:
                 if exact_only:
                     continue
-                score = float(scores[left_pos, right_pos])  # type: ignore[index]
+                assert scores is not None
+                score = float(scores[left_pos, right_pos])
                 if min_score > 0.0 and score < min_score:
                     continue
                 kind = "near"

--- a/src/lele_manager/ml/features.py
+++ b/src/lele_manager/ml/features.py
@@ -49,7 +49,11 @@ class LessonFeatureExtractor(BaseEstimator, TransformerMixin):
         self._scaler: Optional[StandardScaler] = None
 
     # --- API scikit-learn ---
-    def fit(self, X: pd.DataFrame, y=None):  # type: ignore[override]
+    def fit(
+        self,
+        X: pd.DataFrame,
+        y: object = None,
+    ) -> "LessonFeatureExtractor":
         texts = self._get_text_series(X)
 
         # 1) Fit TF-IDF
@@ -63,7 +67,7 @@ class LessonFeatureExtractor(BaseEstimator, TransformerMixin):
 
         return self
 
-    def transform(self, X: pd.DataFrame):  # type: ignore[override]
+    def transform(self, X: pd.DataFrame) -> sparse.csr_matrix:
         texts = self._get_text_series(X)
 
         # 1) TF-IDF

--- a/src/lele_manager/ml/similarity.py
+++ b/src/lele_manager/ml/similarity.py
@@ -70,13 +70,22 @@ class LessonSimilarityIndex:
         [features] -> [clf]
         """
         try:
-            transformer: LessonFeatureExtractor = pipeline.named_steps["features"]  # type: ignore[assignment]
+            feature_step = pipeline.named_steps["features"]
         except KeyError:
             raise KeyError(
                 "Pipeline must have a 'features' step of type LessonFeatureExtractor."
             )
 
-        return cls.from_dataframe(df=df, transformer=transformer, id_column=id_column)
+        if not isinstance(feature_step, LessonFeatureExtractor):
+            raise TypeError(
+                "Pipeline step 'features' must be a LessonFeatureExtractor."
+            )
+
+        return cls.from_dataframe(
+            df=df,
+            transformer=feature_step,
+            id_column=id_column,
+        )
 
     def most_similar_with_ranking(
         self,

--- a/src/lele_manager/ml/similarity_backend.py
+++ b/src/lele_manager/ml/similarity_backend.py
@@ -6,10 +6,16 @@ from typing import Optional, Protocol
 
 import numpy as np
 import pandas as pd
+from scipy import sparse
 
 from lele_manager.core.ranking import SimilarityRankingConfig
 from lele_manager.ml.features import LessonFeatureExtractor
 from lele_manager.ml.similarity import LessonSimilarityIndex, LessonSimilarityResult
+
+
+class _SvdTransformer(Protocol):
+    def transform(self, matrix: sparse.spmatrix) -> np.ndarray:
+        ...
 
 
 # --------------------------
@@ -33,7 +39,7 @@ class _LsaCacheKey_Internal:
 class _LsaIndexCache_Internal:
     lesson_ids: np.ndarray
     x_dense: np.ndarray
-    svd: object
+    svd: _SvdTransformer
 
 
 class _TfidfLsaBackend_Internal:
@@ -64,7 +70,6 @@ class _TfidfLsaBackend_Internal:
         if cached is not None:
             return cached
 
-        from scipy import sparse
         from sklearn.decomposition import TruncatedSVD
 
         # ids
@@ -148,7 +153,7 @@ class _LsaIndexCache:
     lesson_ids: np.ndarray
     x_dense: np.ndarray
     # store fitted svd so we can transform query vectors consistently
-    svd: object
+    svd: _SvdTransformer
 
 
 class TfidfLsaSimilarityBackend:
@@ -180,7 +185,6 @@ class TfidfLsaSimilarityBackend:
         if cached is not None:
             return cached
 
-        from scipy import sparse
         from sklearn.decomposition import TruncatedSVD
 
         # ids are derived exactly like LessonSimilarityIndex.from_dataframe
@@ -230,7 +234,6 @@ class TfidfLsaSimilarityBackend:
         if ranking is None:
             ranking = SimilarityRankingConfig()
 
-        from scipy import sparse
 
         cache = self._build_or_get_index(df=df, transformer=transformer)
         query_df = pd.DataFrame({"text": [query_text]})


### PR DESCRIPTION
## Summary

Establishes a maintainable Mypy baseline for the Python package and adds type checking to pull-request CI.

The implementation:

- adds Mypy and maintained third-party stub packages to the development dependencies;
- configures Mypy for the Python 3.12 CI environment;
- limits missing-import overrides to Joblib and scikit-learn;
- resolves existing first-party typing errors without global ignores;
- adds an explicit Mypy step to GitHub Actions;
- documents the canonical local type-checking command.

## Compatibility

- Runtime support remains declared as Python 3.10 or newer.
- The supported Mypy baseline runs on Python 3.12, matching GitHub Actions.
- `scipy-stubs` is conditionally installed only on Python 3.12 or newer.
- Public API, CLI and runtime behavior remain unchanged.

## Validation

- Ruff: passed
- Mypy: 40 source files checked, no issues
- Pytest: 184 passed, 3 skipped
- Build: sdist and wheel created successfully
- Wheel installation: passed in a clean virtual environment
- CLI smoke test: passed
- `compileall`: passed
- `git diff --check`: passed

## Typing policy

No global `ignore_errors`, blanket `follow_imports = skip`, broad `Any` casts or repository-wide missing-import suppression were introduced.

Missing-import overrides are restricted to third-party modules without a usable typed contract:

- `joblib`
- `sklearn.*`

Closes #114
