### PR TITLE
feat(api): expose versioned external lessons feed

### DIFF
--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -15,8 +15,14 @@ from threading import Lock
 
 from lele_manager.core.analytics import compute_stats_summary, compute_timeline
 from lele_manager.application.dataframes import records_to_legacy_dataframe
+from lele_manager.application.external_lessons import external_lessons_feed
 from lele_manager.composition import legacy_jsonl_append_facade, projection_store
-from lele_manager.core.projection_store import DuplicateLessonIdError, ProjectionStoreError
+from lele_manager.core.projection_store import (
+    DuplicateLessonIdError,
+    LessonOrder,
+    LessonQuery,
+    ProjectionStoreError,
+)
 from lele_manager.core.deduplication import DEFAULT_MIN_SCORE, find_duplicates
 from lele_manager.core.export import search_results_to_markdown
 from lele_manager.core.config import resolve_data_path, resolve_model_path
@@ -122,6 +128,26 @@ class Lesson(LessonBase):
 
 class LessonSearchResult(Lesson):
     pass
+
+
+class ExternalLessonResponse(BaseModel):
+    id: str
+    text: str
+    title: Optional[str]
+    topic: Optional[str]
+    source: Optional[str]
+    importance: Optional[int]
+    tags: List[str]
+    date: Optional[str]
+    created_at: Optional[str]
+
+
+class ExternalLessonsResponse(BaseModel):
+    schema_version: Literal[1]
+    generation: str
+    total_lessons: int
+    returned_lessons: int
+    lessons: List[ExternalLessonResponse]
 
 
 class LessonSearchRequest(BaseModel):
@@ -608,6 +634,56 @@ def _row_to_search_result(row: dict) -> LessonSearchResult:
 # -----------------------------------------------------------------------------
 # Endpoint
 # -----------------------------------------------------------------------------
