### PR TITLE
feat(staging): add deterministic lesson candidates

### DIFF
--- a/src/lele_manager/adapters/json_candidate_repository.py
+++ b/src/lele_manager/adapters/json_candidate_repository.py
@@ -1,0 +1,251 @@
+"""Deterministic filesystem adapter for lesson-candidate staging."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+import stat
+import tempfile
+from typing import Mapping, Sequence
+
+from lele_manager.application.lesson_candidate import (
+    CandidateNotFoundError,
+    CandidateProvenance,
+    CandidateState,
+    CandidateStorageError,
+    DuplicateCandidateIdError,
+    ImmutableCandidateFieldError,
+    LessonCandidate,
+    MalformedStagingDataError,
+    SourceSpan,
+)
+from lele_manager.application.raw_source import SourceKind
+from lele_manager.core.json_compat import canonical_json
+
+SCHEMA_VERSION = 1
+ROOT_FIELDS = {"candidates", "schema_version"}
+CANDIDATE_FIELDS = {"candidate_id", "proposed_metadata", "provenance", "state", "text"}
+PROVENANCE_FIELDS = {
+    "chunk_index", "ingested_at", "run_metadata", "source_fingerprint",
+    "source_kind", "source_logical_name", "source_span", "transformations",
+}
+SOURCE_SPAN_FIELDS = {"end", "start"}
+
+
+def _json_value(value: object) -> object:
+    """Thaw immutable domain JSON values into serializer-native containers."""
+    if isinstance(value, Mapping):
+        return {key: _json_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_value(item) for item in value]
+    return value
+
+
+def _candidate_to_dict(candidate: LessonCandidate) -> dict[str, object]:
+    provenance = candidate.provenance
+    span = provenance.source_span
+    return {
+        "candidate_id": candidate.candidate_id,
+        "proposed_metadata": _json_value(candidate.proposed_metadata),
+        "provenance": {
+            "chunk_index": provenance.chunk_index,
+            "ingested_at": provenance.ingested_at.isoformat(),
+            "run_metadata": _json_value(provenance.run_metadata),
+            "source_fingerprint": provenance.source_fingerprint,
+            "source_kind": provenance.source_kind.value,
+            "source_logical_name": provenance.source_logical_name,
+            "source_span": None if span is None else {"end": span.end, "start": span.start},
+            "transformations": _json_value(provenance.transformations),
+        },
+        "state": candidate.state.value,
+        "text": candidate.text,
+    }
+
+
+def _object(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise MalformedStagingDataError(f"{name} must be an object")
+    return value
+
+
+def _exact_fields(value: Mapping[str, object], expected: set[str], name: str) -> None:
+    if set(value) != expected:
+        raise MalformedStagingDataError(f"{name} has missing or unknown fields")
+
+
+def _reject_constant(value: str) -> object:
+    raise ValueError(f"non-finite JSON number {value}")
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _candidate_from_dict(value: object, position: int) -> LessonCandidate:
+    try:
+        record = _object(value, f"candidate {position}")
+        _exact_fields(record, CANDIDATE_FIELDS, f"candidate {position}")
+        provenance_data = _object(record["provenance"], f"candidate {position} provenance")
+        _exact_fields(provenance_data, PROVENANCE_FIELDS, f"candidate {position} provenance")
+        raw_span = provenance_data["source_span"]
+        span_data = None if raw_span is None else _object(raw_span, "source span")
+        if span_data is not None:
+            _exact_fields(span_data, SOURCE_SPAN_FIELDS, "source span")
+        span = (
+            None
+            if span_data is None
+            else SourceSpan(start=span_data["start"], end=span_data["end"])  # type: ignore[arg-type]
+        )
+        raw_transformations = provenance_data["transformations"]
+        if not isinstance(raw_transformations, list):
+            raise MalformedStagingDataError("transformations must be an array")
+        transformations = tuple(
+            _object(item, "transformation metadata") for item in raw_transformations
+        )
+        run_metadata = _object(provenance_data["run_metadata"], "run metadata")
+        proposed_raw = record["proposed_metadata"]
+        proposed = None if proposed_raw is None else _object(proposed_raw, "proposed metadata")
+        provenance = CandidateProvenance(
+            source_kind=SourceKind(provenance_data["source_kind"]),
+            source_logical_name=provenance_data["source_logical_name"],  # type: ignore[arg-type]
+            source_fingerprint=provenance_data["source_fingerprint"],  # type: ignore[arg-type]
+            ingested_at=datetime.fromisoformat(provenance_data["ingested_at"]),  # type: ignore[arg-type]
+            chunk_index=provenance_data["chunk_index"],  # type: ignore[arg-type]
+            source_span=span,
+            run_metadata=run_metadata,
+            transformations=transformations,
+        )
+        candidate = LessonCandidate(
+            text=record["text"],  # type: ignore[arg-type]
+            provenance=provenance,
+            proposed_metadata=proposed,
+            state=CandidateState(record["state"]),
+        )
+        stored_id = record["candidate_id"]
+        if not isinstance(stored_id, str) or stored_id != candidate.candidate_id:
+            raise MalformedStagingDataError(f"candidate {position} has an invalid ID")
+        return candidate
+    except MalformedStagingDataError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise MalformedStagingDataError(f"candidate {position} is malformed") from exc
+
+
+class JsonCandidateRepository:
+    """One versioned JSON document, atomically replaced and sorted by ID."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    def _load(self) -> list[LessonCandidate]:
+        try:
+            if not self._path.exists():
+                return []
+            raw = self._path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise MalformedStagingDataError("staging data is not valid UTF-8") from exc
+        except OSError:
+            raise CandidateStorageError("could not read staging storage") from None
+        try:
+            document = json.loads(
+                raw, parse_constant=_reject_constant, object_pairs_hook=_unique_object
+            )
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise MalformedStagingDataError("staging data is not valid JSON") from exc
+        root = _object(document, "staging data")
+        _exact_fields(root, ROOT_FIELDS, "staging data")
+        schema_version = root["schema_version"]
+        if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
+            raise MalformedStagingDataError("unsupported staging schema version")
+        records = root["candidates"]
+        if not isinstance(records, list):
+            raise MalformedStagingDataError("staging candidates must be an array")
+        candidates: list[LessonCandidate] = []
+        seen: set[str] = set()
+        for position, record in enumerate(records, start=1):
+            candidate = _candidate_from_dict(record, position)
+            if candidate.candidate_id in seen:
+                raise DuplicateCandidateIdError(
+                    f"duplicate candidate id {candidate.candidate_id!r}"
+                )
+            seen.add(candidate.candidate_id)
+            candidates.append(candidate)
+        return sorted(candidates, key=lambda item: item.candidate_id)
+
+    def _write(self, candidates: Sequence[LessonCandidate]) -> None:
+        document = {
+            "candidates": [_candidate_to_dict(item) for item in sorted(
+                candidates, key=lambda candidate: candidate.candidate_id
+            )],
+            "schema_version": SCHEMA_VERSION,
+        }
+        temporary_path: Path | None = None
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self._path.parent,
+                prefix=f".{self._path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as target:
+                temporary_path = Path(target.name)
+                target.write(canonical_json(document) + "\n")
+                target.flush()
+                os.fsync(target.fileno())
+            if self._path.exists():
+                os.chmod(temporary_path, stat.S_IMODE(self._path.stat().st_mode))
+            os.replace(temporary_path, self._path)
+            temporary_path = None
+        except (OSError, UnicodeError):
+            raise CandidateStorageError("could not write staging storage") from None
+        finally:
+            if temporary_path is not None:
+                try:
+                    temporary_path.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+    def create(self, candidate: LessonCandidate) -> LessonCandidate:
+        candidates = self._load()
+        if any(item.candidate_id == candidate.candidate_id for item in candidates):
+            raise DuplicateCandidateIdError(
+                f"duplicate candidate id {candidate.candidate_id!r}"
+            )
+        self._write((*candidates, candidate))
+        return candidate
+
+    def get(self, candidate_id: str) -> LessonCandidate:
+        for candidate in self._load():
+            if candidate.candidate_id == candidate_id:
+                return candidate
+        raise CandidateNotFoundError(f"candidate {candidate_id!r} was not found")
+
+    def list(self) -> tuple[LessonCandidate, ...]:
+        return tuple(self._load())
+
+    def update(self, candidate_id: str, candidate: LessonCandidate) -> LessonCandidate:
+        candidates = self._load()
+        for position, existing in enumerate(candidates):
+            if existing.candidate_id != candidate_id:
+                continue
+            if (
+                candidate.candidate_id != candidate_id
+                or existing.text != candidate.text
+                or existing.provenance != candidate.provenance
+            ):
+                raise ImmutableCandidateFieldError(
+                    "candidate text, identity and provenance are immutable"
+                )
+            candidates[position] = candidate
+            self._write(candidates)
+            return candidate
+        raise CandidateNotFoundError(f"candidate {candidate_id!r} was not found")

