### PR TITLE
feat(approval): add candidate approval workflow

### DIFF
--- a/src/lele_manager/adapters/canonical_markdown_vault.py
+++ b/src/lele_manager/adapters/canonical_markdown_vault.py
@@ -1,0 +1,177 @@
+"""Collision-safe filesystem adapter for canonical candidate approval."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import math
+import os
+from pathlib import Path
+import tempfile
+
+from lele_manager.application.candidate_approval import (
+    CanonicalIdentityCollisionError,
+    CanonicalLessonSpec,
+    CanonicalPathCollisionError,
+    CanonicalVaultStorageError,
+    VaultWriteOutcome,
+)
+from lele_manager.cli.import_from_dir import parse_markdown_with_frontmatter
+from lele_manager.core.vault import render_lesson_markdown
+
+
+def _plain(value: object, active: set[int] | None = None) -> object:
+    active = set() if active is None else active
+    if isinstance(value, Mapping):
+        if any(type(key) is not str for key in value):
+            raise CanonicalVaultStorageError(
+                "canonical provenance mapping keys must be strings"
+            )
+        identity = id(value)
+        if identity in active:
+            raise CanonicalVaultStorageError("canonical provenance must not be cyclic")
+        active.add(identity)
+        try:
+            return {key: _plain(value[key], active) for key in sorted(value)}
+        finally:
+            active.remove(identity)
+    if isinstance(value, (list, tuple)):
+        identity = id(value)
+        if identity in active:
+            raise CanonicalVaultStorageError("canonical provenance must not be cyclic")
+        active.add(identity)
+        try:
+            return [_plain(item, active) for item in value]
+        finally:
+            active.remove(identity)
+    if value is None or type(value) in (bool, int, str):
+        return value
+    if type(value) is float and math.isfinite(value):
+        return value
+    raise CanonicalVaultStorageError(
+        "canonical provenance must contain only JSON-compatible values"
+    )
+
+
+class FilesystemCanonicalMarkdownVault:
+    """Publish fully rendered UTF-8 bytes without replacing existing files."""
+
+    def __init__(self, vault_dir: Path) -> None:
+        self._vault_dir = vault_dir
+
+    def publish(self, lesson: CanonicalLessonSpec) -> VaultWriteOutcome:
+        temporary: Path | None = None
+        try:
+            root = self._vault_dir.resolve()
+            destination = (root / lesson.relative_path).resolve()
+            try:
+                destination.relative_to(root)
+            except ValueError:
+                raise CanonicalVaultStorageError(
+                    "invalid relative vault path"
+                ) from None
+            if destination.suffix.lower() != ".md":
+                raise CanonicalVaultStorageError("invalid relative vault path")
+
+            rendered = render_lesson_markdown(
+                lesson_id=lesson.lesson_id,
+                body=lesson.body,
+                topic=lesson.topic,
+                source=lesson.source,
+                importance=lesson.importance,
+                tags=list(lesson.tags),
+                date=lesson.date,
+                title=lesson.title,
+                provenance=_plain(lesson.provenance),  # type: ignore[arg-type]
+            ).encode("utf-8")
+
+            root.mkdir(parents=True, exist_ok=True)
+            for path in sorted(root.rglob("*.md")):
+                content = path.read_bytes()
+                frontmatter, _ = parse_markdown_with_frontmatter(
+                    content.decode("utf-8")
+                )
+                if (
+                    frontmatter.get("id") == lesson.lesson_id
+                    and path.resolve() != destination
+                ):
+                    raise CanonicalIdentityCollisionError("lesson ID exists elsewhere")
+
+            if destination.exists():
+                if not destination.is_file() or destination.read_bytes() != rendered:
+                    raise CanonicalPathCollisionError("destination is occupied")
+                return VaultWriteOutcome.IDENTICAL
+
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                "wb",
+                dir=destination.parent,
+                prefix=f".{destination.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as target:
+                temporary = Path(target.name)
+                target.write(rendered)
+                target.flush()
+                os.fsync(target.fileno())
+            try:
+                os.link(temporary, destination)
+            except FileExistsError:
+                if destination.is_file() and destination.read_bytes() == rendered:
+                    return VaultWriteOutcome.IDENTICAL
+                raise CanonicalPathCollisionError("destination is occupied") from None
+            return VaultWriteOutcome.CREATED
+        except (
+            CanonicalPathCollisionError,
+            CanonicalIdentityCollisionError,
+            CanonicalVaultStorageError,
+        ):
+            raise
+        except (OSError, UnicodeError):
+            raise CanonicalVaultStorageError("vault I/O failed") from None
+        finally:
+            if temporary is not None:
+                try:
+                    temporary.unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+    def verify(self, lesson: CanonicalLessonSpec) -> VaultWriteOutcome:
+        """Verify an approved candidate's exact artifact without creating it."""
+        try:
+            root = self._vault_dir.resolve()
+            destination = (root / lesson.relative_path).resolve()
+            destination.relative_to(root)
+            rendered = render_lesson_markdown(
+                lesson_id=lesson.lesson_id,
+                body=lesson.body,
+                topic=lesson.topic,
+                source=lesson.source,
+                importance=lesson.importance,
+                tags=list(lesson.tags),
+                date=lesson.date,
+                title=lesson.title,
+                provenance=_plain(lesson.provenance),  # type: ignore[arg-type]
+            ).encode("utf-8")
+            for path in sorted(root.rglob("*.md")):
+                content = path.read_bytes()
+                frontmatter, _ = parse_markdown_with_frontmatter(
+                    content.decode("utf-8")
+                )
+                if (
+                    frontmatter.get("id") == lesson.lesson_id
+                    and path.resolve() != destination
+                ):
+                    raise CanonicalIdentityCollisionError("lesson ID exists elsewhere")
+            if not destination.is_file() or destination.read_bytes() != rendered:
+                raise CanonicalPathCollisionError(
+                    "canonical lesson is missing or changed"
+                )
+            return VaultWriteOutcome.IDENTICAL
+        except (
+            CanonicalPathCollisionError,
+            CanonicalIdentityCollisionError,
+            CanonicalVaultStorageError,
+        ):
+            raise
+        except (OSError, UnicodeError, ValueError):
+            raise CanonicalVaultStorageError("vault verification failed") from None