+@app.get("/integrations/v1/lessons", response_model=ExternalLessonsResponse)
+def integration_lessons(
+    q: Optional[str] = Query(default=None),
+    topic: Optional[List[str]] = Query(default=None),
+    source: Optional[List[str]] = Query(default=None),
+    tag: Optional[List[str]] = Query(default=None),
+    importance_gte: Optional[int] = Query(default=None),
+    importance_lte: Optional[int] = Query(default=None),
+    limit: Optional[int] = Query(default=None, ge=1),
+) -> ExternalLessonsResponse:
+    """Expose a stable, read-only lesson projection to external tools."""
+    query = LessonQuery(
+        text=q,
+        topics=topic,
+        sources=source,
+        tags=tag,
+        importance_gte=importance_gte,
+        importance_lte=importance_lte,
+        order=LessonOrder.ID,
+        limit=limit,
+    )
+    try:
+        feed = external_lessons_feed(projection_store(get_data_path()), query)
+    except (ProjectionStoreError, OSError) as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Lesson projection is unavailable.",
+        ) from exc
+    return ExternalLessonsResponse(
+        schema_version=feed.schema_version,
+        generation=feed.generation,
+        total_lessons=feed.total_lessons,
+        returned_lessons=feed.returned_lessons,
+        lessons=[
+            ExternalLessonResponse(
+                id=lesson.id,
+                text=lesson.text,
+                title=lesson.title,
+                topic=lesson.topic,
+                source=lesson.source,
+                importance=lesson.importance,
+                tags=lesson.tags,
+                date=lesson.date,
+                created_at=lesson.created_at,
+            )
+            for lesson in feed.lessons
+        ],
+    )
+
+
 @app.get("/health", response_model=HealthResponse)
 def health() -> HealthResponse:
     """

--- a/src/lele_manager/application/external_lessons.py
+++ b/src/lele_manager/application/external_lessons.py
@@ -1,0 +1,111 @@
+"""Stable, backend-neutral lesson feed for external integrations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import math
+from typing import Any, Literal
+
+from lele_manager.core.projection_store import LessonQuery, ProjectionStore
+
+
+@dataclass(frozen=True)
+class ExternalLesson:
+    """The deliberately small public representation of one lesson."""
+
+    id: str
+    text: str
+    title: str | None
+    topic: str | None
+    source: str | None
+    importance: int | None
+    tags: list[str]
+    date: str | None
+    created_at: str | None
+
+
+@dataclass(frozen=True)
+class ExternalLessonsFeed:
+    """Versioned response contract exposed to external read-only consumers."""
+
+    schema_version: Literal[1]
+    generation: str
+    total_lessons: int
+    returned_lessons: int
+    lessons: list[ExternalLesson]
+
+
+def _scalar_string(value: object) -> str | None:
+    if (
+        value is None
+        or isinstance(value, (Mapping, Sequence))
+        and not isinstance(value, str)
+    ):
+        return None
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    try:
+        return str(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _importance(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value) if math.isfinite(value) and value.is_integer() else None
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return int(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def _tags(value: object) -> list[str]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        return []
+    normalized = {
+        item
+        for raw_item in value
+        if (item := _scalar_string(raw_item)) is not None and item
+    }
+    return sorted(normalized)
+
+
+def _normalize_lesson(record: Mapping[str, Any]) -> ExternalLesson:
+    return ExternalLesson(
+        id=_scalar_string(record.get("id")) or "",
+        text=_scalar_string(record.get("text")) or "",
+        title=_scalar_string(record.get("title")),
+        topic=_scalar_string(record.get("topic")),
+        source=_scalar_string(record.get("source")),
+        importance=_importance(record.get("importance")),
+        tags=_tags(record.get("tags")),
+        date=_scalar_string(record.get("date")),
+        created_at=_scalar_string(record.get("created_at")),
+    )
+
+
+def external_lessons_feed(
+    store: ProjectionStore,
+    query: LessonQuery,
+) -> ExternalLessonsFeed:
+    """Read and normalize a feed from one coherent projection snapshot."""
+    snapshot = store.snapshot()
+    records = snapshot.list(query)
+    lessons = [_normalize_lesson(record) for record in records]
+    return ExternalLessonsFeed(
+        schema_version=1,
+        generation=snapshot.generation,
+        total_lessons=snapshot.statistics.lesson_count,
+        returned_lessons=len(lessons),
+        lessons=lessons,
+    )

--- a/tests/test_api_external_lessons.py
+++ b/tests/test_api_external_lessons.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from lele_manager.api import server
+
+
+def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def test_endpoint_contract_repeated_queries_limit_and_importance(
+    tmp_path, monkeypatch
+) -> None:
+    data_path = tmp_path / "lessons.jsonl"
+    _write_jsonl(
+        data_path,
+        [
+            {
+                "id": "z",
+                "text": "Quiz Z",
+                "topic": "python",
+                "source": "book",
+                "importance": 4,
+                "tags": ["quiz"],
+            },
+            {
+                "id": "a",
+                "text": "Quiz A",
+                "topic": "git",
+                "source": "notes",
+                "importance": 3,
+                "tags": ["quiz", "review"],
+            },
+            {
+                "id": "b",
+                "text": "Quiz B",
+                "topic": "rust",
+                "source": "notes",
+                "importance": 5,
+                "tags": ["quiz"],
+            },
+        ],
+    )
+    monkeypatch.setattr(server, "DATA_PATH", data_path)
+
+    response = TestClient(server.app).get(
+        "/integrations/v1/lessons",
+        params=[
+            ("q", "quiz"),
+            ("topic", "python"),
+            ("topic", "git"),
+            ("source", "book"),
+            ("source", "notes"),
+            ("tag", "quiz"),
+            ("importance_gte", "3"),
+            ("importance_lte", "4"),
+            ("limit", "2"),
+        ],
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == 1
+    assert payload["total_lessons"] == 3
+    assert payload["returned_lessons"] == 2
+    assert [lesson["id"] for lesson in payload["lessons"]] == ["a", "z"]
+    assert set(payload["lessons"][0]) == {
+        "id",
+        "text",
+        "title",
+        "topic",
+        "source",
+        "importance",
+        "tags",
+        "date",
+        "created_at",
+    }
+    assert payload["generation"].startswith("sha256:")
+
+
+def test_empty_or_missing_projection_is_successful(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(server, "DATA_PATH", tmp_path / "missing.jsonl")
+
+    response = TestClient(server.app).get("/integrations/v1/lessons")
+
+    assert response.status_code == 200
+    assert response.json()["total_lessons"] == 0
+    assert response.json()["returned_lessons"] == 0
+    assert response.json()["lessons"] == []
+
+
+def test_malformed_projection_returns_controlled_500(tmp_path, monkeypatch) -> None:
+    data_path = tmp_path / "lessons.jsonl"
+    data_path.write_text("not-json\n", encoding="utf-8")
+    monkeypatch.setattr(server, "DATA_PATH", data_path)
+
+    response = TestClient(server.app, raise_server_exceptions=False).get(
+        "/integrations/v1/lessons"
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Lesson projection is unavailable."}
+    assert "Jsonl" not in response.text
+    assert "Traceback" not in response.text
+
+
+def test_unreadable_projection_returns_controlled_500(monkeypatch) -> None:
+    class UnreadableStore:
+        def snapshot(self) -> object:
+            raise OSError("private adapter details")
+
+    monkeypatch.setattr(server, "projection_store", lambda path: UnreadableStore())
+
+    with pytest.raises(HTTPException) as caught:
+        server.integration_lessons(
+            q=None,
+            topic=None,
+            source=None,
+            tag=None,
+            importance_gte=None,
+            importance_lte=None,
+            limit=None,
+        )
+
+    assert caught.value.status_code == 500
+    assert caught.value.detail == "Lesson projection is unavailable."
+
+
+def test_invalid_query_returns_422() -> None:
+    client = TestClient(server.app)
+
+    assert client.get("/integrations/v1/lessons?limit=0").status_code == 422
+    assert client.get("/integrations/v1/lessons?importance_gte=nope").status_code == 422

--- a/tests/test_external_lessons_service.py
+++ b/tests/test_external_lessons_service.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict
+from typing import Any
+
+from lele_manager.application.external_lessons import external_lessons_feed
+from lele_manager.core.projection_store import (
+    LessonOrder,
+    LessonQuery,
+    ProjectionStatistics,
+)
+
+
+class FakeSnapshot:
+    generation = "generation-7"
+    statistics = ProjectionStatistics(9, 2, 3)
+
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self.records = records
+        self.queries: list[LessonQuery] = []
+
+    def get(self, lesson_id: str) -> dict[str, Any] | None:
+        return None
+
+    def list(self, query: LessonQuery = LessonQuery()) -> tuple[dict[str, Any], ...]:
+        self.queries.append(query)
+        return tuple(self.records)
+
+
+class FakeStore:
+    def __init__(self, snapshot: FakeSnapshot) -> None:
+        self.value = snapshot
+        self.snapshot_calls = 0
+        self.publish_calls = 0
+
+    def snapshot(self) -> FakeSnapshot:
+        self.snapshot_calls += 1
+        return self.value
+
+    def publish(self, records: object) -> FakeSnapshot:
+        self.publish_calls += 1
+        raise AssertionError("the external feed must be read-only")
+
+
+def test_feed_has_exact_public_shape_and_uses_one_snapshot() -> None:
+    source = {
+        "id": 42,
+        "text": "A lesson",
+        "title": "Title",
+        "topic": "python",
+        "source": "notes",
+        "importance": "4",
+        "tags": ["z", "a", "z"],
+        "date": "2026-01-02",
+        "created_at": "2026-01-02T03:04:05Z",
+        "frontmatter": {"secret": True},
+        "frontmatter_hash": "internal",
+        "path": "/internal/lesson.md",
+        "unknown": "excluded",
+    }
+    original = deepcopy(source)
+    snapshot = FakeSnapshot([source])
+    store = FakeStore(snapshot)
+    query = LessonQuery(order=LessonOrder.ID)
+
+    feed = external_lessons_feed(store, query)
+
+    assert asdict(feed) == {
+        "schema_version": 1,
+        "generation": "generation-7",
+        "total_lessons": 9,
+        "returned_lessons": 1,
+        "lessons": [
+            {
+                "id": "42",
+                "text": "A lesson",
+                "title": "Title",
+                "topic": "python",
+                "source": "notes",
+                "importance": 4,
+                "tags": ["a", "z"],
+                "date": "2026-01-02",
+                "created_at": "2026-01-02T03:04:05Z",
+            }
+        ],
+    }
+    assert source == original
+    assert store.snapshot_calls == 1
+    assert store.publish_calls == 0
+    assert snapshot.queries == [query]
+
+
+def test_query_filters_and_id_order_are_passed_to_snapshot() -> None:
+    snapshot = FakeSnapshot([])
+    query = LessonQuery(
+        text="needle",
+        topics=["python", "git"],
+        sources=["notes"],
+        tags=["quiz", "review"],
+        importance_gte=2,
+        importance_lte=4,
+        order=LessonOrder.ID,
+        limit=8,
+    )
+
+    external_lessons_feed(FakeStore(snapshot), query)
+
+    assert snapshot.queries == [query]
+    assert snapshot.queries[0].order is LessonOrder.ID
+
+
+def test_irregular_values_are_normalized_without_mutation() -> None:
+    source = {
+        "id": "lesson",
+        "text": {"invalid": "structured"},
+        "title": ["invalid"],
+        "topic": 12,
+        "source": None,
+        "importance": True,
+        "tags": ["b", "", None, 3, "a", "b", {"bad": True}, ["bad"], float("nan")],
+        "date": float("inf"),
+        "created_at": False,
+    }
+    original = deepcopy(source)
+
+    lesson = external_lessons_feed(
+        FakeStore(FakeSnapshot([source])), LessonQuery(order=LessonOrder.ID)
+    ).lessons[0]
+
+    assert asdict(lesson) == {
+        "id": "lesson",
+        "text": "",
+        "title": None,
+        "topic": "12",
+        "source": None,
+        "importance": None,
+        "tags": ["3", "a", "b"],
+        "date": None,
+        "created_at": "False",
+    }
+    assert source == original
+
+
+def test_importance_rejects_non_integral_and_invalid_values() -> None:
+    records = [
+        {"id": "a", "importance": 2.0},
+        {"id": "b", "importance": "2.5"},
+        {"id": "c", "importance": " 5 "},
+    ]
+
+    lessons = external_lessons_feed(
+        FakeStore(FakeSnapshot(records)), LessonQuery(order=LessonOrder.ID)
+    ).lessons
+
+    assert [lesson.importance for lesson in lessons] == [2, None, 5]
+
+
+def test_empty_dataset_returns_empty_feed() -> None:
+    snapshot = FakeSnapshot([])
+    snapshot.statistics = ProjectionStatistics(0, 0, 0)
+
+    feed = external_lessons_feed(FakeStore(snapshot), LessonQuery(order=LessonOrder.ID))
+
+    assert feed.total_lessons == 0
+    assert feed.returned_lessons == 0
+    assert feed.lessons == []


### PR DESCRIPTION
## Summary

Expose approved lessons through a stable, versioned, read-only integration contract for LeLe Quizzer and future review tools.

## What changed

- adds `GET /integrations/v1/lessons`;
- introduces a backend-neutral application service built on `ProjectionStore`, `ProjectionSnapshot` and `LessonQuery`;
- returns `schema_version`, projection `generation`, total/returned counts and normalized lessons;
- supports repeatable topic/source/tag filters, text search, importance bounds and optional limit;
- orders results deterministically by lesson ID;
- excludes JSONL, pandas, frontmatter, path and other backend-specific fields;
- normalizes irregular optional metadata and tags without mutating snapshot records;
- handles missing projections as an empty feed and malformed/unreadable projections with a controlled HTTP 500.

## Compatibility and scope

Existing `/lessons`, `/lessons/search`, export, CLI, GUI, JSONL and `ProjectionStore` behavior remain unchanged.

Out of scope: quiz generation, spaced repetition, answer evaluation, candidate ingestion/approval, pagination, authentication and new CLI commands.

## Validation

- 10 new service/API tests passed;
- 4 targeted existing API regression tests passed;
- Ruff passed;
- Mypy passed for 43 source files;
- `git diff --check` passed.

The Starlette/httpx deprecation warning is pre-existing and does not affect the test results.

Part of #82.

Closes #93.