### PR TITLE
feat(import): add deterministic dry-run preview

### DIFF
--- a/src/lele_manager/adapters/jsonl_projection_store.py
+++ b/src/lele_manager/adapters/jsonl_projection_store.py
@@ -15,6 +15,7 @@ import tempfile
 import stat
 from typing import Any
 
+from lele_manager.core.json_compat import canonical_json
 from lele_manager.core.projection_store import (
     DuplicateLessonIdError,
     LessonOrder,
@@ -27,9 +28,7 @@ from lele_manager.core.projection_store import (
 
 def _canonical_json(record: LessonRecord) -> str:
     try:
-        return json.dumps(
-            record, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
-        )
+        return canonical_json(record)
     except (TypeError, ValueError) as exc:
         raise MalformedProjectionError(f"lesson record is not JSON serializable: {exc}") from exc
 

--- a/src/lele_manager/cli/import_from_dir.py
+++ b/src/lele_manager/cli/import_from_dir.py
@@ -7,9 +7,20 @@ import yaml
 
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Mapping, Optional, Sequence, Tuple
 
 from lele_manager.composition import projection_store
+from lele_manager.core.import_plan import (
+    DuplicateId,
+    DuplicatePolicy as PlanDuplicatePolicy,
+    DuplicateResolution,
+    IgnoredFile,
+    ImportPlan,
+    LessonChange,
+    LessonChangeKind,
+    PendingSourceWrite,
+    ValidationProblem,
+)
 
 DuplicatePolicy = Literal["overwrite", "skip", "error"]
 
@@ -84,7 +95,9 @@ def derive_id_from_path(md_path: Path, root_dir: Path) -> str:
     return rel
 
 
-def derive_topic(frontmatter: Dict[str, object], md_path: Path, default_topic: Optional[str]) -> Optional[str]:
+def derive_topic(
+    frontmatter: Dict[str, object], md_path: Path, default_topic: Optional[str]
+) -> Optional[str]:
     if "topic" in frontmatter and isinstance(frontmatter["topic"], str):
         t = frontmatter["topic"].strip()
         if t:
@@ -159,27 +172,39 @@ def compute_frontmatter_hash(frontmatter: Dict[str, object]) -> str:
 # ---------------------------------------------------------------------------
 # Importer
 # ---------------------------------------------------------------------------
-def import_from_dir(
+def _markdown_files(input_dir: Path) -> List[Path]:
+    return sorted(
+        path
+        for path in input_dir.rglob("*")
+        if path.is_file() and path.suffix.lower() == ".md"
+    )
+
+
+def analyze_import_from_dir(
     input_dir: Path,
     on_duplicate: DuplicatePolicy,
     default_source: Optional[str],
     default_importance: Optional[int],
     default_topic: Optional[str],
     write_missing_frontmatter: bool,
-) -> Dict[str, LeLeRecord]:
+    existing_records: Sequence[Mapping[str, Any]] = (),
+) -> ImportPlan:
     if not input_dir.is_dir():
         raise SystemExit(f"[errore] Directory di input non trovata: {input_dir}")
 
     records_by_id: Dict[str, LeLeRecord] = {}
     first_path_by_id: Dict[str, Path] = {}
-    files_to_update: List[Tuple[Path, str]] = []
+    plan = ImportPlan()
 
-    md_files = sorted(input_dir.rglob("*.md"))
+    for path in sorted(input_dir.rglob("*")):
+        if path.is_file() and path.suffix.lower() != ".md":
+            plan.ignored_files.append(
+                IgnoredFile(path.relative_to(input_dir).as_posix(), "not_markdown")
+            )
+
+    md_files = _markdown_files(input_dir)
     if not md_files:
-        print(f"[warn] Nessun file .md trovato sotto {input_dir}")
-        return records_by_id
-
-    print(f"[info] Trovati {len(md_files)} file .md sotto {input_dir}")
+        return plan
 
     for md_path in md_files:
         rel_path = md_path.relative_to(input_dir).as_posix()
@@ -187,10 +212,24 @@ def import_from_dir(
         try:
             content = md_path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
-            print(f"[warn] Impossibile leggere {rel_path} come UTF-8, salto.")
+            plan.validation_problems.append(
+                ValidationProblem(
+                    code="invalid_utf8",
+                    message="Impossibile leggere il file come UTF-8.",
+                    path=rel_path,
+                )
+            )
             continue
 
         source_frontmatter, body = parse_markdown_with_frontmatter(content)
+        if _has_malformed_yaml_frontmatter(content):
+            plan.validation_problems.append(
+                ValidationProblem(
+                    code="malformed_yaml",
+                    message="Frontmatter YAML malformato; trattato come assente.",
+                    path=rel_path,
+                )
+            )
         frontmatter = dict(source_frontmatter)
         source_frontmatter_changed = False
 
@@ -288,26 +327,144 @@ def import_from_dir(
             msg = f"ID duplicato '{lele_id}' in {rel_path} (già visto in {existing_path.relative_to(input_dir)})"
 
             if on_duplicate == "error":
-                raise SystemExit(f"[errore] {msg}")
+                resolution = DuplicateResolution.BLOCKED
+                plan.validation_problems.append(
+                    ValidationProblem(
+                        code="duplicate_id",
+                        message=msg,
+                        path=rel_path,
+                        field="id",
+                        blocking=True,
+                    )
+                )
+                plan.duplicates.append(
+                    DuplicateId(
+                        lele_id,
+                        existing_path.relative_to(input_dir).as_posix(),
+                        rel_path,
+                        PlanDuplicatePolicy.ERROR,
+                        resolution,
+                    )
+                )
+                continue
             if on_duplicate == "skip":
-                print(f"[warn] {msg} -> skip nuovo file.")
+                plan.duplicates.append(
+                    DuplicateId(
+                        lele_id,
+                        existing_path.relative_to(input_dir).as_posix(),
+                        rel_path,
+                        PlanDuplicatePolicy.SKIP,
+                        DuplicateResolution.KEPT_FIRST,
+                    )
+                )
                 continue
             if on_duplicate == "overwrite":
-                print(f"[info] {msg} -> overwrite con {rel_path}.")
+                plan.duplicates.append(
+                    DuplicateId(
+                        lele_id,
+                        existing_path.relative_to(input_dir).as_posix(),
+                        rel_path,
+                        PlanDuplicatePolicy.OVERWRITE,
+                        DuplicateResolution.KEPT_LAST,
+                    )
+                )
 
         records_by_id[lele_id] = record
         first_path_by_id[lele_id] = md_path
 
         if write_missing_frontmatter and source_frontmatter_changed:
             new_content = render_markdown_with_frontmatter(source_frontmatter, body)
-            files_to_update.append((md_path, new_content))
+            plan.pending_source_writes.append(
+                PendingSourceWrite(rel_path, "complete_frontmatter")
+            )
+            plan.pending_source_contents[rel_path] = new_content
 
-    if files_to_update:
-        print(f"[info] Aggiorno {len(files_to_update)} file per aggiungere/sincronizzare il frontmatter.")
-        for md_path, new_content in files_to_update:
-            md_path.write_text(new_content, encoding="utf-8")
+    plan.candidate_records = {
+        lesson_id: asdict(record) for lesson_id, record in records_by_id.items()
+    }
+    plan.replace_all = bool(records_by_id) and not plan.blocking
+    existing_by_id = {
+        str(record["id"]): record for record in existing_records if "id" in record
+    }
+    for lesson_id, record in records_by_id.items():
+        candidate = asdict(record)
+        existing = existing_by_id.get(lesson_id)
+        if existing is None:
+            kind = LessonChangeKind.CREATE
+        elif dict(existing) == candidate:
+            kind = LessonChangeKind.UNCHANGED
+        else:
+            kind = LessonChangeKind.UPDATE
+        plan.changes.append(LessonChange(lesson_id, kind, record.path))
+    if plan.replace_all:
+        for lesson_id in existing_by_id.keys() - records_by_id.keys():
+            plan.changes.append(LessonChange(lesson_id, LessonChangeKind.REMOVED))
+    return plan
 
-    return records_by_id
+
+def _has_malformed_yaml_frontmatter(content: str) -> bool:
+    lines = content.splitlines()
+    if not lines or not lines[0].strip().startswith("---"):
+        return False
+    for index in range(1, len(lines)):
+        if lines[index].strip().startswith("---"):
+            try:
+                return not isinstance(
+                    yaml.safe_load("\n".join(lines[1:index])) or {}, dict
+                )
+            except yaml.YAMLError:
+                return True
+    return False
+
+
+def import_from_dir(
+    input_dir: Path,
+    on_duplicate: DuplicatePolicy,
+    default_source: Optional[str],
+    default_importance: Optional[int],
+    default_topic: Optional[str],
+    write_missing_frontmatter: bool,
+) -> Dict[str, LeLeRecord]:
+    plan = analyze_import_from_dir(
+        input_dir,
+        on_duplicate,
+        default_source,
+        default_importance,
+        default_topic,
+        write_missing_frontmatter,
+    )
+    md_files = _markdown_files(input_dir)
+    if not md_files:
+        print(f"[warn] Nessun file .md trovato sotto {input_dir}")
+        return {}
+    print(f"[info] Trovati {len(md_files)} file .md sotto {input_dir}")
+    for duplicate in plan.duplicates:
+        msg = (
+            f"ID duplicato '{duplicate.lesson_id}' in {duplicate.duplicate_path} "
+            f"(già visto in {duplicate.first_path})"
+        )
+        if duplicate.policy is PlanDuplicatePolicy.ERROR:
+            raise SystemExit(f"[errore] {msg}")
+        if duplicate.policy is PlanDuplicatePolicy.SKIP:
+            print(f"[warn] {msg} -> skip nuovo file.")
+        else:
+            print(f"[info] {msg} -> overwrite con {duplicate.duplicate_path}.")
+    for problem in plan.validation_problems:
+        if problem.code == "invalid_utf8":
+            print(f"[warn] Impossibile leggere {problem.path} come UTF-8, salto.")
+    if plan.pending_source_writes:
+        print(
+            f"[info] Aggiorno {len(plan.pending_source_writes)} file per "
+            "aggiungere/sincronizzare il frontmatter."
+        )
+        for pending in plan.pending_source_writes:
+            (input_dir / pending.path).write_text(
+                plan.pending_source_contents[pending.path], encoding="utf-8"
+            )
+    return {
+        lesson_id: LeLeRecord(**dict(record))
+        for lesson_id, record in plan.candidate_records.items()
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -320,8 +477,12 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
             "e genera un file JSONL compatibile con LeLe Manager."
         )
     )
-    parser.add_argument("input_dir", help="Directory radice che contiene le LeLe in formato Markdown.")
-    parser.add_argument("output", help="Percorso del file JSONL di output (sarà sovrascritto).")
+    parser.add_argument(
+        "input_dir", help="Directory radice che contiene le LeLe in formato Markdown."
+    )
+    parser.add_argument(
+        "output", help="Percorso del file JSONL di output (sarà sovrascritto)."
+    )
     parser.add_argument(
         "--on-duplicate",
         choices=["overwrite", "skip", "error"],

--- a/src/lele_manager/cli/import_from_dir.py
+++ b/src/lele_manager/cli/import_from_dir.py
@@ -382,7 +382,8 @@ def analyze_import_from_dir(
             )
 
         records_by_id[lele_id] = record
-        first_path_by_id[lele_id] = md_path
+        if lele_id not in first_path_by_id:
+            first_path_by_id[lele_id] = md_path
         pending_source_by_id[lele_id] = pending_source
 
     if not plan.blocking:
@@ -638,15 +639,22 @@ def main(argv: Optional[List[str]] = None) -> None:
                 file=sys.stderr,
             )
             raise SystemExit(2) from exc
-        plan = analyze_import_from_dir(
-            input_dir=input_dir,
-            on_duplicate=args.on_duplicate,
-            default_source=args.default_source,
-            default_importance=args.default_importance,
-            default_topic=args.default_topic,
-            write_missing_frontmatter=args.write_missing_frontmatter,
-            existing_records=existing_records,
-        )
+        try:
+            plan = analyze_import_from_dir(
+                input_dir=input_dir,
+                on_duplicate=args.on_duplicate,
+                default_source=args.default_source,
+                default_importance=args.default_importance,
+                default_topic=args.default_topic,
+                write_missing_frontmatter=args.write_missing_frontmatter,
+                existing_records=existing_records,
+            )
+        except OSError as exc:
+            print(
+                f"[errore] Impossibile leggere la directory di input: {exc}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2) from exc
         print(render_import_plan(plan))
         if plan.blocking:
             raise SystemExit(1)

--- a/src/lele_manager/cli/import_from_dir.py
+++ b/src/lele_manager/cli/import_from_dir.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import hashlib
+import sys
 import yaml
 
 from dataclasses import asdict, dataclass
@@ -21,6 +22,7 @@ from lele_manager.core.import_plan import (
     PendingSourceWrite,
     ValidationProblem,
 )
+from lele_manager.core.projection_store import ProjectionStoreError
 
 DuplicatePolicy = Literal["overwrite", "skip", "error"]
 
@@ -470,6 +472,86 @@ def import_from_dir(
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+def render_import_plan(plan: ImportPlan) -> str:
+    """Render a stable, human-readable dry-run report."""
+    changes_by_kind = {
+        kind: sorted(
+            (change for change in plan.changes if change.kind is kind),
+            key=lambda change: (change.lesson_id, change.path or ""),
+        )
+        for kind in LessonChangeKind
+    }
+    lines = [
+        "Piano import (dry-run)",
+        "Riepilogo: "
+        + ", ".join(
+            f"{kind.value}={len(changes_by_kind[kind])}"
+            for kind in LessonChangeKind
+        )
+        + f", duplicati={len(plan.duplicates)}"
+        + f", problemi={len(plan.validation_problems)}"
+        + f", file ignorati={len(plan.ignored_files)}"
+        + f", scritture sorgenti={len(plan.pending_source_writes)}",
+    ]
+
+    for kind in LessonChangeKind:
+        lines.append(f"{kind.value}:")
+        changes = changes_by_kind[kind]
+        if not changes:
+            lines.append("  (nessuno)")
+        for change in changes:
+            location = f" — {change.path}" if change.path else ""
+            lines.append(f"  - {change.lesson_id}{location}")
+
+    lines.append("duplicate IDs:")
+    if not plan.duplicates:
+        lines.append("  (nessuno)")
+    for duplicate in sorted(
+        plan.duplicates,
+        key=lambda item: (item.lesson_id, item.first_path, item.duplicate_path),
+    ):
+        lines.append(
+            f"  - {duplicate.lesson_id}: {duplicate.first_path} / "
+            f"{duplicate.duplicate_path}; policy={duplicate.policy.value}; "
+            f"risoluzione={duplicate.resolution.value}"
+        )
+
+    lines.append("validation problems:")
+    if not plan.validation_problems:
+        lines.append("  (nessuno)")
+    for problem in sorted(
+        plan.validation_problems,
+        key=lambda item: (item.path or "", item.code, item.field or "", item.message),
+    ):
+        severity = "bloccante" if problem.blocking else "non bloccante"
+        location = f" — {problem.path}" if problem.path else ""
+        field = f"; campo={problem.field}" if problem.field else ""
+        lines.append(
+            f"  - [{severity}] {problem.code}{location}{field}: {problem.message}"
+        )
+
+    lines.append("ignored files:")
+    if not plan.ignored_files:
+        lines.append("  (nessuno)")
+    for ignored in sorted(plan.ignored_files, key=lambda item: (item.path, item.reason)):
+        lines.append(f"  - {ignored.path}: {ignored.reason}")
+
+    lines.append("pending source writes:")
+    if not plan.pending_source_writes:
+        lines.append("  (nessuna)")
+    for pending in sorted(
+        plan.pending_source_writes, key=lambda item: (item.path, item.reason)
+    ):
+        lines.append(f"  - {pending.path}: {pending.reason}")
+
+    if plan.replace_all:
+        lines.append("Pubblicazione replace-all: avverrebbe.")
+    else:
+        lines.append("Pubblicazione replace-all: non avverrebbe.")
+    lines.append("Nessuna modifica applicata.")
+    return "\n".join(lines)
+
+
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
@@ -513,6 +595,11 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
             "i file già validi non vengono riscritti."
         ),
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Analizza e mostra le modifiche senza applicare alcuna scrittura.",
+    )
     return parser.parse_args(argv)
 
 
@@ -521,6 +608,37 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     input_dir = Path(args.input_dir).resolve()
     output_path = Path(args.output).resolve()
+
+    if args.dry_run:
+        if not input_dir.is_dir():
+            print(
+                f"[errore] Directory di input non trovata: {input_dir}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+
+        store = projection_store(output_path)
+        try:
+            existing_records = store.snapshot().list()
+        except ProjectionStoreError as exc:
+            print(
+                f"[errore] Output corrente non valido o non leggibile: {exc}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2) from exc
+        plan = analyze_import_from_dir(
+            input_dir=input_dir,
+            on_duplicate=args.on_duplicate,
+            default_source=args.default_source,
+            default_importance=args.default_importance,
+            default_topic=args.default_topic,
+            write_missing_frontmatter=args.write_missing_frontmatter,
+            existing_records=existing_records,
+        )
+        print(render_import_plan(plan))
+        if plan.blocking:
+            raise SystemExit(1)
+        return
 
     records_by_id = import_from_dir(
         input_dir=input_dir,

--- a/src/lele_manager/cli/import_from_dir.py
+++ b/src/lele_manager/cli/import_from_dir.py
@@ -22,6 +22,7 @@ from lele_manager.core.import_plan import (
     PendingSourceWrite,
     ValidationProblem,
 )
+from lele_manager.core.json_compat import json_native
 from lele_manager.core.projection_store import ProjectionStoreError
 
 DuplicatePolicy = Literal["overwrite", "skip", "error"]
@@ -196,6 +197,7 @@ def analyze_import_from_dir(
 
     records_by_id: Dict[str, LeLeRecord] = {}
     first_path_by_id: Dict[str, Path] = {}
+    pending_source_by_id: dict[str, tuple[PendingSourceWrite, str] | None] = {}
     plan = ImportPlan()
 
     for path in sorted(input_dir.rglob("*")):
@@ -371,15 +373,25 @@ def analyze_import_from_dir(
                     )
                 )
 
-        records_by_id[lele_id] = record
-        first_path_by_id[lele_id] = md_path
-
+        pending_source: tuple[PendingSourceWrite, str] | None = None
         if write_missing_frontmatter and source_frontmatter_changed:
             new_content = render_markdown_with_frontmatter(source_frontmatter, body)
-            plan.pending_source_writes.append(
-                PendingSourceWrite(rel_path, "complete_frontmatter")
+            pending_source = (
+                PendingSourceWrite(rel_path, "complete_frontmatter"),
+                new_content,
             )
-            plan.pending_source_contents[rel_path] = new_content
+
+        records_by_id[lele_id] = record
+        first_path_by_id[lele_id] = md_path
+        pending_source_by_id[lele_id] = pending_source
+
+    if not plan.blocking:
+        for lesson_id in sorted(pending_source_by_id):
+            pending = pending_source_by_id[lesson_id]
+            if pending is not None:
+                source_write, content = pending
+                plan.pending_source_writes.append(source_write)
+                plan.pending_source_contents[source_write.path] = content
 
     plan.candidate_records = {
         lesson_id: asdict(record) for lesson_id, record in records_by_id.items()
@@ -393,7 +405,7 @@ def analyze_import_from_dir(
         existing = existing_by_id.get(lesson_id)
         if existing is None:
             kind = LessonChangeKind.CREATE
-        elif dict(existing) == candidate:
+        elif json_native(existing) == json_native(candidate):
             kind = LessonChangeKind.UNCHANGED
         else:
             kind = LessonChangeKind.UPDATE
@@ -620,7 +632,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         store = projection_store(output_path)
         try:
             existing_records = store.snapshot().list()
-        except ProjectionStoreError as exc:
+        except (ProjectionStoreError, OSError) as exc:
             print(
                 f"[errore] Output corrente non valido o non leggibile: {exc}",
                 file=sys.stderr,

--- a/src/lele_manager/core/import_plan.py
+++ b/src/lele_manager/core/import_plan.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class LessonChangeKind(str, Enum):
+    CREATE = "create"
+    UPDATE = "update"
+    UNCHANGED = "unchanged"
+    REMOVED = "removed"
+
+
+class DuplicatePolicy(str, Enum):
+    ERROR = "error"
+    SKIP = "skip"
+    OVERWRITE = "overwrite"
+
+
+class DuplicateResolution(str, Enum):
+    BLOCKED = "blocked"
+    KEPT_FIRST = "kept_first"
+    KEPT_LAST = "kept_last"
+
+
+@dataclass(frozen=True)
+class LessonChange:
+    lesson_id: str
+    kind: LessonChangeKind
+    path: str | None = None
+
+
+@dataclass(frozen=True)
+class DuplicateId:
+    lesson_id: str
+    first_path: str
+    duplicate_path: str
+    policy: DuplicatePolicy
+    resolution: DuplicateResolution
+
+
+@dataclass(frozen=True)
+class ValidationProblem:
+    code: str
+    message: str
+    path: str | None = None
+    field: str | None = None
+    blocking: bool = False
+
+
+@dataclass(frozen=True)
+class IgnoredFile:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PendingSourceWrite:
+    path: str
+    reason: str
+
+
+@dataclass
+class ImportPlan:
+    changes: list[LessonChange] = field(default_factory=list)
+    duplicates: list[DuplicateId] = field(default_factory=list)
+    validation_problems: list[ValidationProblem] = field(default_factory=list)
+    ignored_files: list[IgnoredFile] = field(default_factory=list)
+    pending_source_writes: list[PendingSourceWrite] = field(default_factory=list)
+    replace_all: bool = False
+    candidate_records: dict[str, Mapping[str, Any]] = field(
+        default_factory=dict, repr=False
+    )
+    pending_source_contents: dict[str, str] = field(default_factory=dict, repr=False)
+
+    @property
+    def blocking(self) -> bool:
+        return any(problem.blocking for problem in self.validation_problems)
+
+    def to_dict(self, *, include_candidate_records: bool = False) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "changes": [
+                {"id": item.lesson_id, "kind": item.kind.value, "path": item.path}
+                for item in sorted(
+                    self.changes,
+                    key=lambda item: (item.lesson_id, item.kind.value, item.path or ""),
+                )
+            ],
+            "duplicates": [
+                {
+                    "id": item.lesson_id,
+                    "first_path": item.first_path,
+                    "duplicate_path": item.duplicate_path,
+                    "policy": item.policy.value,
+                    "resolution": item.resolution.value,
+                }
+                for item in sorted(
+                    self.duplicates,
+                    key=lambda item: (
+                        item.lesson_id,
+                        item.first_path,
+                        item.duplicate_path,
+                    ),
+                )
+            ],
+            "validation_problems": [
+                {
+                    "code": item.code,
+                    "message": item.message,
+                    "path": item.path,
+                    "field": item.field,
+                    "blocking": item.blocking,
+                }
+                for item in sorted(
+                    self.validation_problems,
+                    key=lambda item: (
+                        item.path or "",
+                        item.code,
+                        item.field or "",
+                        item.message,
+                    ),
+                )
+            ],
+            "ignored_files": [
+                {"path": item.path, "reason": item.reason}
+                for item in sorted(
+                    self.ignored_files, key=lambda item: (item.path, item.reason)
+                )
+            ],
+            "pending_source_writes": [
+                {"path": item.path, "reason": item.reason}
+                for item in sorted(
+                    self.pending_source_writes,
+                    key=lambda item: (item.path, item.reason),
+                )
+            ],
+            "replace_all": self.replace_all,
+            "blocking": self.blocking,
+        }
+        if include_candidate_records:
+            result["candidate_records"] = [
+                _json_native(self.candidate_records[lesson_id])
+                for lesson_id in sorted(self.candidate_records)
+            ]
+        return result
+
+
+def _json_native(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value).decode("utf-8", errors="replace")
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_native(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_native(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted((_json_native(item) for item in value), key=repr)
+    if isinstance(value, Enum):
+        return value.value
+    raise TypeError(f"Value is not JSON-native: {type(value).__name__}")

--- a/src/lele_manager/core/json_compat.py
+++ b/src/lele_manager/core/json_compat.py
@@ -1,0 +1,22 @@
+"""Shared JSON compatibility helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def canonical_json(value: Any) -> str:
+    """Return the canonical JSON representation used for persisted records."""
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+def json_native(value: Any) -> Any:
+    """Return the JSON-native structure produced by canonical persistence."""
+    return json.loads(canonical_json(value))

--- a/tests/test_import_from_dir.py
+++ b/tests/test_import_from_dir.py
@@ -84,3 +84,18 @@ Body
     assert rec.date == "2025-01-01"
     assert rec.frontmatter["date"] == "2025-01-01"
     assert md.read_bytes() == original
+
+
+def test_overwrite_updates_only_winning_duplicate_source(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    paths = [vault / name for name in ("a.md", "b.md", "c.md")]
+    for index, path in enumerate(paths, start=1):
+        path.write_text(f"---\nid: dup\n---\nbody {index}\n", encoding="utf-8")
+    originals = [path.read_bytes() for path in paths]
+
+    records = import_from_dir(vault, "overwrite", "note", 3, None, True)
+
+    assert records["dup"].text == "body 3"
+    assert [path.read_bytes() for path in paths[:2]] == originals[:2]
+    assert paths[2].read_bytes() != originals[2]

--- a/tests/test_import_from_dir_cli.py
+++ b/tests/test_import_from_dir_cli.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -6,12 +7,22 @@ from pathlib import Path
 import textwrap
 import yaml
 
+import pytest
+
+from lele_manager.cli import import_from_dir as import_cli
+
 
 def run_cmd(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
     """Helper per eseguire un comando Python -m ... in modo robusto."""
+    project_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(project_root / "src"), env.get("PYTHONPATH", "")]
+    )
     return subprocess.run(
         args,
         cwd=str(cwd) if cwd else None,
+        env=env,
         check=False,
         capture_output=True,
         text=True,
@@ -424,3 +435,195 @@ def test_valid_vault_import_does_not_modify_sources(tmp_path: Path) -> None:
         ("vault/b", "2025-01-02"),
     ]
     assert {name: (vault_dir / name).read_bytes() for name in sources} == sources
+
+
+def _dry_run(vault: Path, output: Path, *extra: str) -> subprocess.CompletedProcess:
+    return run_cmd(
+        [
+            sys.executable,
+            "-m",
+            "lele_manager.cli.import_from_dir",
+            str(vault),
+            str(output),
+            "--dry-run",
+            *extra,
+        ]
+    )
+
+
+def _lesson(path: Path, lesson_id: str, body: str = "Body") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nid: {lesson_id}\ntopic: topic\nsource: manual\nimportance: 3\n---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_parse_args_accepts_dry_run() -> None:
+    assert import_cli.parse_args(["vault", "out.jsonl", "--dry-run"]).dry_run is True
+
+
+def test_dry_run_does_not_create_output_or_parent_and_is_deterministic(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _lesson(vault / "lesson.MD", "uppercase")
+    output = tmp_path / "missing" / "nested" / "lessons.jsonl"
+
+    first = _dry_run(vault, output)
+    second = _dry_run(vault, output)
+
+    assert first.returncode == second.returncode == 0
+    assert first.stdout == second.stdout
+    assert "create=1" in first.stdout
+    assert "uppercase — lesson.MD" in first.stdout
+    assert not output.exists()
+    assert not output.parent.exists()
+
+
+def test_dry_run_preserves_existing_output_and_source_with_pending_write(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    markdown = vault / "topic" / "2025-01-01.lesson.md"
+    markdown.parent.mkdir(parents=True)
+    markdown.write_bytes(b"Body without frontmatter\n")
+    original_source = markdown.read_bytes()
+    output = tmp_path / "lessons.jsonl"
+    output.write_bytes(b'{"id":"old","text":"untouched"}\n')
+    original_output = output.read_bytes()
+
+    result = _dry_run(vault, output, "--write-missing-frontmatter")
+
+    assert result.returncode == 0
+    assert "pending source writes:" in result.stdout
+    assert "topic/2025-01-01.lesson.md" in result.stdout
+    assert output.read_bytes() == original_output
+    assert markdown.read_bytes() == original_source
+
+
+def test_dry_run_never_calls_publish(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vault = tmp_path / "vault"
+    _lesson(vault / "one.md", "one")
+
+    class Snapshot:
+        def list(self) -> tuple[dict[str, object], ...]:
+            return ()
+
+    class SpyStore:
+        def snapshot(self) -> Snapshot:
+            return Snapshot()
+
+        def publish(self, records: object) -> None:
+            pytest.fail(f"publish called with {records!r}")
+
+    monkeypatch.setattr(import_cli, "projection_store", lambda path: SpyStore())
+    import_cli.main([str(vault), str(tmp_path / "out.jsonl"), "--dry-run"])
+
+
+def test_dry_run_reports_all_change_kinds(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _lesson(vault / "same.md", "same")
+    _lesson(vault / "changed.md", "changed", "new")
+    _lesson(vault / "new.md", "new")
+    baseline = import_cli.analyze_import_from_dir(
+        vault, "overwrite", "manual", 3, None, False
+    )
+    same = dict(baseline.candidate_records["same"])
+    changed = dict(baseline.candidate_records["changed"])
+    changed["text"] = "old"
+    output = tmp_path / "lessons.jsonl"
+    output.write_text(
+        "\n".join(json.dumps(record) for record in [same, changed, {"id": "removed"}])
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _dry_run(vault, output)
+
+    assert result.returncode == 0
+    assert "Riepilogo: create=1, update=1, unchanged=1, removed=1" in result.stdout
+    for expected in ("new — new.md", "changed — changed.md", "same — same.md", "removed"):
+        assert expected in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("policy", "returncode", "resolution"),
+    [("error", 1, "blocked"), ("skip", 0, "kept_first"), ("overwrite", 0, "kept_last")],
+)
+def test_dry_run_duplicate_exit_codes(
+    tmp_path: Path, policy: str, returncode: int, resolution: str
+) -> None:
+    vault = tmp_path / policy
+    _lesson(vault / "a.md", "dup", "first")
+    _lesson(vault / "b.md", "dup", "second")
+
+    result = _dry_run(vault, tmp_path / f"{policy}.jsonl", "--on-duplicate", policy)
+
+    assert result.returncode == returncode
+    assert f"policy={policy}; risoluzione={resolution}" in result.stdout
+    assert "Nessuna modifica applicata." in result.stdout
+
+
+def test_dry_run_reports_ignored_and_malformed_yaml(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "ignored.txt").write_text("ignored", encoding="utf-8")
+    (vault / "bad.md").write_text("---\nid: [broken\n---\nBody\n", encoding="utf-8")
+
+    result = _dry_run(vault, tmp_path / "out.jsonl")
+
+    assert result.returncode == 0
+    assert "[non bloccante] malformed_yaml — bad.md" in result.stdout
+    assert "ignored.txt: not_markdown" in result.stdout
+
+
+def test_dry_run_empty_directory_does_not_report_total_removal(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    output = tmp_path / "lessons.jsonl"
+    output.write_text('{"id":"existing"}\n', encoding="utf-8")
+
+    result = _dry_run(vault, output)
+
+    assert result.returncode == 0
+    assert "removed=0" in result.stdout
+    assert "Pubblicazione replace-all: non avverrebbe." in result.stdout
+
+
+
+def test_dry_run_missing_input_is_global_error_without_side_effects(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "missing-vault"
+    output = tmp_path / "missing-output" / "lessons.jsonl"
+
+    result = _dry_run(vault, output)
+
+    assert result.returncode == 2
+    assert "Directory di input non trovata" in result.stderr
+    assert result.stdout == ""
+    assert not output.exists()
+    assert not output.parent.exists()
+
+@pytest.mark.parametrize(
+    "existing_output",
+    [
+        b"not-json\n",
+        b'{"id":"duplicate"}\n{"id":"duplicate"}\n',
+    ],
+)
+def test_dry_run_rejects_invalid_existing_snapshot_without_modifying_it(
+    tmp_path: Path, existing_output: bytes
+) -> None:
+    vault = tmp_path / "vault"
+    _lesson(vault / "lesson.md", "lesson")
+    output = tmp_path / "lessons.jsonl"
+    output.write_bytes(existing_output)
+
+    result = _dry_run(vault, output)
+
+    assert result.returncode == 2
+    assert "Output corrente non valido o non leggibile" in result.stderr
+    assert result.stdout == ""
+    assert output.read_bytes() == existing_output

--- a/tests/test_import_from_dir_cli.py
+++ b/tests/test_import_from_dir_cli.py
@@ -679,3 +679,26 @@ def test_dry_run_permission_error_is_controlled(
     assert exc_info.value.code == 2
     assert "Output corrente non valido o non leggibile" in captured.err
     assert "Traceback" not in captured.err
+
+
+def test_dry_run_input_io_error_is_controlled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    vault = tmp_path / "vault"
+    _lesson(vault / "lesson.md", "lesson")
+
+    def deny_analysis(*args: object, **kwargs: object) -> object:
+        raise PermissionError("input denied")
+
+    monkeypatch.setattr(import_cli, "analyze_import_from_dir", deny_analysis)
+
+    with pytest.raises(SystemExit) as exc_info:
+        import_cli.main([str(vault), str(tmp_path / "out.jsonl"), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "Impossibile leggere la directory di input" in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""

--- a/tests/test_import_from_dir_cli.py
+++ b/tests/test_import_from_dir_cli.py
@@ -627,3 +627,55 @@ def test_dry_run_rejects_invalid_existing_snapshot_without_modifying_it(
     assert "Output corrente non valido o non leggibile" in result.stderr
     assert result.stdout == ""
     assert output.read_bytes() == existing_output
+
+
+def test_dry_run_round_trip_nested_yaml_date_is_unchanged(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "lesson.md").write_text(
+        "---\nid: lesson\nmetadata:\n  schedule:\n    due: 2026-07-16\n---\nBody\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "lessons.jsonl"
+    initial = import_cli.analyze_import_from_dir(
+        vault, "overwrite", "manual", 3, None, False
+    )
+    import_cli.projection_store(output).publish(list(initial.candidate_records.values()))
+
+    result = _dry_run(vault, output)
+
+    assert result.returncode == 0
+    assert "Riepilogo: create=0, update=0, unchanged=1, removed=0" in result.stdout
+
+
+def test_dry_run_output_directory_is_controlled_io_error(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _lesson(vault / "lesson.md", "lesson")
+    output = tmp_path / "output-directory"
+    output.mkdir()
+
+    result = _dry_run(vault, output)
+
+    assert result.returncode == 2
+    assert "Output corrente non valido o non leggibile" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_dry_run_permission_error_is_controlled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    vault = tmp_path / "vault"
+    _lesson(vault / "lesson.md", "lesson")
+
+    class DeniedStore:
+        def snapshot(self) -> object:
+            raise PermissionError("denied")
+
+    monkeypatch.setattr(import_cli, "projection_store", lambda path: DeniedStore())
+    with pytest.raises(SystemExit) as exc_info:
+        import_cli.main([str(vault), str(tmp_path / "out.jsonl"), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "Output corrente non valido o non leggibile" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_import_plan.py
+++ b/tests/test_import_plan.py
@@ -121,6 +121,7 @@ def test_three_duplicates_keep_only_winner_pending_write(
     assert plan.blocking is blocking
     assert plan.candidate_records["dup"]["text"] == winner
     assert [item.duplicate_path for item in plan.duplicates] == ["b.md", "c.md"]
+    assert [item.first_path for item in plan.duplicates] == ["a.md", "a.md"]
     expected_paths = [] if pending_path is None else [pending_path]
     assert [item.path for item in plan.pending_source_writes] == expected_paths
     assert sorted(plan.pending_source_contents) == expected_paths

--- a/tests/test_import_plan.py
+++ b/tests/test_import_plan.py
@@ -95,6 +95,37 @@ def test_duplicate_policies(
     assert plan.blocking is blocking
 
 
+@pytest.mark.parametrize(
+    ("policy", "winner", "pending_path", "blocking"),
+    [
+        ("error", "first", None, True),
+        ("skip", "first", "a.md", False),
+        ("overwrite", "third", "c.md", False),
+    ],
+)
+def test_three_duplicates_keep_only_winner_pending_write(
+    tmp_path: Path,
+    policy: str,
+    winner: str,
+    pending_path: str | None,
+    blocking: bool,
+) -> None:
+    vault = tmp_path / "vault"
+    for name, body in (("a.md", "first"), ("b.md", "second"), ("c.md", "third")):
+        path = vault / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"---\nid: dup\n---\n{body}\n", encoding="utf-8")
+
+    plan = _analyze(vault, on_duplicate=policy, write_missing_frontmatter=True)
+
+    assert plan.blocking is blocking
+    assert plan.candidate_records["dup"]["text"] == winner
+    assert [item.duplicate_path for item in plan.duplicates] == ["b.md", "c.md"]
+    expected_paths = [] if pending_path is None else [pending_path]
+    assert [item.path for item in plan.pending_source_writes] == expected_paths
+    assert sorted(plan.pending_source_contents) == expected_paths
+
+
 def test_ignored_file_pending_write_and_analysis_has_no_side_effects(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_import_plan.py
+++ b/tests/test_import_plan.py
@@ -1,0 +1,145 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from lele_manager.cli.import_from_dir import analyze_import_from_dir
+
+
+def _analyze(vault: Path, **kwargs: object):
+    return analyze_import_from_dir(
+        vault,
+        kwargs.pop("on_duplicate", "overwrite"),  # type: ignore[arg-type]
+        "note",
+        3,
+        None,
+        bool(kwargs.pop("write_missing_frontmatter", False)),
+        kwargs.pop("existing_records", ()),  # type: ignore[arg-type]
+    )
+
+
+def _write(vault: Path, name: str, lesson_id: str, body: str = "Body") -> Path:
+    path = vault / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nid: {lesson_id}\ntopic: topic\nsource: note\nimportance: 3\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_to_dict_is_json_native_deterministic_and_hides_candidates(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    _write(vault, "z.md", "z")
+    _write(vault, "a.md", "a")
+
+    serialized = _analyze(vault).to_dict()
+
+    assert "candidate_records" not in serialized
+    assert [change["id"] for change in serialized["changes"]] == ["a", "z"]
+    assert json.loads(json.dumps(serialized)) == serialized
+    with_candidates = _analyze(vault).to_dict(include_candidate_records=True)
+    assert json.loads(json.dumps(with_candidates)) == with_candidates
+
+
+def test_classifies_complete_record_changes_and_removed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _write(vault, "same.md", "same")
+    _write(vault, "changed.md", "changed", "new body")
+    first = _analyze(vault)
+    same = dict(first.candidate_records["same"])
+    changed = dict(first.candidate_records["changed"])
+    changed["frontmatter_hash"] = "sha256:old"
+    old = dict(same)
+    old["id"] = "removed"
+
+    plan = _analyze(vault, existing_records=[same, changed, old])
+    kinds = {change.lesson_id: change.kind.value for change in plan.changes}
+
+    assert kinds == {"same": "unchanged", "changed": "update", "removed": "removed"}
+    assert plan.replace_all is True
+
+
+def test_create_and_no_total_removal_without_publish(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    plan = _analyze(vault, existing_records=[{"id": "old"}])
+    assert plan.replace_all is False
+    assert plan.changes == []
+
+    _write(vault, "new.md", "new")
+    assert _analyze(vault).changes[0].kind.value == "create"
+
+
+@pytest.mark.parametrize(
+    ("policy", "resolution", "body", "blocking"),
+    [
+        ("error", "blocked", "first", True),
+        ("skip", "kept_first", "first", False),
+        ("overwrite", "kept_last", "second", False),
+    ],
+)
+def test_duplicate_policies(
+    tmp_path: Path, policy: str, resolution: str, body: str, blocking: bool
+) -> None:
+    vault = tmp_path / "vault"
+    _write(vault, "a.md", "dup", "first")
+    _write(vault, "b.md", "dup", "second")
+
+    plan = _analyze(vault, on_duplicate=policy)
+
+    assert plan.duplicates[0].resolution.value == resolution
+    assert plan.candidate_records["dup"]["text"] == body
+    assert plan.blocking is blocking
+
+
+def test_ignored_file_pending_write_and_analysis_has_no_side_effects(
+    tmp_path: Path,
+) -> None:
+    vault = tmp_path / "vault"
+    markdown = vault / "topic" / "2025-01-01.lesson.md"
+    markdown.parent.mkdir(parents=True)
+    markdown.write_text("Body\n", encoding="utf-8")
+    ignored = vault / "notes.txt"
+    ignored.write_text("ignored", encoding="utf-8")
+    (vault / "empty-directory").mkdir()
+    original = markdown.read_bytes()
+
+    plan = _analyze(vault, write_missing_frontmatter=True)
+
+    assert [(item.path, item.reason) for item in plan.ignored_files] == [
+        ("notes.txt", "not_markdown")
+    ]
+    assert [(item.path, item.reason) for item in plan.pending_source_writes] == [
+        ("topic/2025-01-01.lesson.md", "complete_frontmatter")
+    ]
+    assert markdown.read_bytes() == original
+
+
+def test_malformed_yaml_is_non_blocking(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "bad.md").write_text("---\nid: [broken\n---\nBody\n", encoding="utf-8")
+
+    plan = _analyze(vault)
+
+    assert [
+        (problem.code, problem.blocking) for problem in plan.validation_problems
+    ] == [("malformed_yaml", False)]
+    assert "bad" in plan.candidate_records
+
+def test_imports_markdown_extension_case_insensitively(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _write(vault, "LEZIONE.MD", "uppercase")
+
+    plan = _analyze(vault)
+
+    assert sorted(plan.candidate_records) == ["uppercase"]
+    assert plan.ignored_files == []
+    assert [
+        (change.lesson_id, change.kind.value)
+        for change in plan.changes
+    ] == [("uppercase", "create")]
+    assert plan.replace_all is True


### PR DESCRIPTION
## Summary

Adds a deterministic `--dry-run` mode to the directory importer so users can inspect the exact replace-all plan before any source or projection write occurs.

## What changed

- extracts a typed `ImportPlan` model for import analysis;
- reports `create`, `update`, `unchanged`, and `removed` records;
- reports duplicate IDs, validation problems, ignored files, and pending source writes;
- supports `error`, `skip`, and `overwrite` duplicate policies with deterministic resolution;
- keeps pending source writes associated only with the winning candidate;
- compares candidates with existing snapshots using the shared JSON-persistence representation;
- preserves the first occurrence path across multiple duplicate events;
- handles unreadable input or projection snapshots with controlled exit code `2`;
- keeps blocking plan problems on exit code `1` and successful previews on exit code `0`;
- prevents dry-run from calling `publish()`, rewriting Markdown, or creating the output parent directory.

## Compatibility and scope

The normal import path and existing Python API remain compatible. Empty or wholly invalid scans do not preview a destructive total replacement.

Out of scope: API/GUI integration, near-duplicate detection, staging workflows, new storage backends, and coordinated transactionality between Markdown rewrites and projection publication.

## Validation

- `49 passed` across import-plan, importer, dry-run CLI, and projection-store contract tests;
- Ruff passed;
- Mypy passed for 42 source files;
- `git diff --check` passed.

Part of #82.

Closes #83.