### PR TITLE
feat(ingestion): normalize raw knowledge sources

### DIFF
--- a/src/lele_manager/adapters/raw_sources.py
+++ b/src/lele_manager/adapters/raw_sources.py
@@ -1,0 +1,91 @@
+"""UTF-8 file and in-memory adapters for the raw-source contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from lele_manager.application.raw_source import RawSource, SourceKind
+
+
+class RawSourceError(Exception):
+    """Base class for controlled raw-source adapter failures."""
+
+
+class SourceReadError(RawSourceError):
+    """A filesystem source could not be read."""
+
+
+class SourceDecodingError(RawSourceError):
+    """Source bytes were not valid UTF-8."""
+
+
+class UnsupportedSourceError(RawSourceError):
+    """An adapter was given an input it does not support."""
+
+
+def _read_utf8(path: Path) -> str:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise SourceReadError(f"could not read source file {path}: {exc}") from exc
+    try:
+        return raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise SourceDecodingError(f"source file is not valid UTF-8: {path}") from exc
+
+
+@dataclass(frozen=True)
+class MarkdownFileSourceAdapter:
+    """Read one UTF-8 Markdown file without interpreting its Markdown."""
+
+    def load(self, path: Path | str, *, logical_name: str | None = None) -> RawSource:
+        origin = Path(path)
+        if origin.suffix.lower() not in {".md", ".markdown"}:
+            raise UnsupportedSourceError(f"not a Markdown source file: {origin}")
+        return RawSource(
+            content=_read_utf8(origin),
+            kind=SourceKind.MARKDOWN,
+            logical_name=origin.name if logical_name is None else logical_name,
+            filesystem_origin=origin,
+        )
+
+
+@dataclass(frozen=True)
+class PlainTextFileSourceAdapter:
+    """Read one UTF-8 plain-text file."""
+
+    def load(self, path: Path | str, *, logical_name: str | None = None) -> RawSource:
+        origin = Path(path)
+        if origin.suffix.lower() != ".txt":
+            raise UnsupportedSourceError(f"not a plain-text source file: {origin}")
+        return RawSource(
+            content=_read_utf8(origin),
+            kind=SourceKind.PLAIN_TEXT,
+            logical_name=origin.name if logical_name is None else logical_name,
+            filesystem_origin=origin,
+        )
+
+
+@dataclass(frozen=True)
+class InMemorySourceAdapter:
+    """Adapt supplied content; reading/parsing a terminal is deliberately external."""
+
+    def load(
+        self,
+        content: str,
+        *,
+        logical_name: str = "stdin",
+        kind: SourceKind = SourceKind.STDIN,
+    ) -> RawSource:
+        if not isinstance(content, str):
+            raise UnsupportedSourceError("in-memory source content must be a string")
+        if kind not in {SourceKind.STDIN, SourceKind.IN_MEMORY}:
+            raise UnsupportedSourceError(
+                "in-memory adapter supports only stdin and in_memory source kinds"
+            )
+        return RawSource(content=content, kind=kind, logical_name=logical_name)
+
+
+# This name makes the stdin use case explicit without coupling it to sys.stdin.
+StdinSourceAdapter = InMemorySourceAdapter

--- a/src/lele_manager/application/raw_source.py
+++ b/src/lele_manager/application/raw_source.py
@@ -1,0 +1,70 @@
+"""Backend-neutral raw source contract.
+
+Line endings are the only content normalization performed: CRLF and lone CR are
+converted to LF. Whitespace, Unicode characters, a possible BOM, and the
+presence or absence of a final newline are preserved.
+
+The fingerprint identifies normalized source content, source kind and logical
+name. The optional filesystem origin is retained as provenance but deliberately
+excluded from identity, so moving the same logical source does not change its
+fingerprint.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import hashlib
+import json
+from pathlib import Path
+
+
+class SourceKind(str, Enum):
+    """Supported raw-source identities."""
+
+    MARKDOWN = "markdown"
+    PLAIN_TEXT = "plain_text"
+    STDIN = "stdin"
+    IN_MEMORY = "in_memory"
+
+
+def normalize_line_endings(content: str) -> str:
+    """Convert CRLF and lone CR line endings to LF, changing nothing else."""
+    return content.replace("\r\n", "\n").replace("\r", "\n")
+
+
+@dataclass(frozen=True)
+class RawSource:
+    """Normalized source content together with all source-level provenance."""
+
+    content: str
+    kind: SourceKind
+    logical_name: str
+    filesystem_origin: Path | None = None
+    fingerprint: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.content, str):
+            raise TypeError("raw source content must be a string")
+        if not isinstance(self.kind, SourceKind):
+            raise TypeError("raw source kind must be a SourceKind")
+        if not isinstance(self.logical_name, str) or not self.logical_name:
+            raise ValueError("raw source logical name must not be empty")
+        if self.filesystem_origin is not None and not isinstance(
+            self.filesystem_origin, Path
+        ):
+            raise TypeError("filesystem origin must be a pathlib.Path or None")
+
+        normalized = normalize_line_endings(self.content)
+        object.__setattr__(self, "content", normalized)
+        identity = {
+            "content": normalized,
+            "kind": self.kind.value,
+            "logical_name": self.logical_name,
+        }
+        payload = json.dumps(
+            identity, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        object.__setattr__(
+            self, "fingerprint", f"sha256:{hashlib.sha256(payload).hexdigest()}"
+        )

--- a/tests/test_raw_sources.py
+++ b/tests/test_raw_sources.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+
+import pytest
+
+from lele_manager.adapters.raw_sources import (
+    InMemorySourceAdapter,
+    MarkdownFileSourceAdapter,
+    PlainTextFileSourceAdapter,
+    SourceDecodingError,
+    SourceReadError,
+    UnsupportedSourceError,
+)
+from lele_manager.application.raw_source import RawSource, SourceKind
+
+
+def test_markdown_file_preserves_content_and_provenance(tmp_path: Path) -> None:
+    path = tmp_path / "lesson.md"
+    path.write_text("# Héading\n\n body  \n", encoding="utf-8")
+
+    source = MarkdownFileSourceAdapter().load(path)
+
+    assert source.content == "# Héading\n\n body  \n"
+    assert source.kind is SourceKind.MARKDOWN
+    assert source.logical_name == "lesson.md"
+    assert source.filesystem_origin == path
+
+
+def test_plain_text_file(tmp_path: Path) -> None:
+    path = tmp_path / "notes.txt"
+    path.write_text("caffè", encoding="utf-8")
+
+    source = PlainTextFileSourceAdapter().load(path, logical_name="notes")
+
+    assert source.content == "caffè"
+    assert source.kind is SourceKind.PLAIN_TEXT
+    assert source.logical_name == "notes"
+    assert source.filesystem_origin == path
+
+
+def test_stdin_and_in_memory_need_no_filesystem_path() -> None:
+    stdin = InMemorySourceAdapter().load("from stdin")
+    memory = InMemorySourceAdapter().load(
+        "in memory", logical_name="paste", kind=SourceKind.IN_MEMORY
+    )
+
+    assert stdin.filesystem_origin is None
+    assert stdin.kind is SourceKind.STDIN
+    assert memory.filesystem_origin is None
+    assert memory.kind is SourceKind.IN_MEMORY
+
+
+def test_lf_crlf_and_cr_normalize_to_the_same_content_and_fingerprint() -> None:
+    sources = [
+        RawSource(text, SourceKind.IN_MEMORY, "same")
+        for text in ("one\ntwo\n", "one\r\ntwo\r\n", "one\rtwo\r")
+    ]
+
+    assert {source.content for source in sources} == {"one\ntwo\n"}
+    assert len({source.fingerprint for source in sources}) == 1
+
+
+def test_empty_input_is_a_valid_source() -> None:
+    source = InMemorySourceAdapter().load("")
+
+    assert source.content == ""
+    assert source.fingerprint.startswith("sha256:")
+
+
+def test_fingerprint_is_stable_and_includes_identity() -> None:
+    first = RawSource("text", SourceKind.IN_MEMORY, "a")
+    same = RawSource("text", SourceKind.IN_MEMORY, "a")
+    renamed = RawSource("text", SourceKind.IN_MEMORY, "b")
+
+    assert first.fingerprint == same.fingerprint
+    assert first.fingerprint == (
+        "sha256:39a8ed5b843155a7a91dd62600ed0fc1d5503de20ddb644f12ee7248aab27072"
+    )
+    assert first.fingerprint != renamed.fingerprint
+
+
+
+def test_filesystem_origin_is_provenance_not_fingerprint_identity() -> None:
+    original = RawSource(
+        "text",
+        SourceKind.MARKDOWN,
+        "lesson.md",
+        Path("first/location/lesson.md"),
+    )
+    moved = RawSource(
+        "text",
+        SourceKind.MARKDOWN,
+        "lesson.md",
+        Path("second/location/lesson.md"),
+    )
+
+    assert original.filesystem_origin != moved.filesystem_origin
+    assert original.fingerprint == moved.fingerprint
+
+
+def test_explicit_empty_logical_name_is_rejected(tmp_path: Path) -> None:
+    markdown = tmp_path / "lesson.md"
+    markdown.write_text("content", encoding="utf-8")
+
+    text_file = tmp_path / "lesson.txt"
+    text_file.write_text("content", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        MarkdownFileSourceAdapter().load(markdown, logical_name="")
+
+    with pytest.raises(ValueError):
+        PlainTextFileSourceAdapter().load(text_file, logical_name="")
+
+def test_unreadable_file_has_controlled_error(tmp_path: Path) -> None:
+    with pytest.raises(SourceReadError):
+        MarkdownFileSourceAdapter().load(tmp_path / "missing.md")
+
+
+def test_invalid_utf8_has_controlled_error(tmp_path: Path) -> None:
+    path = tmp_path / "bad.txt"
+    path.write_bytes(b"\xff")
+
+    with pytest.raises(SourceDecodingError):
+        PlainTextFileSourceAdapter().load(path)
+
+
+def test_unsupported_input_has_controlled_error(tmp_path: Path) -> None:
+    with pytest.raises(UnsupportedSourceError):
+        MarkdownFileSourceAdapter().load(tmp_path / "lesson.txt")
+    with pytest.raises(UnsupportedSourceError):
+        InMemorySourceAdapter().load(b"bytes")  # type: ignore[arg-type]
+
+
+def test_adapters_do_not_create_or_stage_candidates(tmp_path: Path) -> None:
+    path = tmp_path / "lesson.md"
+    path.write_text("content", encoding="utf-8")
+    before = sorted(tmp_path.iterdir())
+
+    source = MarkdownFileSourceAdapter().load(path)
+
+    assert source.content == "content"
+    assert sorted(tmp_path.iterdir()) == before
+    assert not hasattr(source, "candidate_records")
+    assert not hasattr(source, "pending_source_writes")


### PR DESCRIPTION
## Summary

Introduce the backend-neutral raw-source boundary required by the TritaLeLe ingestion workflow.

## What changed

- adds a typed `RawSource` value object and closed `SourceKind` enum;
- normalizes CRLF and lone CR to LF while preserving all other content, including whitespace, Unicode, BOM, empty content and final-newline presence;
- adds UTF-8 Markdown and plain-text file adapters;
- adds an in-memory/stdin adapter with no dependency on terminal parsing or filesystem paths;
- retains source kind, logical name and optional filesystem origin as provenance;
- computes deterministic SHA-256 fingerprints over canonical JSON containing normalized content, source kind and logical name;
- deliberately excludes filesystem origin from fingerprint identity so moving the same logical source does not create a new source identity;
- adds controlled adapter errors for unreadable files, invalid UTF-8 and unsupported input;
- keeps candidate creation, staging, chunking, API, GUI and LLM behavior completely out of scope.

## Contract decisions

- Fingerprint format: `sha256:<hex digest>`.
- Fingerprint identity: normalized content + source kind + logical name.
- Filesystem origin is provenance only, not identity.
- Empty input is valid.
- Explicitly empty logical names are rejected.
- stdin and in-memory sources require no filesystem path.

## Validation

- 12 new raw-source tests passed;
- projection store contract tests: 9 passed;
- full suite: 236 passed, 3 skipped;
- Ruff passed;
- Mypy passed for 45 source files;
- `git diff --check` passed.

Existing deprecation warnings are pre-existing and non-blocking.

Part of #94 and #82.

Closes #119.