### PR TITLE
feat(chunking): add deterministic raw-source contract

### DIFF
--- a/src/lele_manager/application/lesson_candidate.py
+++ b/src/lele_manager/application/lesson_candidate.py
@@ -16,7 +16,11 @@ import math
 from types import MappingProxyType
 from typing import Mapping, Protocol, Sequence
 
-from lele_manager.application.raw_source import SourceKind, normalize_line_endings
+from lele_manager.application.raw_source import (
+    SourceKind,
+    SourceSpan,
+    normalize_line_endings,
+)
 from lele_manager.core.json_compat import canonical_json
 
 
@@ -54,20 +58,6 @@ class ImmutableCandidateFieldError(CandidateRepositoryError):
 def _validate_unicode(value: str, name: str) -> None:
     if any("\ud800" <= character <= "\udfff" for character in value):
         raise ValueError(f"{name} must not contain Unicode surrogate code points")
-
-
-@dataclass(frozen=True)
-class SourceSpan:
-    """Half-open character offsets in normalized source content."""
-
-    start: int
-    end: int
-
-    def __post_init__(self) -> None:
-        if isinstance(self.start, bool) or not isinstance(self.start, int) or self.start < 0:
-            raise ValueError("source span start must be a non-negative integer")
-        if isinstance(self.end, bool) or not isinstance(self.end, int) or self.end < self.start:
-            raise ValueError("source span end must be at least start")
 
 
 def _freeze_json(value: object, name: str, active: set[int]) -> object:

--- a/src/lele_manager/application/raw_source.py
+++ b/src/lele_manager/application/raw_source.py
@@ -28,6 +28,28 @@ class SourceKind(str, Enum):
     IN_MEMORY = "in_memory"
 
 
+@dataclass(frozen=True)
+class SourceSpan:
+    """Half-open character offsets in normalized source content."""
+
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.start, bool)
+            or not isinstance(self.start, int)
+            or self.start < 0
+        ):
+            raise ValueError("source span start must be a non-negative integer")
+        if (
+            isinstance(self.end, bool)
+            or not isinstance(self.end, int)
+            or self.end < self.start
+        ):
+            raise ValueError("source span end must be at least start")
+
+
 def normalize_line_endings(content: str) -> str:
     """Convert CRLF and lone CR line endings to LF, changing nothing else."""
     return content.replace("\r\n", "\n").replace("\r", "\n")