--- a/src/lele_manager/application/lesson_candidate.py
+++ b/src/lele_manager/application/lesson_candidate.py
@@ -1,0 +1,219 @@
+"""Backend-neutral lesson-candidate domain and staging repository port.
+
+Candidate identity is the SHA-256 digest of canonical JSON containing the
+normalized candidate text and its source/chunk identity.  Ingestion timestamps,
+run metadata, transformations, proposed metadata and lifecycle state are
+deliberately excluded, so replaying identical input produces the same ID.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+import hashlib
+import math
+from types import MappingProxyType
+from typing import Mapping, Protocol, Sequence
+
+from lele_manager.application.raw_source import SourceKind, normalize_line_endings
+from lele_manager.core.json_compat import canonical_json
+
+
+class CandidateState(str, Enum):
+    STAGED = "staged"
+    IN_REVIEW = "in_review"
+    REJECTED = "rejected"
+    APPROVED = "approved"
+
+
+class CandidateRepositoryError(Exception):
+    """Base class for controlled candidate repository failures."""
+
+
+class DuplicateCandidateIdError(CandidateRepositoryError):
+    """A candidate ID already exists or occurs twice in storage."""
+
+
+class CandidateNotFoundError(CandidateRepositoryError):
+    """The requested candidate does not exist."""
+
+
+class MalformedStagingDataError(CandidateRepositoryError):
+    """Persisted staging data does not match the supported schema."""
+
+
+class CandidateStorageError(CandidateRepositoryError):
+    """The staging backend could not complete an I/O operation."""
+
+
+class ImmutableCandidateFieldError(CandidateRepositoryError):
+    """An update attempted to change candidate identity or provenance."""
+
+
+def _validate_unicode(value: str, name: str) -> None:
+    if any("\ud800" <= character <= "\udfff" for character in value):
+        raise ValueError(f"{name} must not contain Unicode surrogate code points")
+
+
+@dataclass(frozen=True)
+class SourceSpan:
+    """Half-open character offsets in normalized source content."""
+
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.start, bool) or not isinstance(self.start, int) or self.start < 0:
+            raise ValueError("source span start must be a non-negative integer")
+        if isinstance(self.end, bool) or not isinstance(self.end, int) or self.end < self.start:
+            raise ValueError("source span end must be at least start")
+
+
+def _freeze_json(value: object, name: str, active: set[int]) -> object:
+    """Copy a JSON value into recursively immutable domain containers."""
+    if isinstance(value, str):
+        _validate_unicode(value, name)
+        return value
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must contain only JSON-compatible values")
+        return value
+    if isinstance(value, Mapping):
+        identity = id(value)
+        if identity in active:
+            raise ValueError(f"{name} must contain only JSON-compatible values (no cycles)")
+        active.add(identity)
+        try:
+            frozen: dict[str, object] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise ValueError(f"{name} must contain only JSON-compatible values")
+                _validate_unicode(key, f"{name} key")
+                frozen[key] = _freeze_json(item, name, active)
+            return MappingProxyType(frozen)
+        finally:
+            active.remove(identity)
+    if isinstance(value, (list, tuple)):
+        identity = id(value)
+        if identity in active:
+            raise ValueError(f"{name} must contain only JSON-compatible values (no cycles)")
+        active.add(identity)
+        try:
+            return tuple(_freeze_json(item, name, active) for item in value)
+        finally:
+            active.remove(identity)
+    raise ValueError(f"{name} must contain only JSON-compatible values")
+
+
+def _freeze_metadata(name: str, value: Mapping[str, object]) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a mapping")
+    frozen = _freeze_json(value, name, set())
+    assert isinstance(frozen, Mapping)
+    return frozen
+
+
+@dataclass(frozen=True)
+class CandidateProvenance:
+    source_kind: SourceKind
+    source_logical_name: str
+    source_fingerprint: str
+    ingested_at: datetime
+    chunk_index: int | None = None
+    source_span: SourceSpan | None = None
+    run_metadata: Mapping[str, object] = field(default_factory=dict)
+    transformations: tuple[Mapping[str, object], ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source_kind, SourceKind):
+            raise TypeError("source kind must be a SourceKind")
+        if not isinstance(self.source_logical_name, str) or not self.source_logical_name:
+            raise ValueError("source logical name must not be empty")
+        _validate_unicode(self.source_logical_name, "source logical name")
+        if not isinstance(self.source_fingerprint, str) or not self.source_fingerprint:
+            raise ValueError("source fingerprint must not be empty")
+        _validate_unicode(self.source_fingerprint, "source fingerprint")
+        if not isinstance(self.ingested_at, datetime):
+            raise ValueError("ingestion timestamp must be timezone-aware")
+        try:
+            offset = self.ingested_at.utcoffset()
+        except Exception:
+            raise ValueError("ingestion timestamp must be timezone-aware") from None
+        if offset is None:
+            raise ValueError("ingestion timestamp must be timezone-aware")
+        if self.chunk_index is not None and (
+            isinstance(self.chunk_index, bool)
+            or not isinstance(self.chunk_index, int)
+            or self.chunk_index < 0
+        ):
+            raise ValueError("chunk index must be a non-negative integer or None")
+        if self.source_span is not None and not isinstance(self.source_span, SourceSpan):
+            raise TypeError("source span must be a SourceSpan or None")
+        object.__setattr__(
+            self, "run_metadata", _freeze_metadata("run metadata", self.run_metadata)
+        )
+        if not isinstance(self.transformations, tuple):
+            raise TypeError("transformations must be a tuple")
+        object.__setattr__(
+            self,
+            "transformations",
+            tuple(
+                _freeze_metadata("transformation metadata", transformation)
+                for transformation in self.transformations
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class LessonCandidate:
+    text: str
+    provenance: CandidateProvenance
+    proposed_metadata: Mapping[str, object] | None = None
+    state: CandidateState = CandidateState.STAGED
+    candidate_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.text, str):
+            raise TypeError("candidate text must be a string")
+        _validate_unicode(self.text, "candidate text")
+        if not isinstance(self.provenance, CandidateProvenance):
+            raise TypeError("candidate provenance must be CandidateProvenance")
+        if self.proposed_metadata is not None:
+            object.__setattr__(
+                self,
+                "proposed_metadata",
+                _freeze_metadata("proposed metadata", self.proposed_metadata),
+            )
+        if not isinstance(self.state, CandidateState):
+            raise TypeError("candidate state must be a CandidateState")
+
+        normalized_text = normalize_line_endings(self.text)
+        object.__setattr__(self, "text", normalized_text)
+        span = self.provenance.source_span
+        identity = {
+            "chunk_index": self.provenance.chunk_index,
+            "source_fingerprint": self.provenance.source_fingerprint,
+            "source_kind": self.provenance.source_kind.value,
+            "source_logical_name": self.provenance.source_logical_name,
+            "source_span": None if span is None else {"end": span.end, "start": span.start},
+            "text": normalized_text,
+        }
+        digest = hashlib.sha256(canonical_json(identity).encode("utf-8")).hexdigest()
+        object.__setattr__(self, "candidate_id", f"sha256:{digest}")
+
+
+class CandidateRepository(Protocol):
+    """Create/read/list/update boundary for isolated staged candidates."""
+
+    def create(self, candidate: LessonCandidate) -> LessonCandidate: ...
+
+    def get(self, candidate_id: str) -> LessonCandidate: ...
+
+    def list(self) -> Sequence[LessonCandidate]: ...
+
+    def update(
+        self, candidate_id: str, candidate: LessonCandidate
+    ) -> LessonCandidate: ...

--- a/tests/test_candidate_repository_contract.py
+++ b/tests/test_candidate_repository_contract.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+
+import pytest
+
+from lele_manager.adapters import json_candidate_repository as json_adapter
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.application.lesson_candidate import (
+    CandidateNotFoundError,
+    CandidateProvenance,
+    CandidateRepository,
+    CandidateState,
+    CandidateStorageError,
+    DuplicateCandidateIdError,
+    ImmutableCandidateFieldError,
+    LessonCandidate,
+    MalformedStagingDataError,
+    SourceSpan,
+)
+from lele_manager.application.raw_source import SourceKind
+
+
+@pytest.fixture(params=["json"])
+def repository_factory(
+    request: pytest.FixtureRequest,
+) -> Callable[[Path], CandidateRepository]:
+    assert request.param == "json"
+    return JsonCandidateRepository
+
+
+def candidate(text: str, *, chunk_index: int = 0) -> LessonCandidate:
+    return LessonCandidate(
+        text,
+        CandidateProvenance(
+            source_kind=SourceKind.MARKDOWN,
+            source_logical_name="inbox.md",
+            source_fingerprint="sha256:raw-source",
+            ingested_at=datetime(2026, 7, 19, 12, 30, tzinfo=timezone.utc),
+            chunk_index=chunk_index,
+            source_span=SourceSpan(chunk_index * 10, chunk_index * 10 + len(text)),
+            run_metadata={"batch": "local-1"},
+            transformations=({"kind": "manual-cleanup"},),
+        ),
+        proposed_metadata={"topic": "architecture", "importance": 4},
+    )
+
+
+def test_missing_storage_is_empty_and_missing_get_is_controlled(
+    tmp_path: Path, repository_factory: Callable[[Path], CandidateRepository]
+) -> None:
+    repository = repository_factory(tmp_path / "missing" / "candidates.json")
+
+    assert repository.list() == ()
+    with pytest.raises(CandidateNotFoundError, match="missing"):
+        repository.get("missing")
+
+
+def test_create_get_list_and_update_lifecycle_and_metadata(
+    tmp_path: Path, repository_factory: Callable[[Path], CandidateRepository]
+) -> None:
+    repository = repository_factory(tmp_path / "candidates.json")
+    original = candidate("review me")
+
+    assert repository.create(original) == original
+    assert repository.get(original.candidate_id) == original
+
+    updated = replace(
+        original,
+        state=CandidateState.IN_REVIEW,
+        proposed_metadata={"topic": "revised"},
+    )
+    assert repository.update(original.candidate_id, updated) == updated
+    assert repository.get(original.candidate_id) == updated
+
+
+def test_nested_metadata_round_trip_is_logically_preserved(
+    tmp_path: Path, repository_factory: Callable[[Path], CandidateRepository]
+) -> None:
+    path = tmp_path / "candidates.json"
+    repository = repository_factory(path)
+    original = replace(
+        candidate("nested"),
+        proposed_metadata={"labels": ["one", {"nested": [1, 2]}]},
+    )
+
+    repository.create(original)
+
+    assert repository.get(original.candidate_id) == original
+    document = json.loads(path.read_text(encoding="utf-8"))
+    assert document["candidates"][0]["proposed_metadata"] == {
+        "labels": ["one", {"nested": [1, 2]}]
+    }
+
+
+def test_valid_unicode_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    original = replace(
+        candidate("Lezione caffè 😀 \U00020000"),
+        proposed_metadata={"città": ["Perché", "😀", "\U00020000"]},
+    )
+
+    JsonCandidateRepository(path).create(original)
+
+    assert JsonCandidateRepository(path).get(original.candidate_id) == original
+    assert "Lezione caffè 😀 \U00020000" in path.read_text(encoding="utf-8")
+
+
+def test_create_collision_never_overwrites(
+    tmp_path: Path, repository_factory: Callable[[Path], CandidateRepository]
+) -> None:
+    repository = repository_factory(tmp_path / "candidates.json")
+    original = candidate("same")
+    repository.create(original)
+
+    with pytest.raises(DuplicateCandidateIdError, match="duplicate candidate id"):
+        repository.create(replace(original, state=CandidateState.REJECTED))
+
+    assert repository.get(original.candidate_id).state is CandidateState.STAGED
+
+
+def test_update_missing_and_immutable_fields_are_controlled(
+    tmp_path: Path, repository_factory: Callable[[Path], CandidateRepository]
+) -> None:
+    repository = repository_factory(tmp_path / "candidates.json")
+    original = candidate("same")
+    repository.create(original)
+    later_provenance = replace(
+        original.provenance,
+        ingested_at=original.provenance.ingested_at + timedelta(seconds=1),
+    )
+
+    with pytest.raises(ImmutableCandidateFieldError, match="immutable"):
+        repository.update(original.candidate_id, replace(original, provenance=later_provenance))
+    with pytest.raises(ImmutableCandidateFieldError, match="immutable"):
+        repository.update(original.candidate_id, replace(original, text="different"))
+    changed_source = replace(original.provenance, source_logical_name="elsewhere.md")
+    with pytest.raises(ImmutableCandidateFieldError, match="immutable"):
+        repository.update(original.candidate_id, replace(original, provenance=changed_source))
+    with pytest.raises(CandidateNotFoundError):
+        repository.update("sha256:genuinely-missing", original)
+
+
+def test_aware_timestamp_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    original = candidate("aware")
+
+    JsonCandidateRepository(path).create(original)
+
+    loaded = JsonCandidateRepository(path).get(original.candidate_id)
+    assert loaded.provenance.ingested_at == original.provenance.ingested_at
+    assert loaded.provenance.ingested_at.utcoffset() is not None
+
+
+def test_explicit_empty_document_and_deterministic_order_and_bytes(tmp_path: Path) -> None:
+    empty_path = tmp_path / "empty.json"
+    empty_path.write_text('{"candidates":[],"schema_version":1}\n', encoding="utf-8")
+    assert JsonCandidateRepository(empty_path).list() == ()
+
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+    first_repository = JsonCandidateRepository(first_path)
+    second_repository = JsonCandidateRepository(second_path)
+    candidates = [candidate("z", chunk_index=1), candidate("a", chunk_index=0)]
+    for item in candidates:
+        first_repository.create(item)
+    for item in reversed(candidates):
+        second_repository.create(item)
+
+    assert first_path.read_bytes() == second_path.read_bytes()
+    assert [item.candidate_id for item in first_repository.list()] == sorted(
+        item.candidate_id for item in candidates
+    )
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "",
+        "not json",
+        "[]",
+        '{"schema_version":2,"candidates":[]}',
+        '{"schema_version":1,"candidates":{}}',
+        '{"schema_version":1,"candidates":[{}]}',
+        '{"schema_version":true,"candidates":[]}',
+        '{"schema_version":1,"candidates":[],"unknown":null}',
+        '{"schema_version":1}',
+        '{"schema_version":1,"schema_version":1,"candidates":[]}',
+        '{"schema_version":1,"candidates":[],"value":NaN}',
+        '{"schema_version":1,"candidates":[],"value":Infinity}',
+        '{"schema_version":1,"candidates":[],"value":-Infinity}',
+    ],
+)
+def test_malformed_storage_is_a_controlled_error(tmp_path: Path, contents: str) -> None:
+    path = tmp_path / "candidates.json"
+    path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(MalformedStagingDataError):
+        JsonCandidateRepository(path).list()
+
+
+def test_duplicate_ids_in_persisted_data_are_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    repository = JsonCandidateRepository(path)
+    repository.create(candidate("duplicate"))
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["candidates"].append(document["candidates"][0])
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(DuplicateCandidateIdError, match="duplicate candidate id"):
+        repository.list()
+
+
+def test_tampered_candidate_id_is_malformed(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    repository = JsonCandidateRepository(path)
+    repository.create(candidate("original"))
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["candidates"][0]["candidate_id"] = "sha256:tampered"
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(MalformedStagingDataError, match="invalid ID"):
+        repository.list()
+
+
+def test_escaped_surrogate_in_persisted_json_is_malformed(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    repository = JsonCandidateRepository(path)
+    repository.create(candidate("original"))
+    contents = path.read_text(encoding="utf-8").replace("original", r"escaped \ud800")
+    path.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(MalformedStagingDataError, match="malformed"):
+        repository.list()
+
+
+@pytest.mark.parametrize("level", ["candidate", "provenance", "source_span"])
+@pytest.mark.parametrize("mutation", ["missing", "unknown"])
+def test_nested_schema_requires_exact_fields(
+    tmp_path: Path, level: str, mutation: str
+) -> None:
+    path = tmp_path / "candidates.json"
+    repository = JsonCandidateRepository(path)
+    original = candidate("schema")
+    repository.create(original)
+    document = json.loads(path.read_text(encoding="utf-8"))
+    candidate_data = document["candidates"][0]
+    targets = {
+        "candidate": (candidate_data, "state"),
+        "provenance": (candidate_data["provenance"], "run_metadata"),
+        "source_span": (candidate_data["provenance"]["source_span"], "start"),
+    }
+    target, required = targets[level]
+    if mutation == "missing":
+        del target[required]
+    else:
+        target["unknown"] = None
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(MalformedStagingDataError):
+        repository.list()
+
+
+def test_storage_failures_are_controlled_and_do_not_leak_paths(tmp_path: Path) -> None:
+    directory_as_file = tmp_path / "storage"
+    directory_as_file.mkdir()
+    repository = JsonCandidateRepository(directory_as_file)
+
+    with pytest.raises(CandidateStorageError, match="read staging storage") as caught:
+        repository.list()
+    assert str(directory_as_file) not in str(caught.value)
+    assert caught.value.__cause__ is None
+
+    blocked_parent = tmp_path / "parent-is-a-file"
+    blocked_parent.write_text("x", encoding="utf-8")
+    with pytest.raises(CandidateStorageError, match="write staging storage") as caught:
+        JsonCandidateRepository(blocked_parent / "candidates.json").create(candidate("x"))
+    assert str(blocked_parent) not in str(caught.value)
+    assert caught.value.__cause__ is None
+
+
+def test_unicode_write_failure_is_controlled_without_details(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "secret" / "candidates.json"
+
+    def fail_serialization(value: object) -> str:
+        raise UnicodeEncodeError("utf-8", "\ud800", 0, 1, "surrogate")
+
+    monkeypatch.setattr(json_adapter, "canonical_json", fail_serialization)
+    with pytest.raises(CandidateStorageError, match="write staging storage") as caught:
+        JsonCandidateRepository(path).create(candidate("valid"))
+
+    assert str(path) not in str(caught.value)
+    assert "Unicode" not in str(caught.value)
+    assert caught.value.__cause__ is None
+
+
+def test_failed_atomic_replace_preserves_previous_storage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "candidates.json"
+    repository = JsonCandidateRepository(path)
+    original = candidate("original")
+    repository.create(original)
+
+    def fail_replace(source: Path, destination: Path) -> None:
+        raise OSError("interrupted")
+
+    monkeypatch.setattr(json_adapter.os, "replace", fail_replace)
+    with pytest.raises(CandidateStorageError):
+        repository.create(candidate("new", chunk_index=1))
+
+    assert JsonCandidateRepository(path).list() == (original,)
+    assert list(tmp_path.glob(".candidates.json.*.tmp")) == []
+
+
+def test_staging_never_touches_vault_projection_exports_or_ml_datasets(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    approved = vault / "approved.md"
+    projection = tmp_path / "lessons.jsonl"
+    export = tmp_path / "export.jsonl"
+    ml_dataset = tmp_path / "training.csv"
+    protected = {
+        approved: b"---\nid: approved\n---\ncanonical\n",
+        projection: b'{"id":"approved"}\n',
+        export: b'{"id":"exported"}\n',
+        ml_dataset: b"text,topic\ncanonical,testing\n",
+    }
+    for path, contents in protected.items():
+        path.write_bytes(contents)
+
+    staging_path = tmp_path / "staging" / "candidates.json"
+    repository = JsonCandidateRepository(staging_path)
+    staged = repository.create(candidate("isolated"))
+    repository.get(staged.candidate_id)
+    repository.list()
+    repository.update(staged.candidate_id, replace(staged, state=CandidateState.REJECTED))
+
+    assert {path: path.read_bytes() for path in protected} == protected
+    assert sorted(path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*")) == [
+        "export.jsonl",
+        "lessons.jsonl",
+        "staging",
+        "staging/candidates.json",
+        "training.csv",
+        "vault",
+        "vault/approved.md",
+    ]

--- a/tests/test_lesson_candidate.py
+++ b/tests/test_lesson_candidate.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone, tzinfo
+
+import pytest
+
+from lele_manager.application.lesson_candidate import (
+    CandidateProvenance,
+    CandidateState,
+    LessonCandidate,
+    SourceSpan,
+)
+from lele_manager.application.raw_source import SourceKind
+
+
+def provenance(**changes: object) -> CandidateProvenance:
+    values: dict[str, object] = {
+        "source_kind": SourceKind.PLAIN_TEXT,
+        "source_logical_name": "notes.txt",
+        "source_fingerprint": "sha256:source",
+        "ingested_at": datetime(2026, 7, 19, 10, 0, tzinfo=timezone.utc),
+        "chunk_index": 2,
+        "source_span": SourceSpan(10, 24),
+        "run_metadata": {"run": "import-7"},
+        "transformations": ({"kind": "trim", "version": 1},),
+    }
+    values.update(changes)
+    return CandidateProvenance(**values)  # type: ignore[arg-type]
+
+
+class NoOffsetTimezone(tzinfo):
+    def utcoffset(self, dt: datetime | None) -> None:
+        return None
+
+    def dst(self, dt: datetime | None) -> timedelta | None:
+        return None
+
+
+def test_candidate_preserves_reviewable_content_and_complete_provenance() -> None:
+    candidate = LessonCandidate(
+        "candidate text",
+        provenance(),
+        proposed_metadata={"topic": "testing", "tags": ["pytest"]},
+    )
+
+    assert candidate.text == "candidate text"
+    assert candidate.proposed_metadata == {"topic": "testing", "tags": ("pytest",)}
+    assert candidate.provenance.chunk_index == 2
+    assert candidate.provenance.source_span == SourceSpan(10, 24)
+    assert candidate.provenance.run_metadata == {"run": "import-7"}
+    assert candidate.provenance.transformations == ({"kind": "trim", "version": 1},)
+    assert candidate.state is CandidateState.STAGED
+
+
+def test_metadata_is_deeply_copied_and_immutable() -> None:
+    run_metadata = {"environment": {"labels": ["local"]}}
+    transformation = {"details": {"steps": ["trim"]}}
+    proposed_metadata = {"classification": {"tags": ["testing"]}}
+    candidate = LessonCandidate(
+        "text",
+        provenance(run_metadata=run_metadata, transformations=(transformation,)),
+        proposed_metadata=proposed_metadata,
+    )
+
+    run_metadata["environment"]["labels"].append("mutated")  # type: ignore[index,union-attr]
+    transformation["details"]["steps"].append("mutated")  # type: ignore[index,union-attr]
+    proposed_metadata["classification"]["tags"].append("mutated")  # type: ignore[index,union-attr]
+
+    assert candidate.provenance.run_metadata == {
+        "environment": {"labels": ("local",)}
+    }
+    assert candidate.provenance.transformations == (
+        {"details": {"steps": ("trim",)}},
+    )
+    assert candidate.proposed_metadata == {
+        "classification": {"tags": ("testing",)}
+    }
+
+    with pytest.raises(TypeError):
+        candidate.provenance.run_metadata["new"] = True  # type: ignore[index]
+    with pytest.raises(TypeError):
+        candidate.provenance.transformations[0]["new"] = True  # type: ignore[index]
+    with pytest.raises(TypeError):
+        candidate.proposed_metadata["new"] = True  # type: ignore[index]
+    with pytest.raises(TypeError):
+        candidate.provenance.run_metadata["environment"]["new"] = True  # type: ignore[index]
+    with pytest.raises(TypeError):
+        candidate.provenance.transformations[0]["details"]["steps"][0] = "x"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        candidate.proposed_metadata["classification"]["tags"][0] = "x"  # type: ignore[index]
+
+
+def test_identity_is_stable_for_normalized_input_and_excludes_timestamp_metadata() -> None:
+    first = LessonCandidate("one\r\ntwo", provenance())
+    replayed = LessonCandidate(
+        "one\ntwo",
+        provenance(
+            ingested_at=datetime(2030, 1, 1, tzinfo=timezone.utc),
+            run_metadata={"different": True},
+            transformations=({"kind": "enrichment", "model": "none"},),
+        ),
+        proposed_metadata={"topic": "changed"},
+        state=CandidateState.IN_REVIEW,
+    )
+
+    assert first.candidate_id == replayed.candidate_id
+    assert first.candidate_id == (
+        "sha256:510995b11a560f11055f41ef5805ec8dda8a5d63e33920bd0b0eb0284ebe8e39"
+    )
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"text": "different"},
+        {"provenance": provenance(source_logical_name="other.txt")},
+        {"provenance": provenance(source_fingerprint="sha256:other")},
+        {"provenance": provenance(chunk_index=3)},
+        {"provenance": provenance(source_span=SourceSpan(11, 24))},
+    ],
+)
+def test_identity_changes_for_distinct_text_or_source_chunk_identity(
+    changed: dict[str, object],
+) -> None:
+    baseline = LessonCandidate("text", provenance())
+    values: dict[str, object] = {"text": "text", "provenance": provenance()}
+    values.update(changed)
+
+    candidate = LessonCandidate(**values)  # type: ignore[arg-type]
+
+    assert candidate.candidate_id != baseline.candidate_id
+
+
+def test_lifecycle_states_are_explicit_without_premature_transition_policy() -> None:
+    candidate = LessonCandidate("text", provenance())
+
+    assert [state.value for state in CandidateState] == [
+        "staged",
+        "in_review",
+        "rejected",
+        "approved",
+    ]
+    assert replace(candidate, state=CandidateState.REJECTED).state is CandidateState.REJECTED
+
+
+def test_invalid_provenance_and_metadata_are_rejected() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        provenance(ingested_at=datetime(2026, 1, 1))
+    with pytest.raises(ValueError, match="JSON-compatible"):
+        LessonCandidate("text", provenance(), proposed_metadata={"bad": object()})
+    with pytest.raises(ValueError, match="chunk index"):
+        provenance(chunk_index=-1)
+    with pytest.raises(ValueError, match="source span"):
+        SourceSpan(4, 3)
+
+
+def test_timezone_with_no_utc_offset_is_rejected() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        provenance(ingested_at=datetime(2026, 1, 1, tzinfo=NoOffsetTimezone()))
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), float("-inf"), object()])
+def test_non_json_metadata_leaves_are_rejected(invalid: object) -> None:
+    with pytest.raises(ValueError, match="JSON-compatible"):
+        LessonCandidate("text", provenance(), proposed_metadata={"bad": invalid})
+
+
+def test_non_string_metadata_keys_and_cycles_are_rejected() -> None:
+    cyclic_mapping: dict[str, object] = {}
+    cyclic_mapping["self"] = cyclic_mapping
+    cyclic_list: list[object] = []
+    cyclic_list.append(cyclic_list)
+    tuple_cycle_list: list[object] = []
+    cyclic_tuple = (tuple_cycle_list,)
+    tuple_cycle_list.append(cyclic_tuple)
+
+    invalid_values: list[object] = [
+        {1: "value"},
+        cyclic_mapping,
+        {"items": cyclic_list},
+        {"items": cyclic_tuple},
+    ]
+    for invalid in invalid_values:
+        with pytest.raises(ValueError, match="JSON-compatible"):
+            LessonCandidate("text", provenance(), proposed_metadata=invalid)  # type: ignore[arg-type]
+
+
+def test_repeated_non_cyclic_metadata_references_are_allowed_and_copied() -> None:
+    shared = ["value"]
+    candidate = LessonCandidate(
+        "text", provenance(), proposed_metadata={"first": shared, "second": shared}
+    )
+
+    shared.append("changed")
+    assert candidate.proposed_metadata == {"first": ("value",), "second": ("value",)}
+
+
+def test_surrogate_in_candidate_text_is_rejected() -> None:
+    with pytest.raises(ValueError, match="candidate text.*surrogate"):
+        LessonCandidate("invalid \ud800 text", provenance())
+
+
+@pytest.mark.parametrize("field", ["source_logical_name", "source_fingerprint"])
+def test_surrogate_in_source_identity_is_rejected(field: str) -> None:
+    with pytest.raises(ValueError, match=f"{field.replace('_', ' ')}.*surrogate"):
+        provenance(**{field: "invalid\udfff"})
+
+
+def test_surrogate_in_metadata_keys_and_nested_values_is_rejected() -> None:
+    with pytest.raises(ValueError, match="key.*surrogate"):
+        LessonCandidate("text", provenance(), proposed_metadata={"bad\ud800": "value"})
+    with pytest.raises(ValueError, match="surrogate"):
+        provenance(run_metadata={"nested": [{"value": "bad\udfff"}]})
+    with pytest.raises(ValueError, match="surrogate"):
+        provenance(transformations=({"nested": ["bad\ud800"]},))
+
+
+def test_valid_unicode_is_accepted_without_changing_identity_semantics() -> None:
+    candidate = LessonCandidate(
+        "Lezione caffè 😀 \U00020000",
+        provenance(
+            source_logical_name="appunti-è-😀.md",
+            source_fingerprint="impronta-\U00020000",
+            run_metadata={"città": {"simbolo": "😀"}},
+        ),
+        proposed_metadata={"descrizione": "caffè \U00020000"},
+    )
+
+    assert candidate.text == "Lezione caffè 😀 \U00020000"
+    assert candidate.proposed_metadata == {"descrizione": "caffè \U00020000"}


### PR DESCRIPTION
## Summary

- introduce a typed `LessonCandidate` domain model with explicit lifecycle states;
- generate stable deterministic candidate IDs from normalized text and source/chunk identity;
- preserve complete provenance and deeply immutable JSON-compatible metadata;
- add a backend-neutral repository contract for create, get, list, and update;
- add a deterministic local JSON staging adapter with strict schema validation and atomic replacement;
- provide controlled errors for collisions, missing candidates, malformed storage, immutable fields, and storage failures;
- reject lone Unicode surrogate code points while preserving valid accented, emoji, and supplementary-plane Unicode.

## Scope boundaries

This change deliberately does not add:

- review or approval commands;
- lifecycle transition policy;
- vault or projection writes;
- JSONL export;
- API or CLI integration;
- ML, pandas, or LLM integration;
- cross-process locking or transaction serialization.

## Validation

- complete suite: `292 passed, 3 skipped`;
- focused candidate and repository tests: `56 passed`;
- Ruff: passed;
- mypy: passed for 47 source files;
- `git diff --cached --check`: passed;
- final independent read-only audit: `VERDICT: PASS`.

## Residual risks

Cross-process locking, transaction serialization, and parent-directory `fsync`
remain intentionally deferred beyond this issue.

Closes #118
