### PR TITLE
feat(review): add explicit candidate review lifecycle

### DIFF
--- a/src/lele_manager/adapters/json_candidate_repository.py
+++ b/src/lele_manager/adapters/json_candidate_repository.py
@@ -13,6 +13,9 @@ from typing import Mapping, Sequence
 from lele_manager.application.lesson_candidate import (
     CandidateNotFoundError,
     CandidateProvenance,
+    CandidateReviewAction,
+    CandidateReviewEvent,
+    CandidateRevisionConflictError,
     CandidateState,
     CandidateStorageError,
     DuplicateCandidateIdError,
@@ -24,9 +27,17 @@ from lele_manager.application.lesson_candidate import (
 from lele_manager.application.raw_source import SourceKind
 from lele_manager.core.json_compat import canonical_json
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 ROOT_FIELDS = {"candidates", "schema_version"}
-CANDIDATE_FIELDS = {"candidate_id", "proposed_metadata", "provenance", "state", "text"}
+CANDIDATE_FIELDS_V1 = {
+    "candidate_id", "proposed_metadata", "provenance", "state", "text",
+}
+CANDIDATE_FIELDS_V2 = CANDIDATE_FIELDS_V1 | {
+    "proposed_text", "revision", "review_history",
+}
+REVIEW_EVENT_FIELDS = {
+    "action", "occurred_at", "previous_state", "reason", "resulting_state", "revision",
+}
 PROVENANCE_FIELDS = {
     "chunk_index", "ingested_at", "run_metadata", "source_fingerprint",
     "source_kind", "source_logical_name", "source_span", "transformations",
@@ -48,6 +59,7 @@ def _candidate_to_dict(candidate: LessonCandidate) -> dict[str, object]:
     span = provenance.source_span
     return {
         "candidate_id": candidate.candidate_id,
+        "proposed_text": candidate.proposed_text,
         "proposed_metadata": _json_value(candidate.proposed_metadata),
         "provenance": {
             "chunk_index": provenance.chunk_index,
@@ -60,6 +72,18 @@ def _candidate_to_dict(candidate: LessonCandidate) -> dict[str, object]:
             "transformations": _json_value(provenance.transformations),
         },
         "state": candidate.state.value,
+        "revision": candidate.revision,
+        "review_history": [
+            {
+                "action": event.action.value,
+                "occurred_at": event.occurred_at.isoformat(),
+                "previous_state": event.previous_state.value,
+                "reason": event.reason,
+                "resulting_state": event.resulting_state.value,
+                "revision": event.revision,
+            }
+            for event in candidate.review_history
+        ],
         "text": candidate.text,
     }
 
@@ -88,10 +112,15 @@ def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
     return result
 
 
-def _candidate_from_dict(value: object, position: int) -> LessonCandidate:
+def _candidate_from_dict(
+    value: object, position: int, schema_version: int
+) -> LessonCandidate:
     try:
         record = _object(value, f"candidate {position}")
-        _exact_fields(record, CANDIDATE_FIELDS, f"candidate {position}")
+        expected_fields = (
+            CANDIDATE_FIELDS_V1 if schema_version == 1 else CANDIDATE_FIELDS_V2
+        )
+        _exact_fields(record, expected_fields, f"candidate {position}")
         provenance_data = _object(record["provenance"], f"candidate {position} provenance")
         _exact_fields(provenance_data, PROVENANCE_FIELDS, f"candidate {position} provenance")
         raw_span = provenance_data["source_span"]
@@ -112,6 +141,26 @@ def _candidate_from_dict(value: object, position: int) -> LessonCandidate:
         run_metadata = _object(provenance_data["run_metadata"], "run metadata")
         proposed_raw = record["proposed_metadata"]
         proposed = None if proposed_raw is None else _object(proposed_raw, "proposed metadata")
+        review_history: tuple[CandidateReviewEvent, ...] = ()
+        if schema_version == 2:
+            raw_history = record["review_history"]
+            if not isinstance(raw_history, list):
+                raise MalformedStagingDataError("review history must be an array")
+            events: list[CandidateReviewEvent] = []
+            for event_position, raw_event in enumerate(raw_history, start=1):
+                event = _object(raw_event, f"review event {event_position}")
+                _exact_fields(event, REVIEW_EVENT_FIELDS, f"review event {event_position}")
+                events.append(
+                    CandidateReviewEvent(
+                        revision=event["revision"],  # type: ignore[arg-type]
+                        action=CandidateReviewAction(event["action"]),
+                        occurred_at=datetime.fromisoformat(event["occurred_at"]),  # type: ignore[arg-type]
+                        previous_state=CandidateState(event["previous_state"]),
+                        resulting_state=CandidateState(event["resulting_state"]),
+                        reason=event["reason"],  # type: ignore[arg-type]
+                    )
+                )
+            review_history = tuple(events)
         provenance = CandidateProvenance(
             source_kind=SourceKind(provenance_data["source_kind"]),
             source_logical_name=provenance_data["source_logical_name"],  # type: ignore[arg-type]
@@ -125,8 +174,11 @@ def _candidate_from_dict(value: object, position: int) -> LessonCandidate:
         candidate = LessonCandidate(
             text=record["text"],  # type: ignore[arg-type]
             provenance=provenance,
+            proposed_text=record["proposed_text"] if schema_version == 2 else None,  # type: ignore[arg-type]
             proposed_metadata=proposed,
             state=CandidateState(record["state"]),
+            revision=record["revision"] if schema_version == 2 else 0,  # type: ignore[arg-type]
+            review_history=review_history,
         )
         stored_id = record["candidate_id"]
         if not isinstance(stored_id, str) or stored_id != candidate.candidate_id:
@@ -162,7 +214,7 @@ class JsonCandidateRepository:
         root = _object(document, "staging data")
         _exact_fields(root, ROOT_FIELDS, "staging data")
         schema_version = root["schema_version"]
-        if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
+        if type(schema_version) is not int or schema_version not in (1, SCHEMA_VERSION):
             raise MalformedStagingDataError("unsupported staging schema version")
         records = root["candidates"]
         if not isinstance(records, list):
@@ -170,7 +222,7 @@ class JsonCandidateRepository:
         candidates: list[LessonCandidate] = []
         seen: set[str] = set()
         for position, record in enumerate(records, start=1):
-            candidate = _candidate_from_dict(record, position)
+            candidate = _candidate_from_dict(record, position, schema_version)
             if candidate.candidate_id in seen:
                 raise DuplicateCandidateIdError(
                     f"duplicate candidate id {candidate.candidate_id!r}"
@@ -232,20 +284,69 @@ class JsonCandidateRepository:
     def list(self) -> tuple[LessonCandidate, ...]:
         return tuple(self._load())
 
-    def update(self, candidate_id: str, candidate: LessonCandidate) -> LessonCandidate:
+    def update(
+        self,
+        candidate_id: str,
+        candidate: LessonCandidate,
+        *,
+        expected_revision: int,
+    ) -> LessonCandidate:
+        if type(expected_revision) is not int or expected_revision < 0:
+            raise ValueError("expected revision must be a non-negative integer")
         candidates = self._load()
         for position, existing in enumerate(candidates):
             if existing.candidate_id != candidate_id:
                 continue
-            if (
-                candidate.candidate_id != candidate_id
-                or existing.text != candidate.text
-                or existing.provenance != candidate.provenance
-            ):
+            if existing.revision != expected_revision:
+                raise CandidateRevisionConflictError("candidate revision conflict")
+            if type(candidate) is not LessonCandidate:
+                raise CandidateRevisionConflictError("candidate update is malformed")
+            try:
+                proposed_id = candidate.candidate_id
+            except AttributeError:
+                raise CandidateRevisionConflictError(
+                    "candidate update is malformed"
+                ) from None
+            if proposed_id != candidate_id:
                 raise ImmutableCandidateFieldError(
                     "candidate text, identity and provenance are immutable"
                 )
-            candidates[position] = candidate
+            try:
+                candidate_data = _candidate_to_dict(candidate)
+                validated_candidate = _candidate_from_dict(
+                    candidate_data, position + 1, SCHEMA_VERSION
+                )
+            except (
+                MalformedStagingDataError,
+                AttributeError,
+                IndexError,
+                KeyError,
+                TypeError,
+                ValueError,
+            ):
+                raise CandidateRevisionConflictError(
+                    "candidate update is malformed"
+                ) from None
+            existing_data = _candidate_to_dict(existing)
+            if existing.text != validated_candidate.text or canonical_json(
+                existing_data["provenance"]
+            ) != canonical_json(candidate_data["provenance"]):
+                raise ImmutableCandidateFieldError(
+                    "candidate text, identity and provenance are immutable"
+                )
+            if validated_candidate.revision != expected_revision + 1:
+                raise CandidateRevisionConflictError("candidate revision must increment once")
+            candidate_history_data = candidate_data["review_history"]
+            existing_history_data = existing_data["review_history"]
+            assert isinstance(candidate_history_data, list)
+            assert isinstance(existing_history_data, list)
+            if (
+                len(validated_candidate.review_history) != len(existing.review_history) + 1
+                or canonical_json(candidate_history_data[:-1])
+                != canonical_json(existing_history_data)
+            ):
+                raise CandidateRevisionConflictError("candidate review history must append once")
+            candidates[position] = validated_candidate
             self._write(candidates)
-            return candidate
+            return validated_candidate
         raise CandidateNotFoundError(f"candidate {candidate_id!r} was not found")

--- a/src/lele_manager/application/candidate_review.py
+++ b/src/lele_manager/application/candidate_review.py
@@ -1,0 +1,287 @@
+"""Backend-neutral human review workflow for staged lesson candidates.
+
+Lifecycle policy:
+
+- ``STAGED`` candidates may be revised, accepted or rejected.
+- Revision keeps the candidate ``STAGED``.
+- Acceptance moves a candidate from ``STAGED`` to ``IN_REVIEW``.
+- Rejection moves ``STAGED`` or ``IN_REVIEW`` to ``REJECTED``.
+- ``REJECTED`` and ``APPROVED`` are terminal for this service.
+- Every successful operation appends exactly one review event and increments
+  the optimistic-concurrency revision exactly once.
+- Repeated or otherwise invalid transitions fail deterministically without
+  calling the clock or writing candidate storage.
+
+Approval into the canonical vault remains outside this module.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from datetime import datetime
+
+from lele_manager.application.lesson_candidate import (
+    CandidateNotFoundError,
+    CandidateRepository,
+    CandidateRepositoryError,
+    CandidateReviewAction,
+    CandidateReviewEvent,
+    CandidateRevisionConflictError,
+    CandidateState,
+    DuplicateCandidateIdError,
+    LessonCandidate,
+)
+from lele_manager.application.raw_source import SourceKind
+
+
+class CandidateReviewError(Exception):
+    """Base class for controlled candidate-review failures."""
+
+
+class ReviewCandidateNotFoundError(CandidateReviewError):
+    """The requested candidate does not exist."""
+
+
+class InvalidCandidateTransitionError(CandidateReviewError):
+    """The requested operation is not valid in the current lifecycle state."""
+
+
+class StaleCandidateRevisionError(CandidateReviewError):
+    """The caller's expected revision is no longer current."""
+
+
+class CandidateReviewConflictError(CandidateReviewError):
+    """Candidate storage contains a conflicting identity."""
+
+
+class CandidateReviewStorageError(CandidateReviewError):
+    """The candidate repository could not complete the operation."""
+
+
+class InvalidCandidateReviewInputError(CandidateReviewError):
+    """Review input does not satisfy the public application contract."""
+
+
+def _non_empty_string(value: object, name: str) -> str:
+    if type(value) is not str or not value.strip():
+        raise InvalidCandidateReviewInputError(f"{name} must be a non-empty string")
+    if any("\ud800" <= character <= "\udfff" for character in value):
+        raise InvalidCandidateReviewInputError(f"{name} contains invalid Unicode")
+    return value
+
+
+def _optional_reason(value: object) -> str | None:
+    if value is None:
+        return None
+    return _non_empty_string(value, "reason")
+
+
+def _expected_revision(value: object) -> int:
+    if type(value) is not int or value < 0:
+        raise InvalidCandidateReviewInputError(
+            "expected revision must be a non-negative integer"
+        )
+    return value
+
+
+@dataclass(frozen=True)
+class CandidateReviewFilter:
+    state: CandidateState | None = None
+    source_fingerprint: str | None = None
+    source_kind: SourceKind | None = None
+    source_logical_name: str | None = None
+    chunk_index: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.state is not None and type(self.state) is not CandidateState:
+            raise InvalidCandidateReviewInputError("state must be a CandidateState or None")
+        if self.source_kind is not None and type(self.source_kind) is not SourceKind:
+            raise InvalidCandidateReviewInputError(
+                "source kind must be a SourceKind or None"
+            )
+        for value, name in (
+            (self.source_fingerprint, "source fingerprint"),
+            (self.source_logical_name, "source logical name"),
+        ):
+            if value is not None:
+                _non_empty_string(value, name)
+        if self.chunk_index is not None and (
+            type(self.chunk_index) is not int or self.chunk_index < 0
+        ):
+            raise InvalidCandidateReviewInputError(
+                "chunk index must be a non-negative integer or None"
+            )
+
+
+class CandidateReviewService:
+    def __init__(
+        self, repository: CandidateRepository, clock: Callable[[], datetime]
+    ) -> None:
+        self._repository = repository
+        self._clock = clock
+
+    @staticmethod
+    def _translate_repository_error(error: CandidateRepositoryError) -> CandidateReviewError:
+        if isinstance(error, CandidateNotFoundError):
+            return ReviewCandidateNotFoundError("candidate was not found")
+        if isinstance(error, CandidateRevisionConflictError):
+            return StaleCandidateRevisionError("candidate revision is stale")
+        if isinstance(error, DuplicateCandidateIdError):
+            return CandidateReviewConflictError("candidate identity conflict")
+        return CandidateReviewStorageError("candidate storage operation failed")
+
+    def _get(self, candidate_id: str) -> LessonCandidate:
+        _non_empty_string(candidate_id, "candidate ID")
+        try:
+            return self._repository.get(candidate_id)
+        except CandidateRepositoryError as error:
+            raise self._translate_repository_error(error) from None
+
+    def get_candidate(self, candidate_id: str) -> LessonCandidate:
+        return self._get(candidate_id)
+
+    def list_candidates(
+        self, filters: CandidateReviewFilter | None = None
+    ) -> tuple[LessonCandidate, ...]:
+        if filters is None:
+            filters = CandidateReviewFilter()
+        elif type(filters) is not CandidateReviewFilter:
+            raise InvalidCandidateReviewInputError(
+                "filters must be a CandidateReviewFilter or None"
+            )
+        try:
+            candidates = self._repository.list()
+        except CandidateRepositoryError as error:
+            raise self._translate_repository_error(error) from None
+        seen: set[str] = set()
+        result: list[LessonCandidate] = []
+        for candidate in candidates:
+            if candidate.candidate_id in seen:
+                raise CandidateReviewConflictError("duplicate candidate identity")
+            seen.add(candidate.candidate_id)
+            provenance = candidate.provenance
+            if filters.state is not None and candidate.state is not filters.state:
+                continue
+            if (
+                filters.source_fingerprint is not None
+                and provenance.source_fingerprint != filters.source_fingerprint
+            ):
+                continue
+            if filters.source_kind is not None and provenance.source_kind is not filters.source_kind:
+                continue
+            if (
+                filters.source_logical_name is not None
+                and provenance.source_logical_name != filters.source_logical_name
+            ):
+                continue
+            if filters.chunk_index is not None and provenance.chunk_index != filters.chunk_index:
+                continue
+            result.append(candidate)
+        return tuple(sorted(result, key=lambda candidate: candidate.candidate_id))
+
+    def _write(
+        self,
+        candidate_id: str,
+        *,
+        expected_revision: int,
+        action: CandidateReviewAction,
+        resulting_state: CandidateState,
+        reason: str | None,
+        proposed_text: str | None = None,
+        proposed_metadata: Mapping[str, object] | None = None,
+    ) -> LessonCandidate:
+        current = self._get(candidate_id)
+        expected = _expected_revision(expected_revision)
+        if current.revision != expected:
+            raise StaleCandidateRevisionError("candidate revision is stale")
+
+        allowed = {
+            CandidateReviewAction.REVISED: (CandidateState.STAGED,),
+            CandidateReviewAction.ACCEPTED: (CandidateState.STAGED,),
+            CandidateReviewAction.REJECTED: (
+                CandidateState.STAGED,
+                CandidateState.IN_REVIEW,
+            ),
+        }
+        if current.state not in allowed[action]:
+            raise InvalidCandidateTransitionError("candidate transition is not allowed")
+
+        validated_reason = _optional_reason(reason)
+        try:
+            validated = (
+                replace(
+                    current,
+                    proposed_text=proposed_text,
+                    proposed_metadata=proposed_metadata,
+                )
+                if action is CandidateReviewAction.REVISED
+                else current
+            )
+        except (TypeError, ValueError):
+            raise InvalidCandidateReviewInputError(
+                "invalid candidate review input"
+            ) from None
+
+        occurred_at = self._clock()
+        event = CandidateReviewEvent(
+            revision=expected + 1,
+            action=action,
+            occurred_at=occurred_at,
+            previous_state=current.state,
+            resulting_state=resulting_state,
+            reason=validated_reason,
+        )
+        updated = replace(
+            validated,
+            state=resulting_state,
+            revision=expected + 1,
+            review_history=current.review_history + (event,),
+        )
+        try:
+            return self._repository.update(
+                candidate_id, updated, expected_revision=expected
+            )
+        except CandidateRepositoryError as error:
+            raise self._translate_repository_error(error) from None
+
+    def revise_candidate(
+        self,
+        candidate_id: str,
+        *,
+        expected_revision: int,
+        proposed_text: str | None,
+        proposed_metadata: Mapping[str, object] | None,
+        reason: str | None = None,
+    ) -> LessonCandidate:
+        return self._write(
+            candidate_id,
+            expected_revision=expected_revision,
+            action=CandidateReviewAction.REVISED,
+            resulting_state=CandidateState.STAGED,
+            reason=reason,
+            proposed_text=proposed_text,
+            proposed_metadata=proposed_metadata,
+        )
+
+    def accept_candidate(
+        self, candidate_id: str, *, expected_revision: int, reason: str | None = None
+    ) -> LessonCandidate:
+        return self._write(
+            candidate_id,
+            expected_revision=expected_revision,
+            action=CandidateReviewAction.ACCEPTED,
+            resulting_state=CandidateState.IN_REVIEW,
+            reason=reason,
+        )
+
+    def reject_candidate(
+        self, candidate_id: str, *, expected_revision: int, reason: str | None = None
+    ) -> LessonCandidate:
+        return self._write(
+            candidate_id,
+            expected_revision=expected_revision,
+            action=CandidateReviewAction.REJECTED,
+            resulting_state=CandidateState.REJECTED,
+            reason=reason,
+        )

--- a/src/lele_manager/application/lesson_candidate.py
+++ b/src/lele_manager/application/lesson_candidate.py
@@ -1,9 +1,11 @@
 """Backend-neutral lesson-candidate domain and staging repository port.
 
 Candidate identity is the SHA-256 digest of canonical JSON containing the
-normalized candidate text and its source/chunk identity.  Ingestion timestamps,
-run metadata, transformations, proposed metadata and lifecycle state are
-deliberately excluded, so replaying identical input produces the same ID.
+normalized immutable source text and its source/chunk identity.
+
+Ingestion timestamps, run metadata, transformations, proposed text, proposed
+metadata, lifecycle state, revision and review history are deliberately
+excluded, so replaying identical source input produces the same candidate ID.
 """
 
 from __future__ import annotations
@@ -31,6 +33,12 @@ class CandidateState(str, Enum):
     APPROVED = "approved"
 
 
+class CandidateReviewAction(str, Enum):
+    REVISED = "revised"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
 class CandidateRepositoryError(Exception):
     """Base class for controlled candidate repository failures."""
 
@@ -53,6 +61,10 @@ class CandidateStorageError(CandidateRepositoryError):
 
 class ImmutableCandidateFieldError(CandidateRepositoryError):
     """An update attempted to change candidate identity or provenance."""
+
+
+class CandidateRevisionConflictError(CandidateRepositoryError):
+    """The persisted candidate revision differs from the expected revision."""
 
 
 def _validate_unicode(value: str, name: str) -> None:
@@ -104,6 +116,59 @@ def _freeze_metadata(name: str, value: Mapping[str, object]) -> Mapping[str, obj
     frozen = _freeze_json(value, name, set())
     assert isinstance(frozen, Mapping)
     return frozen
+
+
+@dataclass(frozen=True)
+class CandidateReviewEvent:
+    revision: int
+    action: CandidateReviewAction
+    occurred_at: datetime
+    previous_state: CandidateState
+    resulting_state: CandidateState
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.revision) is not int or self.revision < 1:
+            raise ValueError("review event revision must be a positive integer")
+        if type(self.action) is not CandidateReviewAction:
+            raise TypeError("review event action must be a CandidateReviewAction")
+        if type(self.occurred_at) is not datetime:
+            raise TypeError("review event timestamp must be a datetime")
+        try:
+            offset = self.occurred_at.utcoffset()
+        except Exception:
+            raise ValueError("review event timestamp must be timezone-aware") from None
+        if offset is None:
+            raise ValueError("review event timestamp must be timezone-aware")
+        if type(self.previous_state) is not CandidateState:
+            raise TypeError("review event previous state must be a CandidateState")
+        if type(self.resulting_state) is not CandidateState:
+            raise TypeError("review event resulting state must be a CandidateState")
+        if self.reason is not None:
+            if type(self.reason) is not str or not self.reason.strip():
+                raise ValueError("review event reason must be None or a non-empty string")
+            _validate_unicode(self.reason, "review event reason")
+
+        allowed = {
+            CandidateReviewAction.REVISED: (
+                CandidateState.STAGED,
+                CandidateState.STAGED,
+            ),
+            CandidateReviewAction.ACCEPTED: (
+                CandidateState.STAGED,
+                CandidateState.IN_REVIEW,
+            ),
+        }
+        if self.action in allowed and (
+            self.previous_state,
+            self.resulting_state,
+        ) != allowed[self.action]:
+            raise ValueError("review event action does not match its state transition")
+        if self.action is CandidateReviewAction.REJECTED and (
+            self.previous_state not in (CandidateState.STAGED, CandidateState.IN_REVIEW)
+            or self.resulting_state is not CandidateState.REJECTED
+        ):
+            raise ValueError("review event action does not match its state transition")
 
 
 @dataclass(frozen=True)
@@ -163,6 +228,9 @@ class LessonCandidate:
     provenance: CandidateProvenance
     proposed_metadata: Mapping[str, object] | None = None
     state: CandidateState = CandidateState.STAGED
+    proposed_text: str | None = None
+    revision: int = 0
+    review_history: tuple[CandidateReviewEvent, ...] = ()
     candidate_id: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -171,6 +239,13 @@ class LessonCandidate:
         _validate_unicode(self.text, "candidate text")
         if not isinstance(self.provenance, CandidateProvenance):
             raise TypeError("candidate provenance must be CandidateProvenance")
+        if self.proposed_text is not None:
+            if type(self.proposed_text) is not str or not self.proposed_text.strip():
+                raise ValueError("proposed text must be None or a non-whitespace string")
+            _validate_unicode(self.proposed_text, "proposed text")
+            object.__setattr__(
+                self, "proposed_text", normalize_line_endings(self.proposed_text)
+            )
         if self.proposed_metadata is not None:
             object.__setattr__(
                 self,
@@ -179,6 +254,26 @@ class LessonCandidate:
             )
         if not isinstance(self.state, CandidateState):
             raise TypeError("candidate state must be a CandidateState")
+        if type(self.revision) is not int or self.revision < 0:
+            raise ValueError("candidate revision must be a non-negative integer")
+        if not isinstance(self.review_history, tuple):
+            raise TypeError("candidate review history must be a tuple")
+        for expected_revision, event in enumerate(self.review_history, start=1):
+            if type(event) is not CandidateReviewEvent:
+                raise TypeError("candidate review history must contain review events")
+            if event.revision != expected_revision:
+                raise ValueError("review event revisions must be exactly 1..revision")
+            if expected_revision > 1:
+                previous = self.review_history[expected_revision - 2]
+                if previous.resulting_state is not event.previous_state:
+                    raise ValueError("review events must form a consistent state chain")
+        if self.review_history:
+            if len(self.review_history) != self.revision:
+                raise ValueError("review event revisions must be exactly 1..revision")
+            if self.review_history[-1].resulting_state is not self.state:
+                raise ValueError("review history final state must equal candidate state")
+        elif self.revision != 0:
+            raise ValueError("empty review history requires revision zero")
 
         normalized_text = normalize_line_endings(self.text)
         object.__setattr__(self, "text", normalized_text)
@@ -194,6 +289,10 @@ class LessonCandidate:
         digest = hashlib.sha256(canonical_json(identity).encode("utf-8")).hexdigest()
         object.__setattr__(self, "candidate_id", f"sha256:{digest}")
 
+    @property
+    def effective_text(self) -> str:
+        return self.proposed_text if self.proposed_text is not None else self.text
+
 
 class CandidateRepository(Protocol):
     """Create/read/list/update boundary for isolated staged candidates."""
@@ -205,5 +304,9 @@ class CandidateRepository(Protocol):
     def list(self) -> Sequence[LessonCandidate]: ...
 
     def update(
-        self, candidate_id: str, candidate: LessonCandidate
+        self,
+        candidate_id: str,
+        candidate: LessonCandidate,
+        *,
+        expected_revision: int,
     ) -> LessonCandidate: ...

--- a/tests/test_candidate_repository_contract.py
+++ b/tests/test_candidate_repository_contract.py
@@ -14,6 +14,9 @@ from lele_manager.application.lesson_candidate import (
     CandidateNotFoundError,
     CandidateProvenance,
     CandidateRepository,
+    CandidateReviewAction,
+    CandidateReviewEvent,
+    CandidateRevisionConflictError,
     CandidateState,
     CandidateStorageError,
     DuplicateCandidateIdError,
@@ -50,6 +53,70 @@ def candidate(text: str, *, chunk_index: int = 0) -> LessonCandidate:
     )
 
 
+def mutated(
+    original: LessonCandidate,
+    *,
+    state: CandidateState = CandidateState.IN_REVIEW,
+    proposed_metadata: dict[str, object] | None = None,
+    provenance: CandidateProvenance | None = None,
+    text: str | None = None,
+) -> LessonCandidate:
+    action = (
+        CandidateReviewAction.REJECTED
+        if state is CandidateState.REJECTED
+        else CandidateReviewAction.ACCEPTED
+    )
+    event = CandidateReviewEvent(
+        revision=1,
+        action=action,
+        occurred_at=datetime(2026, 7, 20, tzinfo=timezone.utc),
+        previous_state=CandidateState.STAGED,
+        resulting_state=state,
+    )
+    return replace(
+        original,
+        text=original.text if text is None else text,
+        provenance=original.provenance if provenance is None else provenance,
+        proposed_metadata=proposed_metadata,
+        state=state,
+        revision=1,
+        review_history=(event,),
+    )
+
+
+def schema_v1_record(item: LessonCandidate) -> dict[str, object]:
+    provenance = item.provenance
+    span = provenance.source_span
+    return {
+        "candidate_id": item.candidate_id,
+        "proposed_metadata": {"legacy": ["kept", {"nested": True}]},
+        "provenance": {
+            "chunk_index": provenance.chunk_index,
+            "ingested_at": provenance.ingested_at.isoformat(),
+            "run_metadata": {"legacy_run": [1, 2]},
+            "source_fingerprint": provenance.source_fingerprint,
+            "source_kind": provenance.source_kind.value,
+            "source_logical_name": provenance.source_logical_name,
+            "source_span": (
+                None if span is None else {"end": span.end, "start": span.start}
+            ),
+            "transformations": [{"kind": "legacy-transform"}],
+        },
+        "state": item.state.value,
+        "text": item.text,
+    }
+
+
+def write_schema_v1(path: Path, items: list[LessonCandidate]) -> bytes:
+    document = {
+        "candidates": [schema_v1_record(item) for item in items],
+        "schema_version": 1,
+    }
+    contents = (json.dumps(document, indent=2, ensure_ascii=False) + "\n").encode()
+    path.write_bytes(contents)
+    return contents
+
+
 def test_missing_storage_is_empty_and_missing_get_is_controlled(
     tmp_path: Path, repository_factory: Callable[[Path], CandidateRepository]
 ) -> None:
@@ -69,12 +136,10 @@ def test_create_get_list_and_update_lifecycle_and_metadata(
     assert repository.create(original) == original
     assert repository.get(original.candidate_id) == original
 
-    updated = replace(
-        original,
-        state=CandidateState.IN_REVIEW,
-        proposed_metadata={"topic": "revised"},
-    )
-    assert repository.update(original.candidate_id, updated) == updated
+    updated = mutated(original, proposed_metadata={"topic": "revised"})
+    assert repository.update(
+        original.candidate_id, updated, expected_revision=0
+    ) == updated
     assert repository.get(original.candidate_id) == updated
 
 
@@ -135,14 +200,28 @@ def test_update_missing_and_immutable_fields_are_controlled(
     )
 
     with pytest.raises(ImmutableCandidateFieldError, match="immutable"):
-        repository.update(original.candidate_id, replace(original, provenance=later_provenance))
+        repository.update(
+            original.candidate_id,
+            mutated(original, provenance=later_provenance),
+            expected_revision=0,
+        )
     with pytest.raises(ImmutableCandidateFieldError, match="immutable"):
-        repository.update(original.candidate_id, replace(original, text="different"))
+        repository.update(
+            original.candidate_id,
+            mutated(original, text="different"),
+            expected_revision=0,
+        )
     changed_source = replace(original.provenance, source_logical_name="elsewhere.md")
     with pytest.raises(ImmutableCandidateFieldError, match="immutable"):
-        repository.update(original.candidate_id, replace(original, provenance=changed_source))
+        repository.update(
+            original.candidate_id,
+            mutated(original, provenance=changed_source),
+            expected_revision=0,
+        )
     with pytest.raises(CandidateNotFoundError):
-        repository.update("sha256:genuinely-missing", original)
+        repository.update(
+            "sha256:genuinely-missing", mutated(original), expected_revision=0
+        )
 
 
 def test_aware_timestamp_round_trips(tmp_path: Path) -> None:
@@ -183,7 +262,7 @@ def test_explicit_empty_document_and_deterministic_order_and_bytes(tmp_path: Pat
         "",
         "not json",
         "[]",
-        '{"schema_version":2,"candidates":[]}',
+        '{"schema_version":3,"candidates":[]}',
         '{"schema_version":1,"candidates":{}}',
         '{"schema_version":1,"candidates":[{}]}',
         '{"schema_version":true,"candidates":[]}',
@@ -319,6 +398,395 @@ def test_failed_atomic_replace_preserves_previous_storage(
     assert list(tmp_path.glob(".candidates.json.*.tmp")) == []
 
 
+def test_schema_v1_is_readable_and_successful_update_rewrites_v2(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("legacy"))
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["schema_version"] = 1
+    record = document["candidates"][0]
+    for field in ("proposed_text", "revision", "review_history"):
+        del record[field]
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+    legacy = repository.get(original.candidate_id)
+    assert (legacy.proposed_text, legacy.revision, legacy.review_history) == (None, 0, ())
+    updated = mutated(legacy, proposed_metadata={"legacy": False})
+    updated = replace(updated, proposed_text="reviewed text")
+    repository.update(legacy.candidate_id, updated, expected_revision=0)
+
+    rewritten = json.loads(path.read_text(encoding="utf-8"))
+    assert rewritten["schema_version"] == 2
+    assert repository.get(original.candidate_id) == updated
+
+
+def test_genuine_schema_v1_all_states_round_trip_without_read_rewrite(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.json"
+    legacy_items = [
+        replace(candidate(f"legacy-{state.value}", chunk_index=index), state=state)
+        for index, state in enumerate(CandidateState)
+    ]
+    before = write_schema_v1(path, legacy_items)
+
+    loaded = JsonCandidateRepository(path).list()
+
+    assert path.read_bytes() == before
+    assert {item.state for item in loaded} == set(CandidateState)
+    assert all(item.revision == 0 and item.review_history == () for item in loaded)
+    assert all(
+        item.proposed_metadata == {"legacy": ("kept", {"nested": True})}
+        for item in loaded
+    )
+    assert all(item.provenance.run_metadata == {"legacy_run": (1, 2)} for item in loaded)
+    assert all(
+        item.provenance.transformations == ({"kind": "legacy-transform"},)
+        for item in loaded
+    )
+
+
+def test_first_genuine_schema_v1_mutation_rewrites_every_record_deterministically(
+    tmp_path: Path,
+) -> None:
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+    items = [candidate("legacy-b", chunk_index=1), candidate("legacy-a", chunk_index=0)]
+    write_schema_v1(first_path, items)
+    write_schema_v1(second_path, list(reversed(items)))
+
+    for path in (first_path, second_path):
+        repository = JsonCandidateRepository(path)
+        target = repository.get(items[0].candidate_id)
+        repository.update(
+            target.candidate_id,
+            mutated(target, proposed_metadata={"reviewed": True}),
+            expected_revision=0,
+        )
+
+    first_document = json.loads(first_path.read_text(encoding="utf-8"))
+    assert first_document["schema_version"] == 2
+    assert all(
+        set(record) == json_adapter.CANDIDATE_FIELDS_V2
+        for record in first_document["candidates"]
+    )
+    assert first_path.read_bytes() == second_path.read_bytes()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("revision", True),
+        ("revision", 1),
+        ("proposed_text", "\ud800"),
+        ("proposed_text", "   "),
+    ],
+)
+def test_malformed_v2_candidate_lifecycle_fields_are_controlled(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    path = tmp_path / "malformed-v2.json"
+    repository = JsonCandidateRepository(path)
+    repository.create(candidate("malformed lifecycle"))
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["candidates"][0][field] = value
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(MalformedStagingDataError):
+        repository.list()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("revision", True),
+        ("action", "approved"),
+        ("previous_state", "unknown"),
+        ("resulting_state", "unknown"),
+        ("occurred_at", "2026-07-21T12:00:00"),
+        ("occurred_at", 7),
+        ("reason", ""),
+        ("reason", "bad\ud800"),
+    ],
+)
+def test_malformed_review_event_fields_are_controlled(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    path = tmp_path / "malformed-event.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("event"))
+    repository.update(original.candidate_id, mutated(original), expected_revision=0)
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["candidates"][0]["review_history"][0][field] = value
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(MalformedStagingDataError):
+        repository.list()
+
+
+def test_mixed_schema_record_and_unknown_review_event_field_are_rejected(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "mixed.json"
+    original = candidate("mixed")
+    write_schema_v1(path, [original])
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["candidates"][0].update(
+        {"proposed_text": None, "revision": 0, "review_history": []}
+    )
+    path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(MalformedStagingDataError):
+        JsonCandidateRepository(path).list()
+
+    repository = JsonCandidateRepository(path)
+    repository._write([mutated(original)])
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document["candidates"][0]["review_history"][0]["unknown"] = None
+    path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(MalformedStagingDataError):
+        repository.list()
+
+
+def test_stale_update_and_rewritten_history_leave_bytes_unchanged(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("concurrent"))
+    first = mutated(original)
+    repository.update(original.candidate_id, first, expected_revision=0)
+    before = path.read_bytes()
+
+    with pytest.raises(CandidateRevisionConflictError):
+        repository.update(original.candidate_id, first, expected_revision=0)
+    assert path.read_bytes() == before
+
+    rejected_event = CandidateReviewEvent(
+        revision=2,
+        action=CandidateReviewAction.REJECTED,
+        occurred_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        previous_state=CandidateState.IN_REVIEW,
+        resulting_state=CandidateState.REJECTED,
+    )
+    rewritten_first = replace(
+        first.review_history[0], occurred_at=datetime(2026, 7, 22, tzinfo=timezone.utc)
+    )
+    rewritten = replace(
+        first,
+        state=CandidateState.REJECTED,
+        revision=2,
+        review_history=(rewritten_first, rejected_event),
+    )
+    with pytest.raises(CandidateRevisionConflictError):
+        repository.update(original.candidate_id, rewritten, expected_revision=1)
+    assert path.read_bytes() == before
+
+
+def test_equal_instant_previous_event_timestamp_cannot_be_rewritten(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "event-offset-rewrite.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("event offset"))
+    first = mutated(original)
+    repository.update(original.candidate_id, first, expected_revision=0)
+    before = path.read_bytes()
+
+    rewritten_first = replace(
+        first.review_history[0],
+        occurred_at=first.review_history[0].occurred_at.astimezone(
+            timezone(timedelta(hours=1))
+        ),
+    )
+    rejected_event = CandidateReviewEvent(
+        revision=2,
+        action=CandidateReviewAction.REJECTED,
+        occurred_at=datetime(2026, 7, 21, tzinfo=timezone.utc),
+        previous_state=CandidateState.IN_REVIEW,
+        resulting_state=CandidateState.REJECTED,
+    )
+    rewritten = replace(
+        first,
+        state=CandidateState.REJECTED,
+        revision=2,
+        review_history=(rewritten_first, rejected_event),
+    )
+
+    with pytest.raises(CandidateRevisionConflictError):
+        repository.update(original.candidate_id, rewritten, expected_revision=1)
+    assert path.read_bytes() == before
+
+
+def test_equal_instant_provenance_timestamp_cannot_be_rewritten(tmp_path: Path) -> None:
+    path = tmp_path / "provenance-rewrite.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("provenance representation"))
+    before = path.read_bytes()
+    changed = replace(
+        original.provenance,
+        ingested_at=original.provenance.ingested_at.astimezone(
+            timezone(timedelta(hours=1))
+        ),
+    )
+    assert changed == original.provenance
+
+    with pytest.raises(ImmutableCandidateFieldError):
+        repository.update(
+            original.candidate_id,
+            mutated(original, provenance=changed),
+            expected_revision=0,
+        )
+    assert path.read_bytes() == before
+
+
+def test_equal_comparing_json_metadata_cannot_rewrite_provenance(tmp_path: Path) -> None:
+    path = tmp_path / "provenance-metadata-rewrite.json"
+    repository = JsonCandidateRepository(path)
+    seeded = candidate("provenance metadata")
+    original = repository.create(
+        replace(
+            seeded,
+            provenance=replace(seeded.provenance, run_metadata={"batch": 1}),
+        )
+    )
+    before = path.read_bytes()
+    changed = replace(original.provenance, run_metadata={"batch": True})
+    assert changed == original.provenance
+
+    with pytest.raises(ImmutableCandidateFieldError):
+        repository.update(
+            original.candidate_id,
+            mutated(original, provenance=changed),
+            expected_revision=0,
+        )
+    assert path.read_bytes() == before
+
+
+def test_missing_candidate_id_on_malformed_update_is_controlled(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "missing-update-id.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("missing update id"))
+    malformed = mutated(original)
+    object.__delattr__(malformed, "candidate_id")
+    before = path.read_bytes()
+
+    with pytest.raises(CandidateRevisionConflictError):
+        repository.update(original.candidate_id, malformed, expected_revision=0)
+    assert path.read_bytes() == before
+
+
+def test_malformed_empty_appended_history_is_a_controlled_conflict(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("malformed update"))
+    malformed = replace(original, proposed_metadata={"changed": True})
+    object.__setattr__(malformed, "revision", 1)
+    before = path.read_bytes()
+
+    with pytest.raises(CandidateRevisionConflictError):
+        repository.update(original.candidate_id, malformed, expected_revision=0)
+
+    assert path.read_bytes() == before
+
+
+def test_malformed_appended_event_is_a_controlled_conflict_without_writing(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "malformed-event-update.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("malformed event update"))
+    malformed = replace(original, proposed_metadata={"changed": True})
+    object.__setattr__(malformed, "revision", 1)
+    object.__setattr__(malformed, "review_history", (object(),))
+    before = path.read_bytes()
+
+    with pytest.raises(CandidateRevisionConflictError):
+        repository.update(original.candidate_id, malformed, expected_revision=0)
+
+    assert path.read_bytes() == before
+
+
+def test_all_rejected_update_shapes_preserve_storage_bytes(tmp_path: Path) -> None:
+    path = tmp_path / "rejected-updates.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("immutable"))
+    first = mutated(original)
+    before = path.read_bytes()
+
+    wrong_id = replace(first)
+    object.__setattr__(wrong_id, "candidate_id", "sha256:wrong")
+    two_events = (
+        CandidateReviewEvent(
+            1,
+            CandidateReviewAction.REVISED,
+            datetime(2026, 7, 20, tzinfo=timezone.utc),
+            CandidateState.STAGED,
+            CandidateState.STAGED,
+        ),
+        CandidateReviewEvent(
+            2,
+            CandidateReviewAction.ACCEPTED,
+            datetime(2026, 7, 21, tzinfo=timezone.utc),
+            CandidateState.STAGED,
+            CandidateState.IN_REVIEW,
+        ),
+    )
+    appended_twice = replace(
+        original,
+        state=CandidateState.IN_REVIEW,
+        revision=2,
+        review_history=two_events,
+    )
+    attempts: list[tuple[str, LessonCandidate, int, type[Exception]]] = [
+        (original.candidate_id, first, 1, CandidateRevisionConflictError),
+        (original.candidate_id, original, 0, CandidateRevisionConflictError),
+        (original.candidate_id, appended_twice, 0, CandidateRevisionConflictError),
+        (original.candidate_id, wrong_id, 0, ImmutableCandidateFieldError),
+        (
+            original.candidate_id,
+            mutated(original, text="changed source text"),
+            0,
+            ImmutableCandidateFieldError,
+        ),
+        (
+            original.candidate_id,
+            mutated(
+                original,
+                provenance=replace(original.provenance, source_fingerprint="changed"),
+            ),
+            0,
+            ImmutableCandidateFieldError,
+        ),
+        ("sha256:missing", first, 0, CandidateNotFoundError),
+    ]
+
+    for candidate_id, proposed, expected, error_type in attempts:
+        with pytest.raises(error_type):
+            repository.update(
+                candidate_id, proposed, expected_revision=expected
+            )
+        assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("expected_revision", [True, -1, 1.5, "0"])
+def test_invalid_expected_revision_never_writes(
+    tmp_path: Path, expected_revision: object
+) -> None:
+    path = tmp_path / "invalid-expected.json"
+    repository = JsonCandidateRepository(path)
+    original = repository.create(candidate("expected"))
+    before = path.read_bytes()
+
+    with pytest.raises(ValueError, match="expected revision"):
+        repository.update(
+            original.candidate_id,
+            mutated(original),
+            expected_revision=expected_revision,  # type: ignore[arg-type]
+        )
+
+    assert path.read_bytes() == before
+
+
 def test_staging_never_touches_vault_projection_exports_or_ml_datasets(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     vault.mkdir()
@@ -340,7 +808,11 @@ def test_staging_never_touches_vault_projection_exports_or_ml_datasets(tmp_path:
     staged = repository.create(candidate("isolated"))
     repository.get(staged.candidate_id)
     repository.list()
-    repository.update(staged.candidate_id, replace(staged, state=CandidateState.REJECTED))
+    repository.update(
+        staged.candidate_id,
+        mutated(staged, state=CandidateState.REJECTED),
+        expected_revision=0,
+    )
 
     assert {path: path.read_bytes() for path in protected} == protected
     assert sorted(path.relative_to(tmp_path).as_posix() for path in tmp_path.rglob("*")) == [

--- a/tests/test_candidate_review.py
+++ b/tests/test_candidate_review.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.application.candidate_review import (
+    CandidateReviewConflictError,
+    CandidateReviewFilter,
+    CandidateReviewService,
+    CandidateReviewStorageError,
+    InvalidCandidateReviewInputError,
+    InvalidCandidateTransitionError,
+    ReviewCandidateNotFoundError,
+    StaleCandidateRevisionError,
+)
+from lele_manager.application.lesson_candidate import (
+    CandidateNotFoundError,
+    CandidateProvenance,
+    CandidateRepositoryError,
+    CandidateReviewAction,
+    CandidateRevisionConflictError,
+    CandidateState,
+    DuplicateCandidateIdError,
+    LessonCandidate,
+)
+from lele_manager.application.raw_source import SourceKind
+
+
+NOW = datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
+
+
+def candidate(
+    text: str = "source",
+    *,
+    state: CandidateState = CandidateState.STAGED,
+    fingerprint: str = "fp-a",
+    kind: SourceKind = SourceKind.MARKDOWN,
+    name: str = "a.md",
+    chunk: int | None = 0,
+) -> LessonCandidate:
+    return LessonCandidate(
+        text=text,
+        provenance=CandidateProvenance(
+            source_kind=kind,
+            source_logical_name=name,
+            source_fingerprint=fingerprint,
+            ingested_at=NOW,
+            chunk_index=chunk,
+        ),
+        state=state,
+    )
+
+
+class MemoryRepository:
+    def __init__(self, candidates: list[LessonCandidate]) -> None:
+        self.items = {item.candidate_id: item for item in candidates}
+        self.update_calls = 0
+
+    def create(self, item: LessonCandidate) -> LessonCandidate:
+        self.items[item.candidate_id] = item
+        return item
+
+    def get(self, candidate_id: str) -> LessonCandidate:
+        try:
+            return self.items[candidate_id]
+        except KeyError:
+            raise CandidateNotFoundError("secret adapter path") from None
+
+    def list(self) -> tuple[LessonCandidate, ...]:
+        return tuple(reversed(tuple(self.items.values())))
+
+    def update(
+        self,
+        candidate_id: str,
+        item: LessonCandidate,
+        *,
+        expected_revision: int,
+    ) -> LessonCandidate:
+        self.update_calls += 1
+        current = self.get(candidate_id)
+        if current.revision != expected_revision:
+            raise CandidateRevisionConflictError("adapter race details")
+        self.items[candidate_id] = item
+        return item
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> datetime:
+        self.calls += 1
+        return NOW
+
+
+def service(item: LessonCandidate) -> tuple[CandidateReviewService, MemoryRepository, Clock]:
+    repository = MemoryRepository([item])
+    clock = Clock()
+    return CandidateReviewService(repository, clock), repository, clock
+
+
+def test_revise_accept_and_reject_append_one_event_and_preserve_source() -> None:
+    original = candidate()
+    review, repository, clock = service(original)
+
+    revised = review.revise_candidate(
+        original.candidate_id,
+        expected_revision=0,
+        proposed_text="better\r\ntext",
+        proposed_metadata={"topic": ["testing"]},
+        reason="edited",
+    )
+    assert revised.text == original.text
+    assert revised.provenance == original.provenance
+    assert revised.state is CandidateState.STAGED
+    assert revised.revision == 1
+    assert revised.effective_text == "better\ntext"
+    assert revised.review_history[0].action is CandidateReviewAction.REVISED
+
+    accepted = review.accept_candidate(
+        original.candidate_id, expected_revision=1, reason="ready"
+    )
+    assert accepted.state is CandidateState.IN_REVIEW
+    assert accepted.review_history[-1].action is CandidateReviewAction.ACCEPTED
+
+    rejected = review.reject_candidate(original.candidate_id, expected_revision=2)
+    assert rejected.state is CandidateState.REJECTED
+    assert rejected.review_history[-1].reason is None
+    assert review.get_candidate(original.candidate_id) == rejected
+    assert review.list_candidates(CandidateReviewFilter(state=CandidateState.REJECTED)) == (
+        rejected,
+    )
+    assert repository.update_calls == 3
+    assert clock.calls == 3
+
+
+def test_reject_from_staged_with_reason() -> None:
+    original = candidate()
+    review, _, _ = service(original)
+    rejected = review.reject_candidate(
+        original.candidate_id, expected_revision=0, reason="not useful"
+    )
+    event = rejected.review_history[0]
+    assert (event.previous_state, event.resulting_state, event.reason) == (
+        CandidateState.STAGED,
+        CandidateState.REJECTED,
+        "not useful",
+    )
+
+
+@pytest.mark.parametrize(
+    ("initial", "operation"),
+    [
+        (CandidateState.IN_REVIEW, "revise"),
+        (CandidateState.IN_REVIEW, "accept"),
+        (CandidateState.REJECTED, "revise"),
+        (CandidateState.REJECTED, "reject"),
+        (CandidateState.REJECTED, "accept"),
+        (CandidateState.APPROVED, "revise"),
+        (CandidateState.APPROVED, "accept"),
+        (CandidateState.APPROVED, "reject"),
+    ],
+)
+def test_invalid_and_repeated_transitions_are_controlled(
+    initial: CandidateState, operation: str
+) -> None:
+    original = candidate(state=initial)
+    review, repository, clock = service(original)
+    with pytest.raises(InvalidCandidateTransitionError):
+        if operation == "revise":
+            review.revise_candidate(
+                original.candidate_id,
+                expected_revision=0,
+                proposed_text="new",
+                proposed_metadata=None,
+            )
+        elif operation == "accept":
+            review.accept_candidate(original.candidate_id, expected_revision=0)
+        else:
+            review.reject_candidate(original.candidate_id, expected_revision=0)
+    assert repository.update_calls == 0
+    assert clock.calls == 0
+
+
+def test_stale_input_is_rejected_before_clock_and_update() -> None:
+    original = candidate()
+    review, repository, clock = service(original)
+    with pytest.raises(StaleCandidateRevisionError):
+        review.accept_candidate(original.candidate_id, expected_revision=4)
+    assert clock.calls == 0
+    assert repository.update_calls == 0
+
+
+def test_repeated_revise_is_deterministic_and_appends_exactly_once() -> None:
+    original = candidate()
+    review, repository, clock = service(original)
+    first = review.revise_candidate(
+        original.candidate_id,
+        expected_revision=0,
+        proposed_text="first",
+        proposed_metadata={"version": 1},
+    )
+    second = review.revise_candidate(
+        original.candidate_id,
+        expected_revision=1,
+        proposed_text="second\r\ntext",
+        proposed_metadata={"version": 2},
+    )
+
+    assert second.effective_text == "second\ntext"
+    assert second.proposed_metadata == {"version": 2}
+    assert second.review_history[:-1] == first.review_history
+    assert [event.revision for event in second.review_history] == [1, 2]
+    assert repository.update_calls == 2
+    assert clock.calls == 2
+
+
+def test_repository_race_is_translated_and_sanitized() -> None:
+    original = candidate()
+
+    class RacingRepository(MemoryRepository):
+        def update(self, *args: object, **kwargs: object) -> LessonCandidate:
+            raise CandidateRevisionConflictError("/secret/path and adapter details")
+
+    repository = RacingRepository([original])
+    review = CandidateReviewService(repository, Clock())
+    with pytest.raises(StaleCandidateRevisionError) as caught:
+        review.accept_candidate(original.candidate_id, expected_revision=0)
+    assert "secret" not in str(caught.value)
+
+
+def test_list_is_sorted_and_all_filters_use_and_semantics() -> None:
+    candidates = [
+        candidate("one", fingerprint="fp-a", name="a.md", chunk=0),
+        candidate(
+            "two", fingerprint="fp-b", kind=SourceKind.PLAIN_TEXT,
+            name="b.txt", chunk=1, state=CandidateState.REJECTED,
+        ),
+        candidate("three", fingerprint="fp-a", name="a.md", chunk=2),
+    ]
+    review = CandidateReviewService(MemoryRepository(candidates), Clock())
+    assert [item.candidate_id for item in review.list_candidates()] == sorted(
+        item.candidate_id for item in candidates
+    )
+    assert review.list_candidates(CandidateReviewFilter(state=CandidateState.REJECTED)) == (
+        candidates[1],
+    )
+    assert review.list_candidates(CandidateReviewFilter(source_fingerprint="fp-b")) == (
+        candidates[1],
+    )
+    assert review.list_candidates(CandidateReviewFilter(source_kind=SourceKind.PLAIN_TEXT)) == (
+        candidates[1],
+    )
+    assert review.list_candidates(CandidateReviewFilter(source_logical_name="b.txt")) == (
+        candidates[1],
+    )
+    assert review.list_candidates(CandidateReviewFilter(chunk_index=1)) == (candidates[1],)
+    assert review.list_candidates(
+        CandidateReviewFilter(source_fingerprint="fp-a", chunk_index=2)
+    ) == (candidates[2],)
+
+
+def test_duplicate_list_identity_is_a_controlled_conflict() -> None:
+    original = candidate()
+    repository = MemoryRepository([original])
+    repository.list = lambda: (original, original)  # type: ignore[method-assign]
+    with pytest.raises(CandidateReviewConflictError):
+        CandidateReviewService(repository, Clock()).list_candidates()
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        lambda: object(),
+        lambda: CandidateReviewFilter(source_fingerprint=""),
+        lambda: CandidateReviewFilter(chunk_index=True),
+    ],
+)
+def test_invalid_filter_input_is_controlled(filters: object) -> None:
+    with pytest.raises(InvalidCandidateReviewInputError):
+        value = filters() if callable(filters) else filters
+        CandidateReviewService(MemoryRepository([]), Clock()).list_candidates(value)  # type: ignore[arg-type]
+
+
+def test_invalid_write_input_does_not_call_clock_or_update() -> None:
+    original = candidate()
+    review, repository, clock = service(original)
+    with pytest.raises(InvalidCandidateReviewInputError):
+        review.revise_candidate(
+            original.candidate_id,
+            expected_revision=0,
+            proposed_text="   ",
+            proposed_metadata=None,
+        )
+    assert clock.calls == 0
+    assert repository.update_calls == 0
+
+
+def test_invalid_mutation_payload_does_not_retain_validation_details() -> None:
+    original = candidate()
+    review, repository, clock = service(original)
+
+    with pytest.raises(InvalidCandidateReviewInputError) as caught:
+        review.revise_candidate(
+            original.candidate_id,
+            expected_revision=0,
+            proposed_text="valid",
+            proposed_metadata={"private": object()},
+        )
+
+    assert caught.value.__cause__ is None
+    assert "private" not in str(caught.value)
+    assert repository.update_calls == 0
+    assert clock.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("candidate_id", "expected_revision", "reason"),
+    [
+        ("   ", 0, None),
+        ("sha256:any", True, None),
+        ("sha256:any", -1, None),
+        ("sha256:any", 0, "   "),
+        ("sha256:any", 0, "bad\ud800"),
+    ],
+)
+def test_invalid_public_mutation_scalars_are_controlled_without_writes(
+    candidate_id: str, expected_revision: object, reason: str | None
+) -> None:
+    original = candidate()
+    repository = MemoryRepository([original])
+    if candidate_id == "sha256:any":
+        candidate_id = original.candidate_id
+    clock = Clock()
+    review = CandidateReviewService(repository, clock)
+
+    with pytest.raises(InvalidCandidateReviewInputError):
+        review.accept_candidate(
+            candidate_id,
+            expected_revision=expected_revision,  # type: ignore[arg-type]
+            reason=reason,
+        )
+
+    assert repository.update_calls == 0
+    assert clock.calls == 0
+
+
+def test_missing_candidate_wins_over_invalid_mutation_payload() -> None:
+    review = CandidateReviewService(MemoryRepository([]), Clock())
+
+    with pytest.raises(ReviewCandidateNotFoundError):
+        review.revise_candidate(
+            "sha256:missing",
+            expected_revision=0,
+            proposed_text="   ",
+            proposed_metadata=None,
+            reason="",
+        )
+
+
+def test_stale_revision_wins_over_invalid_mutation_payload() -> None:
+    original = candidate()
+    review, repository, clock = service(original)
+
+    with pytest.raises(StaleCandidateRevisionError):
+        review.revise_candidate(
+            original.candidate_id,
+            expected_revision=1,
+            proposed_text="   ",
+            proposed_metadata=None,
+            reason="",
+        )
+
+    assert repository.update_calls == 0
+    assert clock.calls == 0
+
+
+def test_invalid_transition_wins_over_invalid_mutation_payload() -> None:
+    original = candidate(state=CandidateState.REJECTED)
+    review, repository, clock = service(original)
+
+    with pytest.raises(InvalidCandidateTransitionError):
+        review.revise_candidate(
+            original.candidate_id,
+            expected_revision=0,
+            proposed_text="   ",
+            proposed_metadata=None,
+            reason="",
+        )
+
+    assert repository.update_calls == 0
+    assert clock.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (CandidateNotFoundError("/secret"), ReviewCandidateNotFoundError),
+        (DuplicateCandidateIdError("/secret"), CandidateReviewConflictError),
+        (CandidateRepositoryError("/secret"), CandidateReviewStorageError),
+    ],
+)
+def test_repository_errors_are_translated_without_details(
+    error: CandidateRepositoryError, expected: type[Exception]
+) -> None:
+    class BrokenRepository(MemoryRepository):
+        def list(self) -> tuple[LessonCandidate, ...]:
+            raise error
+
+    review = CandidateReviewService(BrokenRepository([]), Clock())
+    with pytest.raises(expected) as caught:
+        review.list_candidates()
+    assert "secret" not in str(caught.value)
+
+
+def test_unexpected_programming_errors_propagate_unchanged() -> None:
+    failure = RuntimeError("bug")
+
+    class BrokenRepository(MemoryRepository):
+        def list(self) -> tuple[LessonCandidate, ...]:
+            raise failure
+
+    with pytest.raises(RuntimeError) as caught:
+        CandidateReviewService(BrokenRepository([]), Clock()).list_candidates()
+    assert caught.value is failure
+
+
+def test_review_only_changes_staging_file(tmp_path: Path) -> None:
+    protected = [tmp_path / "vault.md", tmp_path / "lessons.jsonl", tmp_path / "ml.csv"]
+    for path in protected:
+        path.write_bytes(b"unchanged")
+    repository = JsonCandidateRepository(tmp_path / "staging" / "candidates.json")
+    original = repository.create(candidate())
+    CandidateReviewService(repository, Clock()).accept_candidate(
+        original.candidate_id, expected_revision=0
+    )
+    assert [path.read_bytes() for path in protected] == [b"unchanged"] * 3

--- a/tests/test_lesson_candidate.py
+++ b/tests/test_lesson_candidate.py
@@ -7,6 +7,8 @@ import pytest
 
 from lele_manager.application.lesson_candidate import (
     CandidateProvenance,
+    CandidateReviewAction,
+    CandidateReviewEvent,
     CandidateState,
     LessonCandidate,
     SourceSpan,
@@ -229,3 +231,162 @@ def test_valid_unicode_is_accepted_without_changing_identity_semantics() -> None
 
     assert candidate.text == "Lezione caffè 😀 \U00020000"
     assert candidate.proposed_metadata == {"descrizione": "caffè \U00020000"}
+
+
+def test_proposed_text_effective_text_and_review_data_do_not_change_identity() -> None:
+    baseline = LessonCandidate("source\r\ntext", provenance())
+    event = CandidateReviewEvent(
+        revision=1,
+        action=CandidateReviewAction.REVISED,
+        occurred_at=datetime(2026, 7, 20, tzinfo=timezone.utc),
+        previous_state=CandidateState.STAGED,
+        resulting_state=CandidateState.STAGED,
+        reason="clarified",
+    )
+    revised = replace(
+        baseline,
+        proposed_text="proposal\rtext",
+        proposed_metadata={"changed": True},
+        revision=1,
+        review_history=(event,),
+    )
+
+    assert baseline.effective_text == "source\ntext"
+    assert revised.effective_text == "proposal\ntext"
+    assert revised.candidate_id == baseline.candidate_id
+    assert revised.review_history == (event,)
+    with pytest.raises(AttributeError):
+        revised.review_history += (event,)
+
+
+@pytest.mark.parametrize("revision", [True, -1, 1.0])
+def test_invalid_candidate_revision_is_rejected(revision: object) -> None:
+    with pytest.raises(ValueError, match="revision"):
+        LessonCandidate("text", provenance(), revision=revision)  # type: ignore[arg-type]
+
+
+def test_review_history_must_be_sequential_and_match_state() -> None:
+    event = CandidateReviewEvent(
+        revision=2,
+        action=CandidateReviewAction.ACCEPTED,
+        occurred_at=datetime(2026, 7, 20, tzinfo=timezone.utc),
+        previous_state=CandidateState.STAGED,
+        resulting_state=CandidateState.IN_REVIEW,
+    )
+    with pytest.raises(ValueError, match="1..revision"):
+        LessonCandidate(
+            "text", provenance(), state=CandidateState.IN_REVIEW,
+            revision=1, review_history=(event,),
+        )
+    with pytest.raises(ValueError, match="final state"):
+        LessonCandidate(
+            "text", provenance(), state=CandidateState.STAGED,
+            revision=1, review_history=(replace(event, revision=1),),
+        )
+
+
+def test_legacy_state_without_review_history_is_permitted() -> None:
+    candidate = LessonCandidate("text", provenance(), state=CandidateState.APPROVED)
+    assert candidate.revision == 0
+    assert candidate.review_history == ()
+
+
+@pytest.mark.parametrize("revision", [True, 0, -1, 1.5])
+def test_review_event_revision_rejects_non_positive_exact_integers(
+    revision: object,
+) -> None:
+    with pytest.raises(ValueError, match="revision"):
+        CandidateReviewEvent(
+            revision=revision,  # type: ignore[arg-type]
+            action=CandidateReviewAction.REVISED,
+            occurred_at=datetime(2026, 7, 20, tzinfo=timezone.utc),
+            previous_state=CandidateState.STAGED,
+            resulting_state=CandidateState.STAGED,
+        )
+
+
+def test_review_event_rejects_naive_timestamp_and_surrogate_reason() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        CandidateReviewEvent(
+            1,
+            CandidateReviewAction.REVISED,
+            datetime(2026, 7, 20),
+            CandidateState.STAGED,
+            CandidateState.STAGED,
+        )
+    with pytest.raises(ValueError, match="surrogate"):
+        CandidateReviewEvent(
+            1,
+            CandidateReviewAction.REVISED,
+            datetime(2026, 7, 20, tzinfo=timezone.utc),
+            CandidateState.STAGED,
+            CandidateState.STAGED,
+            "bad\ud800",
+        )
+    with pytest.raises(ValueError, match="reason"):
+        CandidateReviewEvent(
+            1,
+            CandidateReviewAction.REVISED,
+            datetime(2026, 7, 20, tzinfo=timezone.utc),
+            CandidateState.STAGED,
+            CandidateState.STAGED,
+            "   ",
+        )
+
+
+@pytest.mark.parametrize(
+    ("action", "previous", "resulting"),
+    [
+        (CandidateReviewAction.REVISED, CandidateState.STAGED, CandidateState.IN_REVIEW),
+        (CandidateReviewAction.ACCEPTED, CandidateState.IN_REVIEW, CandidateState.IN_REVIEW),
+        (CandidateReviewAction.REJECTED, CandidateState.APPROVED, CandidateState.REJECTED),
+        (CandidateReviewAction.REJECTED, CandidateState.STAGED, CandidateState.STAGED),
+    ],
+)
+def test_review_event_action_and_state_must_be_internally_consistent(
+    action: CandidateReviewAction,
+    previous: CandidateState,
+    resulting: CandidateState,
+) -> None:
+    with pytest.raises(ValueError, match="transition"):
+        CandidateReviewEvent(
+            1,
+            action,
+            datetime(2026, 7, 20, tzinfo=timezone.utc),
+            previous,
+            resulting,
+        )
+
+
+def test_review_history_rejects_reordered_and_disconnected_events() -> None:
+    revised = CandidateReviewEvent(
+        1,
+        CandidateReviewAction.REVISED,
+        datetime(2026, 7, 20, tzinfo=timezone.utc),
+        CandidateState.STAGED,
+        CandidateState.STAGED,
+    )
+    accepted = CandidateReviewEvent(
+        2,
+        CandidateReviewAction.ACCEPTED,
+        datetime(2026, 7, 20, tzinfo=timezone.utc),
+        CandidateState.STAGED,
+        CandidateState.IN_REVIEW,
+    )
+    with pytest.raises(ValueError, match="1..revision"):
+        LessonCandidate(
+            "text", provenance(), state=CandidateState.IN_REVIEW,
+            revision=2, review_history=(accepted, revised),
+        )
+    disconnected = CandidateReviewEvent(
+        2,
+        CandidateReviewAction.REJECTED,
+        datetime(2026, 7, 20, tzinfo=timezone.utc),
+        CandidateState.IN_REVIEW,
+        CandidateState.REJECTED,
+    )
+    with pytest.raises(ValueError, match="consistent state chain"):
+        LessonCandidate(
+            "text", provenance(), state=CandidateState.REJECTED,
+            revision=2, review_history=(revised, disconnected),
+        )

--- a/tests/test_raw_source_ingestion.py
+++ b/tests/test_raw_source_ingestion.py
@@ -8,6 +8,8 @@ from typing import Sequence
 import pytest
 
 from lele_manager.application.lesson_candidate import (
+    CandidateReviewAction,
+    CandidateReviewEvent,
     CandidateState,
     CandidateStorageError,
     DuplicateCandidateIdError,
@@ -123,10 +125,21 @@ def test_identical_rerun_skips_and_preserves_review_data() -> None:
     settings = ChunkingSettings(max_characters=19)
     first = service(repository).ingest(source(), settings)
     original = repository.candidates[first.candidate_ids[0]]
+    event = CandidateReviewEvent(
+        1,
+        CandidateReviewAction.ACCEPTED,
+        NOW,
+        CandidateState.STAGED,
+        CandidateState.IN_REVIEW,
+        "ready",
+    )
     reviewed = replace(
         original,
         state=CandidateState.IN_REVIEW,
+        proposed_text="reviewed text",
         proposed_metadata={"topic": "kept"},
+        revision=1,
+        review_history=(event,),
     )
     repository.candidates[reviewed.candidate_id] = reviewed
 
@@ -135,6 +148,7 @@ def test_identical_rerun_skips_and_preserves_review_data() -> None:
     assert rerun.created_candidate_ids == ()
     assert rerun.skipped_candidate_ids == first.candidate_ids
     assert repository.candidates[reviewed.candidate_id] is reviewed
+    assert repository.candidates[reviewed.candidate_id] == reviewed
     assert repository.create_calls == list(first.candidate_ids)
 
 


### PR DESCRIPTION
## Summary

- add a backend-neutral lesson-candidate review service;
- separate immutable source text from revisable proposed text;
- record append-only review events and lifecycle transitions;
- add optimistic concurrency through candidate revisions;
- upgrade candidate staging writes to JSON schema version 2 while retaining schema-version-1 read compatibility;
- preserve reviewed candidate data during deterministic ingestion replays.

## Lifecycle

- `STAGED` candidates may be revised, accepted or rejected;
- revision keeps the candidate `STAGED`;
- acceptance moves `STAGED` to `IN_REVIEW`;
- rejection moves `STAGED` or `IN_REVIEW` to `REJECTED`;
- `REJECTED` and `APPROVED` are terminal for the review service;
- approval and publication remain outside this change.

## Safety

- immutable source text and provenance remain unchanged;
- candidate identity excludes proposed content and review state;
- stale writes and invalid transitions return controlled errors;
- rejected candidates remain inspectable;
- review operations never write to the canonical vault, projections, exports or ML datasets.

## Validation

- focused review, repository, domain and ingestion tests: 153 passed;
- complete test suite: 412 passed, 3 skipped;
- Ruff: passed;
- Mypy: passed for 50 source files;
- `git diff --check`: passed.

Closes #122