--- a/src/lele_manager/adapters/vault_jsonl_refresh.py
+++ b/src/lele_manager/adapters/vault_jsonl_refresh.py
@@ -1,0 +1,25 @@
+"""Configured aggregate refresh backed by the existing vault-to-JSONL import."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lele_manager.application.candidate_approval import (
+    DerivedRefreshPortError,
+    RefreshOutcome,
+)
+from lele_manager.core.vault import import_vault_to_jsonl
+from lele_manager.core.projection_store import ProjectionStoreError
+
+
+class VaultJsonlRefresh:
+    def __init__(self, vault_dir: Path, output_path: Path) -> None:
+        self._vault_dir = vault_dir
+        self._output_path = output_path
+
+    def refresh(self) -> RefreshOutcome:
+        try:
+            import_vault_to_jsonl(self._vault_dir, self._output_path)
+        except (OSError, UnicodeError, ProjectionStoreError):
+            raise DerivedRefreshPortError("configured refresh failed") from None
+        return RefreshOutcome()

--- a/src/lele_manager/application/candidate_approval.py
+++ b/src/lele_manager/application/candidate_approval.py
@@ -1,0 +1,420 @@
+"""Approve exactly one reviewed candidate into the canonical Markdown vault.
+
+Only the six documented metadata keys are accepted. Unknown keys are rejected;
+generated ``id`` and ``provenance`` therefore cannot be supplied or replaced.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import date, datetime
+from enum import Enum
+import hashlib
+import math
+import re
+import unicodedata
+from typing import Protocol
+
+from lele_manager.application.lesson_candidate import (
+    CandidateNotFoundError,
+    CandidateRepository,
+    CandidateRepositoryError,
+    CandidateReviewAction,
+    CandidateReviewEvent,
+    CandidateRevisionConflictError,
+    CandidateState,
+    DuplicateCandidateIdError,
+    ImmutableCandidateFieldError,
+    LessonCandidate,
+)
+
+
+class VaultWriteOutcome(str, Enum):
+    CREATED = "created"
+    IDENTICAL = "identical"
+
+
+@dataclass(frozen=True)
+class RefreshOutcome:
+    refreshed: bool = True
+
+
+@dataclass(frozen=True)
+class CanonicalLessonSpec:
+    lesson_id: str
+    relative_path: str
+    body: str
+    topic: str
+    source: str
+    importance: int
+    tags: tuple[str, ...]
+    date: str
+    title: str
+    provenance: Mapping[str, object]
+
+
+@dataclass(frozen=True)
+class ApprovalResult:
+    candidate_id: str
+    candidate_revision: int
+    lesson_id: str
+    relative_vault_path: str
+    vault_write_outcome: VaultWriteOutcome
+    candidate_state_changed: bool
+    refresh_outcome: RefreshOutcome
+
+
+class CandidateApprovalError(Exception):
+    """Base class for stable, controlled approval failures."""
+
+
+class InvalidApprovalInputError(CandidateApprovalError):
+    pass
+
+
+class InvalidApprovalMetadataError(CandidateApprovalError):
+    pass
+
+
+class CandidateApprovalNotFoundError(CandidateApprovalError):
+    pass
+
+
+class InvalidApprovalLifecycleError(CandidateApprovalError):
+    pass
+
+
+class StaleApprovalRevisionError(CandidateApprovalError):
+    pass
+
+
+class ApprovalCollisionError(CandidateApprovalError):
+    pass
+
+
+class ApprovalPathCollisionError(ApprovalCollisionError):
+    pass
+
+
+class ApprovalIdentityCollisionError(ApprovalCollisionError):
+    pass
+
+
+class ApprovalVaultStorageError(CandidateApprovalError):
+    pass
+
+
+class ApprovalCandidatePersistenceError(CandidateApprovalError):
+    pass
+
+
+class ApprovalRefreshError(CandidateApprovalError):
+    pass
+
+
+class CanonicalVaultError(Exception):
+    pass
+
+
+class CanonicalVaultStorageError(CanonicalVaultError):
+    pass
+
+
+class CanonicalPathCollisionError(CanonicalVaultError):
+    pass
+
+
+class CanonicalIdentityCollisionError(CanonicalVaultError):
+    pass
+
+
+class DerivedRefreshPortError(Exception):
+    pass
+
+
+class CanonicalMarkdownVault(Protocol):
+    def publish(self, lesson: CanonicalLessonSpec) -> VaultWriteOutcome: ...
+    def verify(self, lesson: CanonicalLessonSpec) -> VaultWriteOutcome: ...
+
+
+class DerivedArtifactRefresh(Protocol):
+    def refresh(self) -> RefreshOutcome: ...
+
+
+class PartialApprovalError(ApprovalCandidatePersistenceError):
+    def __init__(
+        self,
+        candidate_id: str,
+        lesson_id: str,
+        relative_vault_path: str,
+        vault_write_outcome: VaultWriteOutcome,
+    ) -> None:
+        self.candidate_id = candidate_id
+        self.lesson_id = lesson_id
+        self.relative_vault_path = relative_vault_path
+        self.vault_write_outcome = vault_write_outcome
+        super().__init__(
+            "canonical lesson exists but candidate approval was not persisted"
+        )
+
+
+class PartialRefreshError(ApprovalRefreshError):
+    def __init__(self, partial_result: ApprovalResult) -> None:
+        self.partial_result = partial_result
+        super().__init__(
+            "canonical lesson and candidate approval succeeded but refresh failed"
+        )
+
+
+_CANDIDATE_ID = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_METADATA_KEYS = {"topic", "source", "importance", "tags", "date", "title"}
+
+
+def _canonical_provenance_value(
+    value: object, active: set[int] | None = None
+) -> object:
+    """Copy JSON-compatible provenance with recursively sorted object keys."""
+    active = set() if active is None else active
+    if value is None or type(value) in (bool, int, str):
+        return value
+    if type(value) is float:
+        if math.isfinite(value):
+            return value
+        raise InvalidApprovalMetadataError("provenance must be JSON-compatible")
+    if isinstance(value, Mapping):
+        if any(type(key) is not str for key in value):
+            raise InvalidApprovalMetadataError(
+                "provenance mapping keys must be strings"
+            )
+        identity = id(value)
+        if identity in active:
+            raise InvalidApprovalMetadataError("provenance must not be cyclic")
+        active.add(identity)
+        try:
+            return {
+                key: _canonical_provenance_value(value[key], active)
+                for key in sorted(value)
+            }
+        finally:
+            active.remove(identity)
+    if isinstance(value, (list, tuple)):
+        identity = id(value)
+        if identity in active:
+            raise InvalidApprovalMetadataError("provenance must not be cyclic")
+        active.add(identity)
+        try:
+            return [_canonical_provenance_value(item, active) for item in value]
+        finally:
+            active.remove(identity)
+    raise InvalidApprovalMetadataError("provenance must be JSON-compatible")
+
+
+def _string(value: object, field: str) -> str:
+    if type(value) is not str or not value.strip():
+        raise InvalidApprovalMetadataError(f"{field} must be a non-empty string")
+    if any("\ud800" <= char <= "\udfff" for char in value):
+        raise InvalidApprovalMetadataError(f"{field} contains invalid Unicode")
+    return value
+
+
+def _slug(value: str) -> str:
+    ascii_value = (
+        unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode()
+    )
+    return re.sub(r"[^a-z0-9]+", "-", ascii_value.lower()).strip("-")[:60] or "lesson"
+
+
+def canonical_lesson_for(candidate: LessonCandidate) -> CanonicalLessonSpec:
+    metadata = candidate.proposed_metadata
+    if metadata is None or set(metadata) != _METADATA_KEYS:
+        raise InvalidApprovalMetadataError(
+            "proposed metadata must contain exactly topic, source, importance, tags, date and title"
+        )
+    topic = _string(metadata["topic"], "topic")
+    if (
+        topic in (".", "..")
+        or topic != topic.strip()
+        or "/" in topic
+        or "\\" in topic
+        or any(ord(character) < 32 or ord(character) == 127 for character in topic)
+    ):
+        raise InvalidApprovalMetadataError("topic must be one canonical path segment")
+    source = _string(metadata["source"], "source")
+    title = _string(metadata["title"], "title")
+    importance = metadata["importance"]
+    if type(importance) is not int or not 1 <= importance <= 5:
+        raise InvalidApprovalMetadataError(
+            "importance must be an integer from 1 through 5"
+        )
+    raw_tags = metadata["tags"]
+    if (
+        isinstance(raw_tags, (str, bytes))
+        or not isinstance(raw_tags, Sequence)
+        or not raw_tags
+    ):
+        raise InvalidApprovalMetadataError("tags must be a non-empty sequence")
+    tags = tuple(_string(tag, "tag") for tag in raw_tags)
+    raw_date = _string(metadata["date"], "date")
+    try:
+        parsed_date = date.fromisoformat(raw_date)
+    except ValueError:
+        raise InvalidApprovalMetadataError(
+            "date must be a real ISO date in YYYY-MM-DD form"
+        ) from None
+    if parsed_date.isoformat() != raw_date or len(raw_date) != 10:
+        raise InvalidApprovalMetadataError(
+            "date must be a real ISO date in YYYY-MM-DD form"
+        )
+    body = candidate.effective_text
+    if not body.strip():
+        raise InvalidApprovalMetadataError("lesson body must be non-empty")
+    suffix = hashlib.sha256(candidate.candidate_id.encode("ascii")).hexdigest()[:12]
+    stem = f"{raw_date}.{_slug(title)}-{suffix}"
+    lesson_id = f"{topic}/{stem}"
+    provenance = candidate.provenance
+    span = provenance.source_span
+    trace: dict[str, object] = {
+        "candidate_id": candidate.candidate_id,
+        "chunk_index": provenance.chunk_index,
+        "ingested_at": provenance.ingested_at.isoformat(),
+        "run_metadata": _canonical_provenance_value(provenance.run_metadata),
+        "source_fingerprint": provenance.source_fingerprint,
+        "source_kind": provenance.source_kind.value,
+        "source_logical_name": provenance.source_logical_name,
+        "source_span": None if span is None else {"end": span.end, "start": span.start},
+        "transformations": _canonical_provenance_value(provenance.transformations),
+    }
+    return CanonicalLessonSpec(
+        lesson_id,
+        f"{lesson_id}.md",
+        body,
+        topic,
+        source,
+        importance,
+        tags,
+        raw_date,
+        title,
+        trace,
+    )
+
+
+class CandidateApprovalService:
+    def __init__(
+        self,
+        repository: CandidateRepository,
+        vault: CanonicalMarkdownVault,
+        refresh: DerivedArtifactRefresh,
+        clock: Callable[[], datetime],
+    ) -> None:
+        self._repository = repository
+        self._vault = vault
+        self._refresh = refresh
+        self._clock = clock
+
+    @staticmethod
+    def _candidate_error(error: CandidateRepositoryError) -> CandidateApprovalError:
+        if isinstance(error, CandidateNotFoundError):
+            return CandidateApprovalNotFoundError("candidate was not found")
+        if isinstance(error, CandidateRevisionConflictError):
+            return StaleApprovalRevisionError("candidate revision is stale")
+        if isinstance(error, (DuplicateCandidateIdError, ImmutableCandidateFieldError)):
+            return ApprovalCandidatePersistenceError("candidate persistence conflict")
+        return ApprovalCandidatePersistenceError(
+            "candidate persistence operation failed"
+        )
+
+    def _refresh_result(self, partial: ApprovalResult) -> ApprovalResult:
+        try:
+            outcome = self._refresh.refresh()
+        except DerivedRefreshPortError:
+            raise PartialRefreshError(partial) from None
+        return replace(partial, refresh_outcome=outcome)
+
+    def approve(self, candidate_id: str, *, expected_revision: int) -> ApprovalResult:
+        if (
+            type(candidate_id) is not str
+            or _CANDIDATE_ID.fullmatch(candidate_id) is None
+        ):
+            raise InvalidApprovalInputError(
+                "candidate ID must be a canonical SHA-256 identity"
+            )
+        try:
+            current = self._repository.get(candidate_id)
+        except CandidateRepositoryError as error:
+            raise self._candidate_error(error) from None
+        if type(expected_revision) is not int or expected_revision < 0:
+            raise InvalidApprovalInputError(
+                "expected revision must be a non-negative integer"
+            )
+        if current.revision != expected_revision:
+            raise StaleApprovalRevisionError("candidate revision is stale")
+        if current.state not in (CandidateState.IN_REVIEW, CandidateState.APPROVED):
+            raise InvalidApprovalLifecycleError("candidate is not approvable")
+        lesson = canonical_lesson_for(current)
+        try:
+            write_outcome = (
+                self._vault.publish(lesson)
+                if current.state is CandidateState.IN_REVIEW
+                else self._vault.verify(lesson)
+            )
+        except CanonicalPathCollisionError:
+            raise ApprovalPathCollisionError(
+                "canonical lesson path collision"
+            ) from None
+        except CanonicalIdentityCollisionError:
+            raise ApprovalIdentityCollisionError(
+                "canonical lesson identity collision"
+            ) from None
+        except CanonicalVaultStorageError:
+            raise ApprovalVaultStorageError(
+                "canonical vault operation failed"
+            ) from None
+
+        changed = current.state is CandidateState.IN_REVIEW
+        persisted = current
+        if changed:
+            occurred_at = self._clock()
+            event = CandidateReviewEvent(
+                revision=current.revision + 1,
+                action=CandidateReviewAction.APPROVED,
+                occurred_at=occurred_at,
+                previous_state=CandidateState.IN_REVIEW,
+                resulting_state=CandidateState.APPROVED,
+            )
+            approved = replace(
+                current,
+                state=CandidateState.APPROVED,
+                revision=current.revision + 1,
+                review_history=(*current.review_history, event),
+            )
+            try:
+                persisted = self._repository.update(
+                    candidate_id, approved, expected_revision=current.revision
+                )
+                confirmed = self._repository.get(candidate_id)
+            except CandidateRepositoryError:
+                raise PartialApprovalError(
+                    candidate_id, lesson.lesson_id, lesson.relative_path, write_outcome
+                ) from None
+            if (
+                persisted != approved
+                or confirmed.candidate_id != candidate_id
+                or confirmed.revision != current.revision + 1
+                or confirmed != approved
+                or confirmed.review_history[-1] != event
+            ):
+                raise PartialApprovalError(
+                    candidate_id, lesson.lesson_id, lesson.relative_path, write_outcome
+                )
+            persisted = confirmed
+        partial = ApprovalResult(
+            candidate_id,
+            persisted.revision,
+            lesson.lesson_id,
+            lesson.relative_path,
+            write_outcome,
+            changed,
+            RefreshOutcome(refreshed=False),
+        )
+        return self._refresh_result(partial)