--- a/src/lele_manager/application/raw_source_chunking.py
+++ b/src/lele_manager/application/raw_source_chunking.py
@@ -1,0 +1,216 @@
+"""Deterministic, backend-neutral chunking of normalized raw sources.
+
+Chunks are exact slices of ``RawSource.content``. Paragraphs and Markdown ATX
+headings are preferred boundaries. A block larger than ``max_characters`` is
+split at the last line ending that fits, or at exactly ``max_characters`` when
+no line ending is available. All sizes and offsets count Python Unicode
+characters, not encoded bytes or tokenizer-specific units.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Protocol, Sequence
+
+from lele_manager.application.raw_source import RawSource, SourceKind, SourceSpan
+
+
+_HEADING = re.compile(
+    r"^[ ]{0,3}(#{1,6})[ \t]+(.+?)(?:[ \t]+#+[ \t]*)?$"
+)
+_FENCE_OPEN = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})(.*)$")
+
+
+@dataclass(frozen=True)
+class ChunkingSettings:
+    """Explicit limits controlling deterministic source chunking."""
+
+    max_characters: int = 2_000
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.max_characters, bool)
+            or not isinstance(self.max_characters, int)
+            or self.max_characters < 1
+        ):
+            raise ValueError("max characters must be a positive integer")
+
+
+@dataclass(frozen=True)
+class RawSourceChunk:
+    """One immutable source slice and its stable downstream identity inputs."""
+
+    text: str
+    source_fingerprint: str
+    source_kind: SourceKind
+    source_logical_name: str
+    index: int
+    source_span: SourceSpan
+    heading_context: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.text, str):
+            raise TypeError("chunk text must be a string")
+        if not self.text.strip():
+            raise ValueError("chunk text must contain non-whitespace content")
+        if not isinstance(self.source_fingerprint, str) or not self.source_fingerprint:
+            raise ValueError("source fingerprint must not be empty")
+        if not isinstance(self.source_kind, SourceKind):
+            raise TypeError("source kind must be a SourceKind")
+        if (
+            not isinstance(self.source_logical_name, str)
+            or not self.source_logical_name
+        ):
+            raise ValueError("source logical name must not be empty")
+        if (
+            isinstance(self.index, bool)
+            or not isinstance(self.index, int)
+            or self.index < 0
+        ):
+            raise ValueError("chunk index must be a non-negative integer")
+        if not isinstance(self.source_span, SourceSpan):
+            raise TypeError("source span must be a SourceSpan")
+        if self.source_span.end - self.source_span.start != len(self.text):
+            raise ValueError("source span length must match chunk text length")
+        if not isinstance(self.heading_context, tuple) or not all(
+            isinstance(heading, str) and heading for heading in self.heading_context
+        ):
+            raise ValueError("heading context must be a tuple of non-empty strings")
+
+
+class RawSourceChunker(Protocol):
+    """Port implemented by deterministic raw-source chunkers."""
+
+    def chunk(
+        self, source: RawSource, settings: ChunkingSettings = ChunkingSettings()
+    ) -> Sequence[RawSourceChunk]: ...
+
+
+@dataclass(frozen=True)
+class _Piece:
+    start: int
+    end: int
+    heading_context: tuple[str, ...]
+
+
+class DeterministicRawSourceChunker:
+    """Character-bounded chunker using source-native semantic boundaries."""
+
+    def chunk(
+        self, source: RawSource, settings: ChunkingSettings = ChunkingSettings()
+    ) -> tuple[RawSourceChunk, ...]:
+        if not isinstance(source, RawSource):
+            raise TypeError("source must be a RawSource")
+        if not isinstance(settings, ChunkingSettings):
+            raise TypeError("settings must be ChunkingSettings")
+        if not source.content or not source.content.strip():
+            return ()
+
+        pieces = self._pieces(source, settings.max_characters)
+        chunks: list[RawSourceChunk] = []
+        for piece in pieces:
+            text = source.content[piece.start : piece.end]
+            if not text.strip():
+                continue
+            chunks.append(
+                RawSourceChunk(
+                    text=text,
+                    source_fingerprint=source.fingerprint,
+                    source_kind=source.kind,
+                    source_logical_name=source.logical_name,
+                    index=len(chunks),
+                    source_span=SourceSpan(piece.start, piece.end),
+                    heading_context=piece.heading_context,
+                )
+            )
+        return tuple(chunks)
+
+    def _pieces(self, source: RawSource, limit: int) -> list[_Piece]:
+        blocks = self._semantic_blocks(source)
+        pieces: list[_Piece] = []
+        pending: _Piece | None = None
+        for block in blocks:
+            for part in self._split_oversized(source.content, block, limit):
+                if (
+                    pending is not None
+                    and pending.heading_context == part.heading_context
+                    and pending.end - pending.start + part.end - part.start <= limit
+                ):
+                    pending = _Piece(pending.start, part.end, pending.heading_context)
+                else:
+                    if pending is not None:
+                        pieces.append(pending)
+                    pending = part
+        if pending is not None:
+            pieces.append(pending)
+        return pieces
+
+    def _semantic_blocks(self, source: RawSource) -> list[_Piece]:
+        content = source.content
+        boundaries = {0, len(content)}
+        offset = 0
+        fence: tuple[str, int] | None = None
+        for line in content.splitlines(keepends=True):
+            line_end = offset + len(line)
+            line_without_newline = line.rstrip("\n")
+
+            if source.kind is SourceKind.MARKDOWN:
+                if fence is not None:
+                    marker, minimum_length = fence
+                    closing = re.fullmatch(
+                        rf"[ ]{{0,3}}{re.escape(marker)}"
+                        rf"{{{minimum_length},}}[ \t]*",
+                        line_without_newline,
+                    )
+                    if closing:
+                        boundaries.add(line_end)
+                        fence = None
+                    offset = line_end
+                    continue
+
+                opening = _FENCE_OPEN.match(line_without_newline)
+                if opening:
+                    marker = opening.group(1)
+                    boundaries.add(offset)
+                    fence = (marker[0], len(marker))
+                    offset = line_end
+                    continue
+
+                if _HEADING.match(line_without_newline):
+                    boundaries.add(offset)
+                    boundaries.add(line_end)
+
+            if not line.strip():
+                boundaries.add(line_end)
+            offset = line_end
+
+        contexts: list[str] = []
+        blocks: list[_Piece] = []
+        ordered = sorted(boundaries)
+        for start, end in zip(ordered, ordered[1:]):
+            if start == end:
+                continue
+            text = content[start:end]
+            if source.kind is SourceKind.MARKDOWN:
+                match = _HEADING.match(text.rstrip("\n"))
+                if match:
+                    level = len(match.group(1))
+                    contexts = contexts[: level - 1]
+                    contexts.append(match.group(2).strip())
+            blocks.append(_Piece(start, end, tuple(contexts)))
+        return blocks
+
+    @staticmethod
+    def _split_oversized(content: str, piece: _Piece, limit: int) -> list[_Piece]:
+        parts: list[_Piece] = []
+        start = piece.start
+        while piece.end - start > limit:
+            hard_end = start + limit
+            newline = content.rfind("\n", start, hard_end)
+            end = newline + 1 if newline >= start else hard_end
+            parts.append(_Piece(start, end, piece.heading_context))
+            start = end
+        if start < piece.end:
+            parts.append(_Piece(start, piece.end, piece.heading_context))
+        return parts

--- a/tests/test_raw_source_chunking.py
+++ b/tests/test_raw_source_chunking.py
@@ -1,0 +1,205 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from lele_manager.application.raw_source import RawSource, SourceKind, SourceSpan
+from lele_manager.application.raw_source_chunking import (
+    ChunkingSettings,
+    DeterministicRawSourceChunker,
+    RawSourceChunk,
+    RawSourceChunker,
+)
+
+
+def chunks(content: str, kind: SourceKind, maximum: int) -> tuple[RawSourceChunk, ...]:
+    source = RawSource(content, kind, "source")
+    return DeterministicRawSourceChunker().chunk(
+        source, ChunkingSettings(max_characters=maximum)
+    )
+
+
+def test_contract_and_outputs_are_typed_and_immutable() -> None:
+    chunker: RawSourceChunker = DeterministicRawSourceChunker()
+    settings = ChunkingSettings(max_characters=20)
+    result = chunker.chunk(RawSource("text", SourceKind.PLAIN_TEXT, "notes"), settings)
+
+    assert result[0].source_span == SourceSpan(0, 4)
+    assert result[0].source_kind is SourceKind.PLAIN_TEXT
+    assert result[0].source_logical_name == "notes"
+    with pytest.raises(FrozenInstanceError):
+        settings.max_characters = 10  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        result[0].text = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("invalid_text", ["", " \n\t"])
+def test_chunk_output_rejects_empty_or_whitespace_only_text(
+    invalid_text: str,
+) -> None:
+    with pytest.raises(ValueError, match="non-whitespace"):
+        RawSourceChunk(
+            text=invalid_text,
+            source_fingerprint="sha256:source",
+            source_kind=SourceKind.PLAIN_TEXT,
+            source_logical_name="notes",
+            index=0,
+            source_span=SourceSpan(0, len(invalid_text)),
+        )
+
+
+def test_chunk_output_rejects_non_string_text() -> None:
+    with pytest.raises(TypeError, match="chunk text must be a string"):
+        RawSourceChunk(
+            text=object(),  # type: ignore[arg-type]
+            source_fingerprint="sha256:source",
+            source_kind=SourceKind.PLAIN_TEXT,
+            source_logical_name="notes",
+            index=0,
+            source_span=SourceSpan(0, 1),
+        )
+
+
+def test_chunk_output_rejects_a_span_that_does_not_match_text_length() -> None:
+    with pytest.raises(ValueError, match="span length"):
+        RawSourceChunk(
+            text="abcd",
+            source_fingerprint="sha256:source",
+            source_kind=SourceKind.PLAIN_TEXT,
+            source_logical_name="notes",
+            index=0,
+            source_span=SourceSpan(10, 15),
+        )
+
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 1.5, "10"])
+def test_invalid_settings_are_rejected(value: object) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        ChunkingSettings(max_characters=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("content", ["", " \n\t"])
+def test_empty_or_whitespace_only_input_produces_no_chunks(content: str) -> None:
+    assert chunks(content, SourceKind.PLAIN_TEXT, 10) == ()
+
+
+def test_exact_boundary_and_one_character_over_use_character_offsets() -> None:
+    assert [item.text for item in chunks("café😀", SourceKind.PLAIN_TEXT, 5)] == [
+        "café😀"
+    ]
+    over = chunks("café😀x", SourceKind.PLAIN_TEXT, 5)
+    assert [item.text for item in over] == ["café😀", "x"]
+    assert [item.source_span for item in over] == [SourceSpan(0, 5), SourceSpan(5, 6)]
+
+
+def test_plain_text_prefers_paragraphs_and_never_emits_empty_chunks() -> None:
+    result = chunks("alpha\n\nbeta\n\ngamma", SourceKind.PLAIN_TEXT, 13)
+
+    assert [item.text for item in result] == ["alpha\n\nbeta\n\n", "gamma"]
+    assert all(item.text and item.text.strip() for item in result)
+
+
+def test_markdown_heading_context_is_predictable_and_not_prepended() -> None:
+    content = "# Café 😀\n\nintro\n\n## Details\n\nbody\n\n# Next\n\nend"
+    result = chunks(content, SourceKind.MARKDOWN, 18)
+
+    assert [(item.text, item.heading_context) for item in result] == [
+        ("# Café 😀\n\nintro\n\n", ("Café 😀",)),
+        ("## Details\n\nbody\n\n", ("Café 😀", "Details")),
+        ("# Next\n\nend", ("Next",)),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("opening", "closing"),
+    [
+        ("```python", "```"),
+        ("~~~python", "~~~"),
+    ],
+)
+def test_markdown_headings_inside_fenced_code_do_not_change_context(
+    opening: str,
+    closing: str,
+) -> None:
+    content = (
+        "# Titolo reale\n\n"
+        f"{opening}\n"
+        "# Questo è codice, non un titolo\n"
+        "print('ciao')\n"
+        f"{closing}\n\n"
+        "Testo conclusivo"
+    )
+
+    result = chunks(content, SourceKind.MARKDOWN, 40)
+
+    assert len(result) > 1
+    assert all(item.heading_context == ("Titolo reale",) for item in result)
+    assert all(
+        "Questo è codice, non un titolo" not in item.heading_context
+        for item in result
+    )
+
+
+def test_markdown_atx_heading_accepts_up_to_three_leading_spaces() -> None:
+    result = chunks(
+        "   # Titolo indentato\n\nContenuto",
+        SourceKind.MARKDOWN,
+        100,
+    )
+
+    assert len(result) == 1
+    assert result[0].heading_context == ("Titolo indentato",)
+
+
+
+def test_oversized_blocks_fall_back_to_line_then_hard_character_boundaries() -> None:
+    plain = chunks("abcd\nefghijkl", SourceKind.PLAIN_TEXT, 6)
+    unbroken = chunks("abcdefghijklm", SourceKind.PLAIN_TEXT, 6)
+
+    assert [item.text for item in plain] == ["abcd\n", "efghij", "kl"]
+    assert [item.text for item in unbroken] == ["abcdef", "ghijkl", "m"]
+
+
+def test_newline_exactly_at_limit_never_creates_an_oversized_chunk() -> None:
+    result = chunks("abcdef\nresto", SourceKind.PLAIN_TEXT, 6)
+
+    assert [item.text for item in result] == ["abcdef", "\nresto"]
+    assert [item.source_span for item in result] == [
+        SourceSpan(0, 6),
+        SourceSpan(6, 12),
+    ]
+    assert all(len(item.text) <= 6 for item in result)
+
+
+
+def test_oversized_markdown_block_keeps_heading_context_during_fallback() -> None:
+    result = chunks("# Topic\nabcdefghijk", SourceKind.MARKDOWN, 6)
+
+    assert [item.text for item in result] == ["# Topi", "c\n", "abcdef", "ghijk"]
+    assert all(item.heading_context == ("Topic",) for item in result)
+
+
+def test_lf_normalization_spans_and_repeated_runs_are_value_equivalent() -> None:
+    source = RawSource("one\r\n\r\ntwö 😀\rthree", SourceKind.PLAIN_TEXT, "notes")
+    settings = ChunkingSettings(max_characters=7)
+    chunker = DeterministicRawSourceChunker()
+
+    first = chunker.chunk(source, settings)
+    second = chunker.chunk(source, settings)
+
+    assert first == second
+    assert repr(first).encode("utf-8") == repr(second).encode("utf-8")
+    assert [item.index for item in first] == list(range(len(first)))
+    assert all(item.source_fingerprint == source.fingerprint for item in first)
+    assert all(
+        item.text == source.content[item.source_span.start : item.source_span.end]
+        for item in first
+    )
+
+
+def test_single_markdown_block_is_preserved_when_it_fits() -> None:
+    result = chunks("# Heading\nbody", SourceKind.MARKDOWN, 50)
+
+    assert len(result) == 1
+    assert result[0].text == "# Heading\nbody"
+    assert result[0].heading_context == ("Heading",)


### PR DESCRIPTION
## Summary

- add a backend-neutral raw-source chunking contract;
- provide immutable, typed chunk outputs with source fingerprint, kind, logical name, index and exact source span;
- implement deterministic Markdown and plain-text chunking;
- prefer headings, paragraphs and blank lines before fallback splitting;
- retain predictable Markdown ATX heading context;
- ignore headings inside backtick and tilde fenced code blocks;
- move `SourceSpan` to the neutral raw-source domain module for reuse.

## Determinism and traceability

For identical normalized source content and settings, the chunker produces equivalent:

- chunk counts;
- chunk ordering;
- text slices;
- source spans;
- heading contexts;
- downstream identity inputs.

Chunks are exact slices of normalized source content and never exceed the configured character limit.

## Validation

- 315 tests passed;
- 3 tests skipped;
- Ruff passed;
- Mypy passed;
- compileall passed;
- `git diff --check` passed.

The remaining warnings are pre-existing dependency and legacy API deprecations outside this issue's scope.

Closes #120