--- a/src/lele_manager/application/lesson_candidate.py
+++ b/src/lele_manager/application/lesson_candidate.py
@@ -37,6 +37,7 @@ class CandidateReviewAction(str, Enum):
     REVISED = "revised"
     ACCEPTED = "accepted"
     REJECTED = "rejected"
+    APPROVED = "approved"
 
 
 class CandidateRepositoryError(Exception):
@@ -167,6 +168,11 @@ class CandidateReviewEvent:
         if self.action is CandidateReviewAction.REJECTED and (
             self.previous_state not in (CandidateState.STAGED, CandidateState.IN_REVIEW)
             or self.resulting_state is not CandidateState.REJECTED
+        ):
+            raise ValueError("review event action does not match its state transition")
+        if self.action is CandidateReviewAction.APPROVED and (
+            self.previous_state is not CandidateState.IN_REVIEW
+            or self.resulting_state is not CandidateState.APPROVED
         ):
             raise ValueError("review event action does not match its state transition")
 

--- a/src/lele_manager/core/vault.py
+++ b/src/lele_manager/core/vault.py
@@ -128,6 +128,7 @@ def build_frontmatter(
     tags: List[str],
     date: str,
     title: Optional[str],
+    provenance: Optional[Dict[str, object]] = None,
 ) -> Dict[str, object]:
     frontmatter: Dict[str, object] = {
         "id": lesson_id,
@@ -139,7 +140,36 @@ def build_frontmatter(
     }
     if title:
         frontmatter["title"] = title
+    if provenance is not None:
+        frontmatter["provenance"] = provenance
     return frontmatter
+
+
+def render_lesson_markdown(
+    *,
+    lesson_id: str,
+    body: str,
+    topic: str,
+    source: str,
+    importance: int,
+    tags: List[str],
+    date: str,
+    title: Optional[str] = None,
+    provenance: Optional[Dict[str, object]] = None,
+) -> str:
+    """Render canonical lesson bytes using the established vault conventions."""
+    frontmatter = build_frontmatter(
+        lesson_id=lesson_id,
+        topic=topic,
+        source=source,
+        importance=importance,
+        tags=tags,
+        date=date,
+        title=title,
+        provenance=provenance,
+    )
+    _ = compute_frontmatter_hash(frontmatter)
+    return render_markdown_with_frontmatter(frontmatter, body.strip())
 
 
 def write_lesson_markdown(
@@ -154,6 +184,7 @@ def write_lesson_markdown(
     date: str,
     title: Optional[str] = None,
     relative_path: Optional[str] = None,
+    provenance: Optional[Dict[str, object]] = None,
 ) -> Path:
     """Write or overwrite a lesson markdown file in the vault."""
     vault_dir.mkdir(parents=True, exist_ok=True)
@@ -174,21 +205,19 @@ def write_lesson_markdown(
     except ValueError as exc:
         raise ValueError(f"Refusing to write outside vault: {md_path}") from exc
 
-    frontmatter = build_frontmatter(
+    rendered = render_lesson_markdown(
         lesson_id=lesson_id,
+        body=body,
         topic=topic,
         source=source,
         importance=importance,
         tags=tags,
         date=date,
         title=title,
+        provenance=provenance,
     )
-    _ = compute_frontmatter_hash(frontmatter)
     md_path.parent.mkdir(parents=True, exist_ok=True)
-    md_path.write_text(
-        render_markdown_with_frontmatter(frontmatter, body.strip()),
-        encoding="utf-8",
-    )
+    md_path.write_text(rendered, encoding="utf-8")
     return md_path
 
 

--- a/tests/test_candidate_approval.py
+++ b/tests/test_candidate_approval.py
@@ -1,0 +1,596 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from lele_manager.adapters.canonical_markdown_vault import (
+    FilesystemCanonicalMarkdownVault,
+)
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.adapters.vault_jsonl_refresh import VaultJsonlRefresh
+from lele_manager.application.candidate_approval import (
+    ApprovalIdentityCollisionError,
+    ApprovalPathCollisionError,
+    ApprovalVaultStorageError,
+    CandidateApprovalNotFoundError,
+    CandidateApprovalService,
+    CanonicalLessonSpec,
+    CanonicalVaultStorageError,
+    DerivedRefreshPortError,
+    InvalidApprovalInputError,
+    InvalidApprovalLifecycleError,
+    InvalidApprovalMetadataError,
+    PartialApprovalError,
+    PartialRefreshError,
+    RefreshOutcome,
+    StaleApprovalRevisionError,
+    VaultWriteOutcome,
+    canonical_lesson_for,
+)
+from lele_manager.application.lesson_candidate import (
+    CandidateNotFoundError,
+    CandidateProvenance,
+    CandidateReviewAction,
+    CandidateReviewEvent,
+    CandidateRevisionConflictError,
+    CandidateState,
+    LessonCandidate,
+)
+from lele_manager.application.raw_source import SourceKind, SourceSpan
+from lele_manager.cli.import_from_dir import parse_markdown_with_frontmatter
+from lele_manager.core.doctor import check_markdown_files
+from lele_manager.core.vault import write_lesson_markdown
+
+
+NOW = datetime(2026, 7, 21, 12, tzinfo=timezone.utc)
+
+
+def reviewed(
+    text: str = "Useful lesson", *, fingerprint: str = "sha256:source"
+) -> LessonCandidate:
+    original = LessonCandidate(
+        text,
+        CandidateProvenance(
+            SourceKind.MARKDOWN,
+            "inbox/lesson.md",
+            fingerprint,
+            NOW,
+            2,
+            SourceSpan(10, 23),
+            {"run": "r1"},
+            ({"kind": "trim"},),
+        ),
+        {
+            "topic": "architecture",
+            "source": "book",
+            "importance": 4,
+            "tags": ["design", "boundaries"],
+            "date": "2026-07-20",
+            "title": "Ports & Adapters",
+        },
+    )
+    accepted = CandidateReviewEvent(
+        1,
+        CandidateReviewAction.ACCEPTED,
+        NOW,
+        CandidateState.STAGED,
+        CandidateState.IN_REVIEW,
+    )
+    return replace(
+        original, state=CandidateState.IN_REVIEW, revision=1, review_history=(accepted,)
+    )
+
+
+class Repository:
+    def __init__(self, item: LessonCandidate) -> None:
+        self.item = item
+        self.updates = 0
+        self.fail_update = False
+
+    def create(self, item: LessonCandidate) -> LessonCandidate:
+        self.item = item
+        return item
+
+    def get(self, candidate_id: str) -> LessonCandidate:
+        return self.item
+
+    def list(self) -> tuple[LessonCandidate, ...]:
+        return (self.item,)
+
+    def update(
+        self, candidate_id: str, item: LessonCandidate, *, expected_revision: int
+    ) -> LessonCandidate:
+        self.updates += 1
+        if self.fail_update:
+            raise CandidateRevisionConflictError("secret race")
+        if self.item.revision != expected_revision:
+            raise CandidateRevisionConflictError("race")
+        self.item = item
+        return item
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> datetime:
+        self.calls += 1
+        return NOW
+
+
+class Refresh:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.fail = False
+
+    def refresh(self) -> RefreshOutcome:
+        self.calls += 1
+        if self.fail:
+            raise DerivedRefreshPortError("secret output path")
+        return RefreshOutcome()
+
+
+def setup(tmp_path: Path, item: LessonCandidate | None = None):
+    candidate = item or reviewed()
+    repository, clock, refresh = Repository(candidate), Clock(), Refresh()
+    vault = FilesystemCanonicalMarkdownVault(tmp_path / "vault")
+    service = CandidateApprovalService(repository, vault, refresh, clock)
+    return candidate, repository, vault, refresh, clock, service
+
+
+def test_approval_writes_valid_markdown_and_complete_provenance(tmp_path: Path) -> None:
+    item, repository, _, refresh, clock, service = setup(tmp_path)
+    result = service.approve(item.candidate_id, expected_revision=1)
+
+    path = tmp_path / "vault" / result.relative_vault_path
+    assert result.vault_write_outcome is VaultWriteOutcome.CREATED
+    assert result.candidate_state_changed is True
+    assert repository.item.state is CandidateState.APPROVED
+    assert repository.item.revision == 2
+    assert repository.item.review_history[-1].action is CandidateReviewAction.APPROVED
+    assert clock.calls == refresh.calls == 1
+    assert result.lesson_id == result.relative_vault_path.removesuffix(".md")
+    assert result.relative_vault_path.startswith(
+        "architecture/2026-07-20.ports-adapters-"
+    )
+    frontmatter, body = parse_markdown_with_frontmatter(
+        path.read_text(encoding="utf-8")
+    )
+    assert body.strip() == item.effective_text
+    assert frontmatter["provenance"] == {
+        "candidate_id": item.candidate_id,
+        "chunk_index": 2,
+        "ingested_at": NOW.isoformat(),
+        "run_metadata": {"run": "r1"},
+        "source_fingerprint": "sha256:source",
+        "source_kind": "markdown",
+        "source_logical_name": "inbox/lesson.md",
+        "source_span": {"end": 23, "start": 10},
+        "transformations": [{"kind": "trim"}],
+    }
+    assert check_markdown_files([path], vault_dir=tmp_path / "vault").valid
+
+
+def test_deterministic_identity_and_title_collision_are_separate(
+    tmp_path: Path,
+) -> None:
+    first, _, _, _, _, first_service = setup(
+        tmp_path, reviewed("one", fingerprint="one")
+    )
+    first_result = first_service.approve(first.candidate_id, expected_revision=1)
+    second, _, _, _, _, second_service = setup(
+        tmp_path, reviewed("two", fingerprint="two")
+    )
+    second_result = second_service.approve(second.candidate_id, expected_revision=1)
+    assert first_result.lesson_id != second_result.lesson_id
+    assert first_result.relative_vault_path != second_result.relative_vault_path
+
+
+@pytest.mark.parametrize("state", [CandidateState.STAGED, CandidateState.REJECTED])
+def test_non_reviewed_states_rejected(tmp_path: Path, state: CandidateState) -> None:
+    item = replace(reviewed(), state=state, revision=0, review_history=())
+    item, repository, _, refresh, clock, service = setup(tmp_path, item)
+    with pytest.raises(InvalidApprovalLifecycleError):
+        service.approve(item.candidate_id, expected_revision=0)
+    assert repository.updates == refresh.calls == clock.calls == 0
+    assert not (tmp_path / "vault").exists()
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"importance": True},
+        {"date": "2026-02-30"},
+        {"tags": []},
+        {"topic": "../bad"},
+        {"unknown": "value"},
+    ],
+)
+def test_invalid_metadata_changes_nothing(
+    tmp_path: Path, change: dict[str, object]
+) -> None:
+    item = reviewed()
+    metadata = dict(item.proposed_metadata or {})
+    metadata.update(change)
+    item = replace(item, proposed_metadata=metadata)
+    item, repository, _, refresh, clock, service = setup(tmp_path, item)
+    with pytest.raises(InvalidApprovalMetadataError):
+        service.approve(item.candidate_id, expected_revision=1)
+    assert repository.updates == refresh.calls == clock.calls == 0
+
+
+def test_stale_precedes_vault_clock_and_refresh(tmp_path: Path) -> None:
+    item, repository, _, refresh, clock, service = setup(tmp_path)
+    with pytest.raises(StaleApprovalRevisionError):
+        service.approve(item.candidate_id, expected_revision=0)
+    assert repository.updates == refresh.calls == clock.calls == 0
+    assert not (tmp_path / "vault").exists()
+
+
+def test_collision_never_overwrites(tmp_path: Path) -> None:
+    item, repository, _, refresh, clock, service = setup(tmp_path)
+    from lele_manager.application.candidate_approval import canonical_lesson_for
+
+    path = tmp_path / "vault" / canonical_lesson_for(item).relative_path
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"occupied")
+    with pytest.raises(ApprovalPathCollisionError):
+        service.approve(item.candidate_id, expected_revision=1)
+    assert path.read_bytes() == b"occupied"
+    assert repository.updates == refresh.calls == clock.calls == 0
+
+
+def test_repository_failure_then_retry_recovers_without_rewrite(tmp_path: Path) -> None:
+    item, repository, _, refresh, clock, service = setup(tmp_path)
+    repository.fail_update = True
+    with pytest.raises(PartialApprovalError) as caught:
+        service.approve(item.candidate_id, expected_revision=1)
+    path = tmp_path / "vault" / caught.value.relative_vault_path
+    before = path.stat().st_mtime_ns
+    repository.fail_update = False
+    result = service.approve(item.candidate_id, expected_revision=1)
+    assert result.vault_write_outcome is VaultWriteOutcome.IDENTICAL
+    assert path.stat().st_mtime_ns == before
+    assert clock.calls == 2
+    assert refresh.calls == 1
+
+
+def test_refresh_failure_and_approved_retry_are_idempotent(tmp_path: Path) -> None:
+    item, repository, _, refresh, clock, service = setup(tmp_path)
+    refresh.fail = True
+    with pytest.raises(PartialRefreshError) as caught:
+        service.approve(item.candidate_id, expected_revision=1)
+    assert caught.value.partial_result.candidate_revision == 2
+    refresh.fail = False
+    result = service.approve(item.candidate_id, expected_revision=2)
+    assert result.candidate_state_changed is False
+    assert result.vault_write_outcome is VaultWriteOutcome.IDENTICAL
+    assert repository.updates == 1
+    assert clock.calls == 1
+    assert refresh.calls == 2
+
+
+def test_approved_missing_or_changed_file_is_controlled(tmp_path: Path) -> None:
+    item, repository, _, refresh, clock, service = setup(tmp_path)
+    result = service.approve(item.candidate_id, expected_revision=1)
+    path = tmp_path / "vault" / result.relative_vault_path
+    path.unlink()
+    with pytest.raises(ApprovalPathCollisionError):
+        service.approve(item.candidate_id, expected_revision=2)
+    assert repository.updates == 1
+    assert refresh.calls == 1
+    assert clock.calls == 1
+
+
+def test_nested_provenance_order_has_identical_specification_and_bytes(
+    tmp_path: Path,
+) -> None:
+    left = reviewed()
+    right = LessonCandidate(
+        left.text,
+        CandidateProvenance(
+            left.provenance.source_kind,
+            left.provenance.source_logical_name,
+            left.provenance.source_fingerprint,
+            left.provenance.ingested_at,
+            left.provenance.chunk_index,
+            left.provenance.source_span,
+            {"outer": {"b": 2, "a": 1}, "items": [{"z": 0, "a": 9}]},
+            ({"nested": {"y": 2, "x": 1}},),
+        ),
+        left.proposed_metadata,
+    )
+    left = replace(
+        left,
+        provenance=CandidateProvenance(
+            left.provenance.source_kind,
+            left.provenance.source_logical_name,
+            left.provenance.source_fingerprint,
+            left.provenance.ingested_at,
+            left.provenance.chunk_index,
+            left.provenance.source_span,
+            {"items": [{"a": 9, "z": 0}], "outer": {"a": 1, "b": 2}},
+            ({"nested": {"x": 1, "y": 2}},),
+        ),
+    )
+    right = replace(right, state=left.state, revision=left.revision,
+                    review_history=left.review_history)
+    left_spec, right_spec = canonical_lesson_for(left), canonical_lesson_for(right)
+    assert left_spec == right_spec
+    left_before = left.provenance.run_metadata
+    first = FilesystemCanonicalMarkdownVault(tmp_path / "one")
+    second = FilesystemCanonicalMarkdownVault(tmp_path / "two")
+    first.publish(left_spec)
+    second.publish(right_spec)
+    assert (tmp_path / "one" / left_spec.relative_path).read_bytes() == (
+        tmp_path / "two" / right_spec.relative_path
+    ).read_bytes()
+    assert left.provenance.run_metadata is left_before
+
+
+@pytest.mark.parametrize("field", ["run_metadata", "transformations"])
+def test_cyclic_candidate_provenance_is_controlled_without_mutation(
+    field: str,
+) -> None:
+    item = reviewed()
+    if field == "run_metadata":
+        cyclic: dict[str, object] = {}
+        cyclic["self"] = cyclic
+        hostile: object = cyclic
+    else:
+        sequence: list[object] = []
+        sequence.append(sequence)
+        hostile = sequence
+    object.__setattr__(item.provenance, field, hostile)
+
+    with pytest.raises(InvalidApprovalMetadataError, match="must not be cyclic"):
+        canonical_lesson_for(item)
+
+    assert getattr(item.provenance, field) is hostile
+    if field == "run_metadata":
+        assert cyclic["self"] is cyclic
+    else:
+        assert sequence[0] is sequence
+
+
+def test_shared_non_cyclic_candidate_provenance_is_supported() -> None:
+    item = reviewed()
+    shared = {"value": [1, 2]}
+    run_metadata = {"first": shared, "second": shared}
+    object.__setattr__(item.provenance, "run_metadata", run_metadata)
+
+    spec = canonical_lesson_for(item)
+
+    assert spec.provenance["run_metadata"] == {
+        "first": {"value": [1, 2]},
+        "second": {"value": [1, 2]},
+    }
+    assert item.provenance.run_metadata is run_metadata
+    assert run_metadata["first"] is run_metadata["second"] is shared
+
+
+@pytest.mark.parametrize("bad", [{1: "bad"}, {"bad": object()}])
+def test_unsupported_canonical_provenance_is_controlled(
+    tmp_path: Path, bad: dict[object, object]
+) -> None:
+    spec = canonical_lesson_for(reviewed())
+    hostile = replace(spec, provenance=bad)  # type: ignore[arg-type]
+    with pytest.raises(CanonicalVaultStorageError):
+        FilesystemCanonicalMarkdownVault(tmp_path / "vault").publish(hostile)
+
+
+@pytest.mark.parametrize("container", [dict, list])
+def test_cyclic_canonical_provenance_is_controlled(
+    tmp_path: Path, container: type[dict[object, object]] | type[list[object]]
+) -> None:
+    cyclic: dict[object, object] | list[object] = container()
+    if isinstance(cyclic, dict):
+        cyclic["self"] = cyclic
+    else:
+        cyclic.append(cyclic)
+    spec = canonical_lesson_for(reviewed())
+    hostile = replace(spec, provenance={"cyclic": cyclic})
+
+    with pytest.raises(CanonicalVaultStorageError, match="must not be cyclic"):
+        FilesystemCanonicalMarkdownVault(tmp_path / "vault").publish(hostile)
+
+
+def test_real_repository_approval_persists_complete_candidate(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.json"
+    original = reviewed()
+    repository = JsonCandidateRepository(path)
+    repository.create(original)
+    refresh, clock = Refresh(), Clock()
+    service = CandidateApprovalService(
+        repository, FilesystemCanonicalMarkdownVault(tmp_path / "vault"), refresh, clock
+    )
+    result = service.approve(original.candidate_id, expected_revision=1)
+    loaded = JsonCandidateRepository(path).get(original.candidate_id)
+    assert loaded.state is CandidateState.APPROVED
+    assert loaded.revision == original.revision + 1 == result.candidate_revision
+    assert loaded.review_history[:-1] == original.review_history
+    event = loaded.review_history[-1]
+    assert event.action is CandidateReviewAction.APPROVED
+    assert event.previous_state is CandidateState.IN_REVIEW
+    assert event.resulting_state is CandidateState.APPROVED
+    assert event.occurred_at == NOW
+    assert loaded.text == original.text
+    assert loaded.provenance == original.provenance
+    assert loaded.proposed_text == original.proposed_text
+    assert loaded.proposed_metadata == original.proposed_metadata
+    document = json.loads(path.read_text(encoding="utf-8"))
+    assert document["candidates"][0]["review_history"][-1]["action"] == "approved"
+    before = path.read_bytes()
+    retry = CandidateApprovalService(
+        JsonCandidateRepository(path),
+        FilesystemCanonicalMarkdownVault(tmp_path / "vault"),
+        refresh,
+        clock,
+    ).approve(original.candidate_id, expected_revision=2)
+    assert retry.candidate_state_changed is False
+    assert path.read_bytes() == before
+    assert clock.calls == 1
+    assert refresh.calls == 2
+
+
+class HostileRepository(Repository):
+    def update(self, candidate_id: str, item: LessonCandidate, *, expected_revision: int) -> LessonCandidate:
+        declared = self.item
+        super().update(candidate_id, item, expected_revision=expected_revision)
+        return declared
+
+
+def test_inconsistent_declared_persistence_result_is_partial_and_skips_refresh(
+    tmp_path: Path,
+) -> None:
+    item = reviewed()
+    repository, refresh = HostileRepository(item), Refresh()
+    service = CandidateApprovalService(
+        repository, FilesystemCanonicalMarkdownVault(tmp_path / "vault"), refresh, Clock()
+    )
+    with pytest.raises(PartialApprovalError):
+        service.approve(item.candidate_id, expected_revision=1)
+    assert refresh.calls == 0
+
+
+@pytest.mark.parametrize("error", [OSError("disk"), UnicodeError("encoding")])
+def test_refresh_operational_error_is_sanitized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: Exception
+) -> None:
+    monkeypatch.setattr(
+        "lele_manager.adapters.vault_jsonl_refresh.import_vault_to_jsonl",
+        lambda *_: (_ for _ in ()).throw(error),
+    )
+    with pytest.raises(DerivedRefreshPortError, match="configured refresh failed"):
+        VaultJsonlRefresh(tmp_path / "vault", tmp_path / "out.jsonl").refresh()
+
+
+@pytest.mark.parametrize("error", [RuntimeError("bug"), AssertionError("bug"), ValueError("bug"), SystemExit(2)])
+def test_refresh_programming_errors_propagate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: BaseException
+) -> None:
+    monkeypatch.setattr(
+        "lele_manager.adapters.vault_jsonl_refresh.import_vault_to_jsonl",
+        lambda *_: (_ for _ in ()).throw(error),
+    )
+    with pytest.raises(type(error)):
+        VaultJsonlRefresh(tmp_path / "vault", tmp_path / "out.jsonl").refresh()
+
+
+def test_application_approval_has_no_forbidden_imports() -> None:
+    path = Path("src/lele_manager/application/candidate_approval.py")
+    imported = {
+        alias.name
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module or ""
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, ast.ImportFrom)
+    }
+    forbidden = ("fastapi", "pandas", "lele_manager.cli", "lele_manager.gui", "lele_manager.frontend", "lele_manager.ml")
+    assert not any(name == prefix or name.startswith(prefix + ".") for name in imported for prefix in forbidden)
+
+
+def test_invalid_id_and_missing_candidate_are_typed(tmp_path: Path) -> None:
+    item, repository, _, _, _, service = setup(tmp_path)
+    with pytest.raises(InvalidApprovalInputError):
+        service.approve("bad", expected_revision=1)
+    repository.get = lambda _: (_ for _ in ()).throw(CandidateNotFoundError("secret"))  # type: ignore[method-assign]
+    with pytest.raises(CandidateApprovalNotFoundError):
+        service.approve(item.candidate_id, expected_revision=1)
+
+
+def test_lesson_id_at_another_path_preserves_original_bytes(tmp_path: Path) -> None:
+    item, repository, vault, refresh, clock, service = setup(tmp_path)
+    spec = canonical_lesson_for(item)
+    other = tmp_path / "vault" / "elsewhere.md"
+    other.parent.mkdir(parents=True)
+    write_lesson_markdown(
+        tmp_path / "vault", lesson_id=spec.lesson_id, body="other", topic="x",
+        source="x", importance=1, tags=["x"], date="2026-01-01",
+        relative_path="elsewhere.md",
+    )
+    before = other.read_bytes()
+    with pytest.raises(ApprovalIdentityCollisionError):
+        service.approve(item.candidate_id, expected_revision=1)
+    assert other.read_bytes() == before
+    assert repository.updates == refresh.calls == clock.calls == 0
+
+
+def test_destination_valid_different_id_preserves_original_bytes(tmp_path: Path) -> None:
+    item, repository, _, refresh, clock, service = setup(tmp_path)
+    spec = canonical_lesson_for(item)
+    destination = write_lesson_markdown(
+        tmp_path / "vault", lesson_id="different/id", body="occupied", topic="x",
+        source="x", importance=1, tags=["x"], date="2026-01-01",
+        relative_path=spec.relative_path,
+    )
+    before = destination.read_bytes()
+    with pytest.raises(ApprovalPathCollisionError):
+        service.approve(item.candidate_id, expected_revision=1)
+    assert destination.read_bytes() == before
+    assert repository.updates == refresh.calls == clock.calls == 0
+
+
+class FailingVault:
+    def publish(self, lesson: CanonicalLessonSpec) -> VaultWriteOutcome:
+        raise CanonicalVaultStorageError("secret path")
+
+    def verify(self, lesson: CanonicalLessonSpec) -> VaultWriteOutcome:
+        raise AssertionError("not reached")
+
+
+def test_declared_vault_failure_keeps_candidate_and_skips_refresh(tmp_path: Path) -> None:
+    item, repository, refresh, clock = reviewed(), Repository(reviewed()), Refresh(), Clock()
+    service = CandidateApprovalService(repository, FailingVault(), refresh, clock)
+    with pytest.raises(ApprovalVaultStorageError, match="canonical vault operation failed"):
+        service.approve(item.candidate_id, expected_revision=1)
+    assert repository.item.state is CandidateState.IN_REVIEW
+    assert repository.updates == refresh.calls == clock.calls == 0
+
+
+class RealRaceRepository:
+    def __init__(self, repository: JsonCandidateRepository) -> None:
+        self.repository = repository
+
+    def create(self, item: LessonCandidate) -> LessonCandidate:
+        return self.repository.create(item)
+
+    def get(self, candidate_id: str) -> LessonCandidate:
+        return self.repository.get(candidate_id)
+
+    def list(self) -> tuple[LessonCandidate, ...]:
+        return self.repository.list()
+
+    def update(self, candidate_id: str, item: LessonCandidate, *, expected_revision: int) -> LessonCandidate:
+        self.repository.update(candidate_id, item, expected_revision=expected_revision)
+        raise CandidateRevisionConflictError("lost response after competing update")
+
+
+def test_exact_bytes_recover_after_real_repository_update_race(tmp_path: Path) -> None:
+    candidate_path = tmp_path / "candidates.json"
+    item = reviewed()
+    real = JsonCandidateRepository(candidate_path)
+    real.create(item)
+    vault_path = tmp_path / "vault"
+    service = CandidateApprovalService(
+        RealRaceRepository(real), FilesystemCanonicalMarkdownVault(vault_path), Refresh(), Clock()
+    )
+    with pytest.raises(PartialApprovalError) as caught:
+        service.approve(item.candidate_id, expected_revision=1)
+    lesson_path = vault_path / caught.value.relative_vault_path
+    before = lesson_path.read_bytes()
+    recovered = CandidateApprovalService(
+        JsonCandidateRepository(candidate_path), FilesystemCanonicalMarkdownVault(vault_path),
+        Refresh(), Clock(),
+    ).approve(item.candidate_id, expected_revision=2)
+    assert recovered.candidate_state_changed is False
+    assert recovered.vault_write_outcome is VaultWriteOutcome.IDENTICAL
+    assert lesson_path.read_bytes() == before


### PR DESCRIPTION
## Summary

- add the application workflow for approving one reviewed lesson candidate;
- render and publish deterministic canonical Markdown through the vault boundary;
- preserve candidate provenance in canonical frontmatter;
- mark candidates approved only after the canonical lesson has been written;
- refresh derived JSONL data only after the approved vault artifact exists;
- provide typed results and controlled application errors;
- support deterministic retries, collisions and partial-approval recovery.

## Failure semantics

- validation and collision failures leave the candidate unapproved;
- vault write failures do not mutate candidate state or derived projections;
- candidate persistence is verified before refresh;
- refresh failures after a successful approval are explicitly reported;
- unexpected programming errors are not swallowed.

## Verification

- `209 passed, 1 warning`
- candidate approval tests: `36 passed`
- Ruff: passed
- Mypy: passed for 53 source files
- `git diff --check`: passed

The remaining warning is the pre-existing Starlette `TestClient` deprecation warning.

Closes #123
