### PR TITLE
feat(cli): expose local TritaLeLe workflow

### DIFF
--- a/src/lele_manager/application/candidate_review.py
+++ b/src/lele_manager/application/candidate_review.py
@@ -4,6 +4,7 @@ Lifecycle policy:
 
 - ``STAGED`` candidates may be revised, accepted or rejected.
 - Revision keeps the candidate ``STAGED``.
+- Revision requires an effective change to proposed text or metadata.
 - Acceptance moves a candidate from ``STAGED`` to ``IN_REVIEW``.
 - Rejection moves ``STAGED`` or ``IN_REVIEW`` to ``REJECTED``.
 - ``REJECTED`` and ``APPROVED`` are terminal for this service.
@@ -222,6 +223,15 @@ class CandidateReviewService:
             raise InvalidCandidateReviewInputError(
                 "invalid candidate review input"
             ) from None
+
+        if (
+            action is CandidateReviewAction.REVISED
+            and validated.proposed_text == current.proposed_text
+            and validated.proposed_metadata == current.proposed_metadata
+        ):
+            raise InvalidCandidateReviewInputError(
+                "candidate revision must make an effective change"
+            )
 
         occurred_at = self._clock()
         event = CandidateReviewEvent(

--- a/src/lele_manager/cli/lele.py
+++ b/src/lele_manager/cli/lele.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from lele_manager.cli import tritalele
 from lele_manager.core.doctor import (
     DoctorOperationalError,
     DoctorProblem,
@@ -341,6 +342,8 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Stampa un report JSON stabile.",
     )
+
+    tritalele.register_commands(subparsers)
 
     return parser
 
@@ -844,7 +847,9 @@ def main(argv: Optional[List[str]] = None) -> None:
     base_url = (args.base_url or DEFAULT_BASE_URL).rstrip("/")
 
     try:
-        if args.command == "search":
+        if hasattr(args, "tritalele_command"):
+            code = tritalele.run_command(args)
+        elif args.command == "search":
             code = cmd_search(base_url, args)
         elif args.command == "export":
             code = cmd_export(base_url, args)

--- a/src/lele_manager/cli/tritalele.py
+++ b/src/lele_manager/cli/tritalele.py
@@ -1,0 +1,966 @@
+"""Local, non-HTTP CLI composition for the TritaLeLe review workflow."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from contextlib import redirect_stdout
+from datetime import datetime, timezone
+from enum import Enum
+import io
+import json
+import math
+from pathlib import Path
+import sys
+from typing import Any, TextIO
+
+from lele_manager.adapters.canonical_markdown_vault import (
+    FilesystemCanonicalMarkdownVault,
+)
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.adapters.raw_sources import (
+    MarkdownFileSourceAdapter,
+    PlainTextFileSourceAdapter,
+    RawSourceError,
+    SourceDecodingError,
+    SourceReadError,
+    StdinSourceAdapter,
+    UnsupportedSourceError,
+)
+from lele_manager.adapters.vault_jsonl_refresh import VaultJsonlRefresh
+from lele_manager.application.candidate_approval import (
+    ApprovalCandidatePersistenceError,
+    ApprovalCollisionError,
+    ApprovalIdentityCollisionError,
+    ApprovalPathCollisionError,
+    ApprovalRefreshError,
+    ApprovalResult,
+    ApprovalVaultStorageError,
+    CandidateApprovalError,
+    CandidateApprovalNotFoundError,
+    CandidateApprovalService,
+    InvalidApprovalInputError,
+    InvalidApprovalLifecycleError,
+    InvalidApprovalMetadataError,
+    PartialApprovalError,
+    PartialRefreshError,
+    StaleApprovalRevisionError,
+)
+from lele_manager.application.candidate_review import (
+    CandidateReviewConflictError,
+    CandidateReviewError,
+    CandidateReviewFilter,
+    CandidateReviewService,
+    CandidateReviewStorageError,
+    InvalidCandidateReviewInputError,
+    InvalidCandidateTransitionError,
+    ReviewCandidateNotFoundError,
+    StaleCandidateRevisionError,
+)
+from lele_manager.application.lesson_candidate import CandidateState, LessonCandidate
+from lele_manager.application.raw_source import RawSource, SourceKind
+from lele_manager.application.raw_source_chunking import (
+    ChunkingSettings,
+    DeterministicRawSourceChunker,
+)
+from lele_manager.application.raw_source_ingestion import (
+    IngestionConflictError,
+    IngestionPlanError,
+    IngestionStagingError,
+    PartialIngestionError,
+    RawSourceIngestionError,
+    RawSourceIngestionResult,
+    RawSourceIngestionService,
+)
+from lele_manager.core.paths import candidates_path, lessons_path
+from lele_manager.core.vault import resolve_vault_dir
+
+
+class TritaLeLeCliInputError(Exception):
+    """User input rejected before invoking an application operation."""
+
+
+class TritaLeLeCliConfigurationError(Exception):
+    """Configured local storage could not be resolved."""
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _add_json_option(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Stampa solo JSON stabile.",
+    )
+
+
+def _add_ingestion_leaf(
+    subparsers: Any, name: str, *, help_text: str
+) -> argparse.ArgumentParser:
+    parser = subparsers.add_parser(name, help=help_text)
+    parser.add_argument(
+        "source_path",
+        metavar="PATH|-",
+        help="File .md/.markdown/.txt oppure '-' per stdin UTF-8.",
+    )
+    parser.add_argument(
+        "--max-characters",
+        type=int,
+        default=ChunkingSettings().max_characters,
+        metavar="N",
+        help="Dimensione massima deterministica di ogni chunk (default: 2000).",
+    )
+    _add_json_option(parser)
+    return parser
+
+
+def _add_revision_and_reason(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "candidate_id",
+        metavar="CANDIDATE-ID",
+        help="ID esplicito del candidato.",
+    )
+    parser.add_argument(
+        "--revision",
+        required=True,
+        type=int,
+        metavar="N",
+        help="Revisione attesa per il controllo di concorrenza.",
+    )
+    parser.add_argument(
+        "--reason",
+        help="Motivo opzionale registrato nella cronologia di revisione.",
+    )
+    _add_json_option(parser)
+
+
+def register_commands(subparsers: Any) -> None:
+    """Register the two nested TritaLeLe command groups."""
+    ingest = subparsers.add_parser(
+        "ingest",
+        help="Prepara o mette in staging candidati da una sorgente locale.",
+    )
+    ingest_subparsers = ingest.add_subparsers(
+        dest="ingest_command", required=True, metavar="{preview,create}"
+    )
+    preview = _add_ingestion_leaf(
+        ingest_subparsers,
+        "preview",
+        help_text="Mostra il piano senza scrivere candidati o lesson.",
+    )
+    preview.set_defaults(tritalele_command="ingest_preview")
+    create = _add_ingestion_leaf(
+        ingest_subparsers,
+        "create",
+        help_text="Mette in staging i candidati mancanti, senza approvarli.",
+    )
+    create.set_defaults(tritalele_command="ingest_create")
+
+    candidates = subparsers.add_parser(
+        "candidates",
+        help="Esamina e revisiona i candidati locali.",
+    )
+    candidate_subparsers = candidates.add_subparsers(
+        dest="candidates_command",
+        required=True,
+        metavar="{list,show,update,accept,reject,approve}",
+    )
+
+    list_parser = candidate_subparsers.add_parser(
+        "list", help="Elenca candidati in ordine deterministico."
+    )
+    list_parser.add_argument(
+        "--state", choices=[state.value for state in CandidateState]
+    )
+    list_parser.add_argument(
+        "--source-kind", choices=[kind.value for kind in SourceKind]
+    )
+    list_parser.add_argument("--source-fingerprint")
+    list_parser.add_argument("--source-logical-name")
+    list_parser.add_argument("--chunk-index", type=int)
+    _add_json_option(list_parser)
+    list_parser.set_defaults(tritalele_command="candidates_list")
+
+    show_parser = candidate_subparsers.add_parser(
+        "show", help="Mostra contenuto, provenienza e cronologia di un candidato."
+    )
+    show_parser.add_argument("candidate_id", metavar="CANDIDATE-ID")
+    _add_json_option(show_parser)
+    show_parser.set_defaults(tritalele_command="candidates_show")
+
+    update_parser = candidate_subparsers.add_parser(
+        "update", help="Revisiona proposta testuale o metadati; resta staged."
+    )
+    update_parser.add_argument("candidate_id", metavar="CANDIDATE-ID")
+    update_parser.add_argument("--revision", required=True, type=int, metavar="N")
+    text_group = update_parser.add_mutually_exclusive_group()
+    text_group.add_argument("--text", dest="proposed_text")
+    text_group.add_argument("--text-file", type=Path, metavar="FILE")
+    update_parser.add_argument("--topic")
+    update_parser.add_argument("--source")
+    update_parser.add_argument("--importance", type=int)
+    update_parser.add_argument("--tag", dest="tags", action="append")
+    update_parser.add_argument("--date")
+    update_parser.add_argument("--title")
+    update_parser.add_argument("--reason")
+    _add_json_option(update_parser)
+    update_parser.set_defaults(tritalele_command="candidates_update")
+
+    for command, help_text in (
+        ("accept", "Sposta un candidato staged in revisione."),
+        ("reject", "Rifiuta un candidato staged o in revisione."),
+    ):
+        parser = candidate_subparsers.add_parser(command, help=help_text)
+        _add_revision_and_reason(parser)
+        parser.set_defaults(tritalele_command=f"candidates_{command}")
+
+    approve_parser = candidate_subparsers.add_parser(
+        "approve", help="Approva esattamente un candidato in revisione."
+    )
+    approve_parser.add_argument("candidate_id", metavar="CANDIDATE-ID")
+    approve_parser.add_argument("--revision", required=True, type=int, metavar="N")
+    _add_json_option(approve_parser)
+    approve_parser.set_defaults(tritalele_command="candidates_approve")
+
+
+def _plain_json(value: object) -> object:
+    if isinstance(value, Enum):
+        return _plain_json(value.value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return value.as_posix()
+    if value is None or type(value) in (bool, int, str):
+        return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise TypeError("non-finite values are not JSON-compatible")
+        return value
+    if isinstance(value, Mapping):
+        return {
+            str(key): _plain_json(value[key])
+            for key in sorted(value, key=lambda item: str(item))
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_plain_json(item) for item in value]
+    raise TypeError(f"unsupported JSON value: {type(value).__name__}")
+
+
+def _print_json(value: object, *, file: TextIO | None = None) -> None:
+    target = sys.stdout if file is None else file
+    print(
+        json.dumps(
+            _plain_json(value),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        ),
+        file=target,
+    )
+
+
+def _provenance_dict(candidate: LessonCandidate) -> dict[str, object]:
+    provenance = candidate.provenance
+    span = provenance.source_span
+    return {
+        "source_kind": provenance.source_kind.value,
+        "source_logical_name": provenance.source_logical_name,
+        "source_fingerprint": provenance.source_fingerprint,
+        "ingested_at": provenance.ingested_at.isoformat(),
+        "chunk_index": provenance.chunk_index,
+        "source_span": None if span is None else {"start": span.start, "end": span.end},
+        "run_metadata": _plain_json(provenance.run_metadata),
+        "transformations": _plain_json(provenance.transformations),
+    }
+
+
+def candidate_to_dict(candidate: LessonCandidate) -> dict[str, object]:
+    """Return the stable public representation used by all candidate commands."""
+    return {
+        "candidate_id": candidate.candidate_id,
+        "state": candidate.state.value,
+        "revision": candidate.revision,
+        "original_text": candidate.text,
+        "proposed_text": candidate.proposed_text,
+        "effective_text": candidate.effective_text,
+        "proposed_metadata": _plain_json(candidate.proposed_metadata),
+        "provenance": _provenance_dict(candidate),
+        "review_history": [
+            {
+                "revision": event.revision,
+                "action": event.action.value,
+                "occurred_at": event.occurred_at.isoformat(),
+                "previous_state": event.previous_state.value,
+                "resulting_state": event.resulting_state.value,
+                "reason": event.reason,
+            }
+            for event in candidate.review_history
+        ],
+    }
+
+
+def _approval_dict(result: ApprovalResult) -> dict[str, object]:
+    return {
+        "candidate_id": result.candidate_id,
+        "candidate_revision": result.candidate_revision,
+        "lesson_id": result.lesson_id,
+        "relative_vault_path": result.relative_vault_path,
+        "vault_write_outcome": result.vault_write_outcome.value,
+        "candidate_state_changed": result.candidate_state_changed,
+        "refresh_outcome": {"refreshed": result.refresh_outcome.refreshed},
+    }
+
+
+def _ingestion_dict(
+    result: RawSourceIngestionResult,
+    source: RawSource,
+    settings: ChunkingSettings,
+) -> dict[str, object]:
+    return {
+        "preview": result.preview,
+        "source": {
+            "kind": source.kind.value,
+            "logical_name": source.logical_name,
+            "fingerprint": result.source_fingerprint,
+        },
+        "chunking": {"max_characters": settings.max_characters},
+        "candidate_ids": list(result.candidate_ids),
+        "created_candidate_ids": list(result.created_candidate_ids),
+        "skipped_candidate_ids": list(result.skipped_candidate_ids),
+        "pending_candidate_ids": list(result.pending_candidate_ids),
+        "counts": {
+            "planned": len(result.planned_candidates),
+            "created": result.created_count,
+            "skipped": result.skipped_count,
+            "pending": result.pending_count,
+        },
+        "candidates": [candidate_to_dict(item) for item in result.planned_candidates],
+    }
+
+
+def _candidate_repository() -> JsonCandidateRepository:
+    try:
+        path = candidates_path()
+    except (OSError, RuntimeError):
+        raise TritaLeLeCliConfigurationError(
+            "Lo storage locale dei candidati non è disponibile."
+        ) from None
+    return JsonCandidateRepository(path)
+
+
+def _review_service() -> CandidateReviewService:
+    return CandidateReviewService(_candidate_repository(), _utc_now)
+
+
+def _approval_service() -> CandidateApprovalService:
+    try:
+        vault_dir = resolve_vault_dir()
+        projection_path = lessons_path()
+    except (OSError, RuntimeError):
+        raise TritaLeLeCliConfigurationError(
+            "La configurazione locale di vault o proiezione non è disponibile."
+        ) from None
+    repository = _candidate_repository()
+    return CandidateApprovalService(
+        repository,
+        FilesystemCanonicalMarkdownVault(vault_dir),
+        VaultJsonlRefresh(vault_dir, projection_path),
+        _utc_now,
+    )
+
+
+def _load_source(source_path: str) -> RawSource:
+    if source_path == "-":
+        try:
+            content = sys.stdin.read()
+        except UnicodeDecodeError:
+            raise SourceDecodingError("stdin is not valid UTF-8") from None
+        except OSError:
+            raise SourceReadError("could not read stdin") from None
+        return StdinSourceAdapter().load(content)
+
+    path = Path(source_path)
+    suffix = path.suffix.lower()
+    if suffix in {".md", ".markdown"}:
+        return MarkdownFileSourceAdapter().load(path)
+    if suffix == ".txt":
+        return PlainTextFileSourceAdapter().load(path)
+    raise UnsupportedSourceError("unsupported source extension")
+
+
+def _chunking_settings(raw_max_characters: int) -> ChunkingSettings:
+    try:
+        return ChunkingSettings(max_characters=raw_max_characters)
+    except ValueError:
+        raise TritaLeLeCliInputError(
+            "--max-characters deve essere un intero positivo."
+        ) from None
+
+
+def _print_ingestion_human(result: RawSourceIngestionResult) -> None:
+    if result.preview:
+        print(
+            f"[info] Anteprima: {len(result.planned_candidates)} candidati; "
+            f"{result.pending_count} da creare, {result.skipped_count} già presenti."
+        )
+    else:
+        print(
+            f"[ok] Staging completato: {result.created_count} creati, "
+            f"{result.skipped_count} già presenti."
+        )
+    if not result.planned_candidates:
+        print("[info] Nessun candidato pianificato.")
+        return
+    created = set(result.created_candidate_ids)
+    skipped = set(result.skipped_candidate_ids)
+    for candidate in result.planned_candidates:
+        if candidate.candidate_id in created:
+            outcome = "created"
+        elif candidate.candidate_id in skipped:
+            outcome = "skipped"
+        else:
+            outcome = "pending"
+        print(
+            f"- {candidate.candidate_id} | "
+            f"chunk={candidate.provenance.chunk_index} | {outcome}"
+        )
+
+
+def _run_ingest(args: argparse.Namespace, *, preview: bool) -> int:
+    source = _load_source(args.source_path)
+    settings = _chunking_settings(args.max_characters)
+    result = RawSourceIngestionService(
+        DeterministicRawSourceChunker(), _candidate_repository(), _utc_now
+    ).ingest(source, settings, preview=preview)
+    payload = _ingestion_dict(result, source, settings)
+    if args.json:
+        _print_json(payload)
+    else:
+        _print_ingestion_human(result)
+    return 0
+
+
+def _print_candidate_summary(candidate: LessonCandidate, *, prefix: str) -> None:
+    print(
+        f"{prefix} {candidate.candidate_id} | stato={candidate.state.value} | "
+        f"revisione={candidate.revision}"
+    )
+
+
+def _run_candidates_list(args: argparse.Namespace) -> int:
+    filters = CandidateReviewFilter(
+        state=None if args.state is None else CandidateState(args.state),
+        source_kind=(
+            None if args.source_kind is None else SourceKind(args.source_kind)
+        ),
+        source_fingerprint=args.source_fingerprint,
+        source_logical_name=args.source_logical_name,
+        chunk_index=args.chunk_index,
+    )
+    candidates = _review_service().list_candidates(filters)
+    if args.json:
+        _print_json(
+            {
+                "count": len(candidates),
+                "candidates": [candidate_to_dict(item) for item in candidates],
+            }
+        )
+    elif not candidates:
+        print("[info] Nessun candidato trovato.")
+    else:
+        print(f"[info] Candidati: {len(candidates)}")
+        for candidate in candidates:
+            provenance = candidate.provenance
+            print(
+                f"- {candidate.candidate_id} | stato={candidate.state.value} | "
+                f"revisione={candidate.revision} | "
+                f"sorgente={provenance.source_logical_name} | "
+                f"chunk={provenance.chunk_index}"
+            )
+    return 0
+
+
+def _print_candidate_human(candidate: LessonCandidate) -> None:
+    provenance = candidate.provenance
+    span = provenance.source_span
+    print(f"ID: {candidate.candidate_id}")
+    print(f"Stato: {candidate.state.value}")
+    print(f"Revisione: {candidate.revision}")
+    print("[info] Provenienza")
+    print(f"  kind: {provenance.source_kind.value}")
+    print(f"  nome logico: {provenance.source_logical_name}")
+    print(f"  fingerprint: {provenance.source_fingerprint}")
+    print(f"  acquisito: {provenance.ingested_at.isoformat()}")
+    print(f"  chunk: {provenance.chunk_index}")
+    print(
+        "  intervallo: "
+        + ("-" if span is None else f"{span.start}:{span.end}")
+    )
+    print("  run metadata: " + json.dumps(_plain_json(provenance.run_metadata)))
+    print("  trasformazioni: " + json.dumps(_plain_json(provenance.transformations)))
+    print("[info] Testo originale")
+    print(candidate.text)
+    print("[info] Testo proposto")
+    print(candidate.proposed_text if candidate.proposed_text is not None else "-")
+    print("[info] Testo effettivo")
+    print(candidate.effective_text)
+    print("[info] Metadati proposti")
+    print(
+        json.dumps(
+            _plain_json(candidate.proposed_metadata),
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    print("[info] Cronologia revisione")
+    if not candidate.review_history:
+        print("  (vuota)")
+    for event in candidate.review_history:
+        reason = f" | motivo={event.reason}" if event.reason else ""
+        print(
+            f"  r{event.revision} {event.action.value}: "
+            f"{event.previous_state.value}->{event.resulting_state.value} | "
+            f"{event.occurred_at.isoformat()}{reason}"
+        )
+
+
+def _run_candidates_show(args: argparse.Namespace) -> int:
+    candidate = _review_service().get_candidate(args.candidate_id)
+    if args.json:
+        _print_json(candidate_to_dict(candidate))
+    else:
+        _print_candidate_human(candidate)
+    return 0
+
+
+def _read_proposed_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="strict")
+    except UnicodeDecodeError:
+        raise TritaLeLeCliInputError(
+            "Il file del testo proposto non è UTF-8 valido."
+        ) from None
+    except OSError:
+        raise TritaLeLeCliInputError(
+            "Impossibile leggere il file del testo proposto."
+        ) from None
+
+
+def _metadata_from_args(args: argparse.Namespace) -> dict[str, object] | None:
+    values = {
+        "topic": args.topic,
+        "source": args.source,
+        "importance": args.importance,
+        "tags": args.tags,
+        "date": args.date,
+        "title": args.title,
+    }
+    supplied = [value is not None for value in values.values()]
+    if any(supplied) and not all(supplied):
+        raise TritaLeLeCliInputError(
+            "I metadati richiedono insieme --topic, --source, --importance, "
+            "almeno un --tag, --date e --title."
+        )
+    if not any(supplied):
+        return None
+    return {
+        "topic": args.topic,
+        "source": args.source,
+        "importance": args.importance,
+        "tags": list(args.tags),
+        "date": args.date,
+        "title": args.title,
+    }
+
+
+def _run_candidates_update(args: argparse.Namespace) -> int:
+    metadata = _metadata_from_args(args)
+    text_requested = args.proposed_text is not None or args.text_file is not None
+    if not text_requested and metadata is None:
+        raise TritaLeLeCliInputError(
+            "update richiede un nuovo testo o il set completo di metadati."
+        )
+    proposed_text = (
+        _read_proposed_text(args.text_file)
+        if args.text_file is not None
+        else args.proposed_text
+    )
+    service = _review_service()
+    current = service.get_candidate(args.candidate_id)
+    updated = service.revise_candidate(
+        args.candidate_id,
+        expected_revision=args.revision,
+        proposed_text=current.proposed_text if not text_requested else proposed_text,
+        proposed_metadata=(
+            current.proposed_metadata if metadata is None else metadata
+        ),
+        reason=args.reason,
+    )
+    if args.json:
+        _print_json(candidate_to_dict(updated))
+    else:
+        _print_candidate_summary(updated, prefix="[ok]")
+    return 0
+
+
+def _run_candidates_accept(args: argparse.Namespace) -> int:
+    updated = _review_service().accept_candidate(
+        args.candidate_id,
+        expected_revision=args.revision,
+        reason=args.reason,
+    )
+    payload = {
+        "candidate_id": updated.candidate_id,
+        "state": updated.state.value,
+        "revision": updated.revision,
+    }
+    if args.json:
+        _print_json(payload)
+    else:
+        _print_candidate_summary(updated, prefix="[ok]")
+    return 0
+
+
+def _run_candidates_reject(args: argparse.Namespace) -> int:
+    updated = _review_service().reject_candidate(
+        args.candidate_id,
+        expected_revision=args.revision,
+        reason=args.reason,
+    )
+    payload = {
+        "candidate_id": updated.candidate_id,
+        "state": updated.state.value,
+        "revision": updated.revision,
+    }
+    if args.json:
+        _print_json(payload)
+    else:
+        _print_candidate_summary(updated, prefix="[ok]")
+    return 0
+
+
+def _run_candidates_approve(args: argparse.Namespace) -> int:
+    # The established vault importer is also used by a standalone human CLI and
+    # prints progress. This command owns its output contract, so keep that legacy
+    # progress text out of both JSON and the concise renderer below.
+    with redirect_stdout(io.StringIO()):
+        result = _approval_service().approve(
+            args.candidate_id, expected_revision=args.revision
+        )
+    payload = _approval_dict(result)
+    if args.json:
+        _print_json(payload)
+    else:
+        print(
+            f"[ok] {result.candidate_id} | "
+            f"revisione={result.candidate_revision}"
+        )
+        print(f"[info] lesson ID: {result.lesson_id}")
+        print(f"[info] path vault: {result.relative_vault_path}")
+        print(f"[info] scrittura vault: {result.vault_write_outcome.value}")
+        print(f"[info] stato candidato modificato: {result.candidate_state_changed}")
+        print(f"[info] proiezione aggiornata: {result.refresh_outcome.refreshed}")
+    return 0
+
+
+def _format_detail(value: object) -> str:
+    plain = _plain_json(value)
+    if isinstance(plain, list):
+        return ", ".join(str(item) for item in plain) if plain else "(nessuno)"
+    if plain is None:
+        return "-"
+    return str(plain)
+
+
+def _emit_error(
+    args: argparse.Namespace,
+    *,
+    error_code: str,
+    message: str,
+    exit_code: int,
+    details: Mapping[str, object] | None = None,
+) -> int:
+    details = {} if details is None else dict(details)
+    if getattr(args, "json", False):
+        _print_json(
+            {
+                "error": {
+                    "code": error_code,
+                    "message": message,
+                    "details": details,
+                }
+            },
+            file=sys.stderr,
+        )
+    else:
+        print(f"[errore] {message}", file=sys.stderr)
+        for name in sorted(details):
+            print(f"[info] {name}: {_format_detail(details[name])}", file=sys.stderr)
+    return exit_code
+
+
+def _raw_source_error(args: argparse.Namespace, error: RawSourceError) -> int:
+    if isinstance(error, UnsupportedSourceError):
+        code, message = "unsupported_source", "Tipo di sorgente non supportato."
+    elif isinstance(error, SourceDecodingError):
+        code, message = "invalid_source_encoding", "La sorgente non è UTF-8 valida."
+    elif isinstance(error, SourceReadError):
+        code, message = "source_unavailable", "Impossibile leggere la sorgente."
+    else:
+        code, message = "invalid_source", "La sorgente non è valida."
+    return _emit_error(
+        args, error_code=code, message=message, exit_code=2
+    )
+
+
+def _ingestion_error(args: argparse.Namespace, error: RawSourceIngestionError) -> int:
+    if isinstance(error, PartialIngestionError):
+        return _emit_error(
+            args,
+            error_code="partial_ingestion",
+            message="Ingestione parziale; ripetere il comando per completarla.",
+            exit_code=1,
+            details={
+                "created_candidate_ids": error.created_candidate_ids,
+                "failed_candidate_id": error.failed_candidate_id,
+                "remaining_candidate_ids": error.remaining_candidate_ids,
+            },
+        )
+    if isinstance(error, IngestionConflictError):
+        return _emit_error(
+            args,
+            error_code="ingestion_conflict",
+            message="Conflitto nell'identità di un candidato.",
+            exit_code=1,
+            details={
+                "candidate_id": error.candidate_id,
+                "created_candidate_ids": error.created_candidate_ids,
+            },
+        )
+    if isinstance(error, IngestionStagingError):
+        return _emit_error(
+            args,
+            error_code="candidate_storage_unavailable",
+            message="Lo storage locale dei candidati non è disponibile o è malformato.",
+            exit_code=2,
+            details={
+                "failed_candidate_id": error.failed_candidate_id,
+                "remaining_candidate_ids": error.remaining_candidate_ids,
+            },
+        )
+    if isinstance(error, IngestionPlanError):
+        return _emit_error(
+            args,
+            error_code="ingestion_plan_failed",
+            message="Non è stato possibile costruire il piano di ingestione.",
+            exit_code=1,
+        )
+    return _emit_error(
+        args,
+        error_code="ingestion_failed",
+        message="Ingestione non completata.",
+        exit_code=1,
+    )
+
+
+def _review_error(args: argparse.Namespace, error: CandidateReviewError) -> int:
+    if isinstance(error, InvalidCandidateReviewInputError):
+        code, message, exit_code = (
+            "invalid_candidate_input",
+            "Input di revisione non valido.",
+            2,
+        )
+    elif isinstance(error, ReviewCandidateNotFoundError):
+        code, message, exit_code = (
+            "candidate_not_found",
+            "Candidato non trovato.",
+            1,
+        )
+    elif isinstance(error, StaleCandidateRevisionError):
+        code, message, exit_code = (
+            "stale_candidate_revision",
+            "La revisione attesa del candidato non è più corrente.",
+            1,
+        )
+    elif isinstance(error, InvalidCandidateTransitionError):
+        code, message, exit_code = (
+            "invalid_candidate_transition",
+            "Transizione di stato non consentita.",
+            1,
+        )
+    elif isinstance(error, CandidateReviewConflictError):
+        code, message, exit_code = (
+            "candidate_conflict",
+            "Conflitto nell'identità del candidato.",
+            1,
+        )
+    elif isinstance(error, CandidateReviewStorageError):
+        code, message, exit_code = (
+            "candidate_storage_unavailable",
+            "Lo storage locale dei candidati non è disponibile o è malformato.",
+            2,
+        )
+    else:
+        code, message, exit_code = (
+            "candidate_review_failed",
+            "Operazione di revisione non completata.",
+            1,
+        )
+    return _emit_error(
+        args, error_code=code, message=message, exit_code=exit_code
+    )
+
+
+def _approval_error(args: argparse.Namespace, error: CandidateApprovalError) -> int:
+    if isinstance(error, PartialRefreshError):
+        return _emit_error(
+            args,
+            error_code="partial_refresh",
+            message=(
+                "Lesson e candidato approvato sono persistiti, ma il refresh è fallito; "
+                "ripetere approve con la revisione risultante."
+            ),
+            exit_code=1,
+            details=_approval_dict(error.partial_result),
+        )
+    if isinstance(error, PartialApprovalError):
+        return _emit_error(
+            args,
+            error_code="partial_approval",
+            message=(
+                "La lesson canonica esiste, ma la persistenza dell'approvazione non "
+                "è stata confermata; verificare candidates show e ripetere approve "
+                "con la revisione corrente."
+            ),
+            exit_code=1,
+            details={
+                "candidate_id": error.candidate_id,
+                "lesson_id": error.lesson_id,
+                "relative_vault_path": error.relative_vault_path,
+                "vault_write_outcome": error.vault_write_outcome.value,
+                "candidate_state_changed": None,
+                "refresh_outcome": {"refreshed": False},
+            },
+        )
+    if isinstance(error, InvalidApprovalInputError):
+        code, message, exit_code = (
+            "invalid_approval_input",
+            "Input di approvazione non valido.",
+            2,
+        )
+    elif isinstance(error, InvalidApprovalMetadataError):
+        code, message, exit_code = (
+            "invalid_approval_metadata",
+            "I metadati proposti non sono completi o validi per l'approvazione.",
+            2,
+        )
+    elif isinstance(error, CandidateApprovalNotFoundError):
+        code, message, exit_code = (
+            "candidate_not_found",
+            "Candidato non trovato.",
+            1,
+        )
+    elif isinstance(error, StaleApprovalRevisionError):
+        code, message, exit_code = (
+            "stale_candidate_revision",
+            "La revisione attesa del candidato non è più corrente.",
+            1,
+        )
+    elif isinstance(error, InvalidApprovalLifecycleError):
+        code, message, exit_code = (
+            "invalid_candidate_transition",
+            "Il candidato non è in uno stato approvabile.",
+            1,
+        )
+    elif isinstance(error, ApprovalPathCollisionError):
+        code, message, exit_code = (
+            "vault_path_collision",
+            "Collisione sul path canonico della lesson.",
+            1,
+        )
+    elif isinstance(error, ApprovalIdentityCollisionError):
+        code, message, exit_code = (
+            "vault_identity_collision",
+            "Collisione sull'identità canonica della lesson.",
+            1,
+        )
+    elif isinstance(error, ApprovalCollisionError):
+        code, message, exit_code = (
+            "vault_collision",
+            "Collisione nella pubblicazione canonica.",
+            1,
+        )
+    elif isinstance(error, ApprovalVaultStorageError):
+        code, message, exit_code = (
+            "vault_storage_unavailable",
+            "Il vault canonico non è disponibile.",
+            2,
+        )
+    elif isinstance(error, ApprovalCandidatePersistenceError):
+        code, message, exit_code = (
+            "candidate_storage_unavailable",
+            "Lo storage locale dei candidati non è disponibile o è malformato.",
+            2,
+        )
+    elif isinstance(error, ApprovalRefreshError):
+        code, message, exit_code = (
+            "refresh_failed",
+            "Il refresh della proiezione derivata non è riuscito.",
+            2,
+        )
+    else:
+        code, message, exit_code = (
+            "approval_failed",
+            "Approvazione non completata.",
+            1,
+        )
+    return _emit_error(
+        args, error_code=code, message=message, exit_code=exit_code
+    )
+
+
+_HANDLERS = {
+    "ingest_preview": lambda args: _run_ingest(args, preview=True),
+    "ingest_create": lambda args: _run_ingest(args, preview=False),
+    "candidates_list": _run_candidates_list,
+    "candidates_show": _run_candidates_show,
+    "candidates_update": _run_candidates_update,
+    "candidates_accept": _run_candidates_accept,
+    "candidates_reject": _run_candidates_reject,
+    "candidates_approve": _run_candidates_approve,
+}
+
+
+def run_command(args: argparse.Namespace) -> int:
+    """Dispatch one registered leaf and translate only controlled failures."""
+    try:
+        handler = _HANDLERS[args.tritalele_command]
+    except KeyError:
+        raise RuntimeError("unregistered TritaLeLe command") from None
+    try:
+        return handler(args)
+    except TritaLeLeCliInputError as error:
+        return _emit_error(
+            args,
+            error_code="invalid_cli_input",
+            message=str(error),
+            exit_code=2,
+        )
+    except TritaLeLeCliConfigurationError as error:
+        return _emit_error(
+            args,
+            error_code="local_configuration_unavailable",
+            message=str(error),
+            exit_code=2,
+        )
+    except RawSourceError as error:
+        return _raw_source_error(args, error)
+    except RawSourceIngestionError as error:
+        return _ingestion_error(args, error)
+    except CandidateReviewError as error:
+        return _review_error(args, error)
+    except CandidateApprovalError as error:
+        return _approval_error(args, error)

--- a/src/lele_manager/core/paths.py
+++ b/src/lele_manager/core/paths.py
@@ -18,6 +18,7 @@ ENV_DATA_PATH_DEPRECATED = "LELE_DATA_PATH"
 ENV_MODEL_PATH_DEPRECATED = "LELE_MODEL_PATH"
 
 DEFAULT_DB_FILENAME = "lessons.jsonl"
+DEFAULT_CANDIDATES_FILENAME = "candidates.json"
 DEFAULT_TOPIC_MODEL_FILENAME = "topic_model.joblib"
 
 
@@ -88,6 +89,11 @@ def lessons_path() -> Path:
     p = data_dir() / DEFAULT_DB_FILENAME
     p.parent.mkdir(parents=True, exist_ok=True)
     return p
+
+
+def candidates_path() -> Path:
+    """Full path to the local TritaLeLe candidate staging document."""
+    return data_dir() / DEFAULT_CANDIDATES_FILENAME
 
 
 def topic_model_path() -> Path:

--- a/tests/test_candidate_review.py
+++ b/tests/test_candidate_review.py
@@ -218,6 +218,31 @@ def test_repeated_revise_is_deterministic_and_appends_exactly_once() -> None:
     assert clock.calls == 2
 
 
+def test_revise_requires_an_effective_proposal_change() -> None:
+    original = candidate()
+    review, repository, clock = service(original)
+    revised = review.revise_candidate(
+        original.candidate_id,
+        expected_revision=0,
+        proposed_text="reviewed text\r\n",
+        proposed_metadata={"topic": ["testing"]},
+    )
+    before = repository.items[original.candidate_id]
+
+    with pytest.raises(InvalidCandidateReviewInputError):
+        review.revise_candidate(
+            original.candidate_id,
+            expected_revision=1,
+            proposed_text="reviewed text\n",
+            proposed_metadata={"topic": ["testing"]},
+        )
+
+    assert revised == before
+    assert repository.items[original.candidate_id] == before
+    assert repository.update_calls == 1
+    assert clock.calls == 1
+
+
 def test_repository_race_is_translated_and_sanitized() -> None:
     original = candidate()
 

--- a/tests/test_cli_tritalele.py
+++ b/tests/test_cli_tritalele.py
@@ -1,0 +1,1195 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.application.candidate_approval import canonical_lesson_for
+from lele_manager.application.lesson_candidate import (
+    CandidateRevisionConflictError,
+    CandidateState,
+    CandidateStorageError,
+    DuplicateCandidateIdError,
+)
+from lele_manager.cli import lele as lele_cli
+from lele_manager.cli import tritalele
+from lele_manager.core.paths import candidates_path
+
+
+def run_cli(argv: list[str]) -> int:
+    with pytest.raises(SystemExit) as caught:
+        lele_cli.main(argv)
+    assert isinstance(caught.value.code, int)
+    return caught.value.code
+
+
+@pytest.fixture
+def local_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Path]:
+    paths = {
+        "data": tmp_path / "data",
+        "candidates": tmp_path / "data" / "candidates.json",
+        "lessons": tmp_path / "data" / "lessons.jsonl",
+        "vault": tmp_path / "vault",
+    }
+    monkeypatch.setenv("LELE_DATA_DIR", str(paths["data"]))
+    monkeypatch.setenv("LELE_VAULT_DIR", str(paths["vault"]))
+    monkeypatch.delenv("LELE_DATA_PATH", raising=False)
+    return paths
+
+
+def parsed_stdout(capsys: pytest.CaptureFixture[str]) -> object:
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    return json.loads(captured.out)
+
+
+def create_source(
+    tmp_path: Path,
+    *,
+    name: str = "source.md",
+    content: str = "# First\n\nalpha\n\n# Second\n\nbeta\n",
+) -> Path:
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def create_one_candidate(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    name: str = "one.md",
+    content: str = "A useful lesson.\n",
+) -> str:
+    source = create_source(tmp_path, name=name, content=content)
+    assert run_cli(["ingest", "create", str(source), "--json"]) == 0
+    payload = parsed_stdout(capsys)
+    assert isinstance(payload, dict)
+    candidate_ids = payload["candidate_ids"]
+    assert isinstance(candidate_ids, list) and len(candidate_ids) == 1
+    return str(candidate_ids[0])
+
+
+def complete_metadata_args() -> list[str]:
+    return [
+        "--topic",
+        "architecture",
+        "--source",
+        "book",
+        "--importance",
+        "4",
+        "--tag",
+        "design",
+        "--tag",
+        "boundaries",
+        "--date",
+        "2026-07-22",
+        "--title",
+        "Ports and Adapters",
+    ]
+
+
+def prepare_candidate_for_approval(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    name: str = "ready.md",
+    content: str = "A candidate ready for approval.\n",
+) -> str:
+    candidate_id = create_one_candidate(
+        tmp_path,
+        capsys,
+        name=name,
+        content=content,
+    )
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "0",
+            *complete_metadata_args(),
+            "--json",
+        ]
+    ) == 0
+    assert parsed_stdout(capsys)["revision"] == 1
+    assert run_cli(
+        ["candidates", "accept", candidate_id, "--revision", "1", "--json"]
+    ) == 0
+    assert parsed_stdout(capsys)["revision"] == 2
+    return candidate_id
+
+
+def test_parser_exposes_every_nested_leaf() -> None:
+    parser = lele_cli.build_parser()
+    invocations = {
+        "ingest_preview": ["ingest", "preview", "source.md"],
+        "ingest_create": ["ingest", "create", "source.txt"],
+        "candidates_list": ["candidates", "list"],
+        "candidates_show": ["candidates", "show", "candidate"],
+        "candidates_update": [
+            "candidates",
+            "update",
+            "candidate",
+            "--revision",
+            "0",
+            "--text",
+            "new",
+        ],
+        "candidates_accept": [
+            "candidates",
+            "accept",
+            "candidate",
+            "--revision",
+            "0",
+        ],
+        "candidates_reject": [
+            "candidates",
+            "reject",
+            "candidate",
+            "--revision",
+            "0",
+        ],
+        "candidates_approve": [
+            "candidates",
+            "approve",
+            "candidate",
+            "--revision",
+            "0",
+        ],
+    }
+
+    assert "ingest" in parser.format_help()
+    assert "candidates" in parser.format_help()
+    for command, argv in invocations.items():
+        assert parser.parse_args(argv).tritalele_command == command
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["ingest", "--help"], ("preview", "create")),
+        (
+            ["candidates", "--help"],
+            ("list", "show", "update", "accept", "reject", "approve"),
+        ),
+        (
+            ["candidates", "update", "--help"],
+            ("--revision", "--text", "--text-file", "--json"),
+        ),
+    ],
+)
+def test_nested_help_is_available_at_each_parser_level(
+    argv: list[str],
+    expected: tuple[str, ...],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_cli(argv) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert all(item in captured.out for item in expected)
+
+
+def test_update_rejects_inline_and_file_text_before_dispatch(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    proposed = tmp_path / "proposal.txt"
+    proposed.write_text("proposal", encoding="utf-8")
+
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            "candidate",
+            "--revision",
+            "0",
+            "--text",
+            "inline",
+            "--text-file",
+            str(proposed),
+        ]
+    ) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "not allowed with argument" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("name", "source_kind"),
+    [("notes.md", "markdown"), ("notes.markdown", "markdown"), ("notes.txt", "plain_text")],
+)
+def test_preview_file_sources_is_read_only_and_deterministic(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    name: str,
+    source_kind: str,
+) -> None:
+    def forbidden_write(*args: object, **kwargs: object) -> object:
+        raise AssertionError("preview must not call a write adapter")
+
+    monkeypatch.setattr(JsonCandidateRepository, "create", forbidden_write)
+    monkeypatch.setattr(JsonCandidateRepository, "update", forbidden_write)
+    monkeypatch.setattr(
+        tritalele.FilesystemCanonicalMarkdownVault, "publish", forbidden_write
+    )
+    monkeypatch.setattr(
+        tritalele.FilesystemCanonicalMarkdownVault, "verify", forbidden_write
+    )
+    monkeypatch.setattr(tritalele.VaultJsonlRefresh, "refresh", forbidden_write)
+    source = create_source(tmp_path, name=name)
+    argv = [
+        "ingest",
+        "preview",
+        str(source),
+        "--max-characters",
+        "16",
+        "--json",
+    ]
+
+    assert run_cli(argv) == 0
+    first = parsed_stdout(capsys)
+    assert run_cli(argv) == 0
+    second = parsed_stdout(capsys)
+
+    assert isinstance(first, dict) and isinstance(second, dict)
+    assert first["source"]["kind"] == source_kind
+    assert first["source"]["logical_name"] == name
+    assert first["candidate_ids"] == second["candidate_ids"]
+    assert first["candidate_ids"] == [
+        item["candidate_id"] for item in first["candidates"]
+    ]
+    assert [
+        item["provenance"]["chunk_index"] for item in first["candidates"]
+    ] == list(range(len(first["candidates"])))
+    assert not local_paths["candidates"].exists()
+    assert not local_paths["vault"].exists()
+    assert not local_paths["lessons"].exists()
+    assert local_paths["data"].is_dir()
+
+
+def test_preview_stdin_reads_once_without_filesystem_writes(
+    local_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class CountingStdin(io.StringIO):
+        calls = 0
+
+        def read(self, *args: object, **kwargs: object) -> str:
+            self.calls += 1
+            return super().read(*args, **kwargs)
+
+    stdin = CountingStdin("stdin lesson\n")
+    monkeypatch.setattr(tritalele.sys, "stdin", stdin)
+
+    def forbidden_write(*args: object, **kwargs: object) -> object:
+        raise AssertionError("preview must not call a write adapter")
+
+    monkeypatch.setattr(JsonCandidateRepository, "create", forbidden_write)
+    monkeypatch.setattr(JsonCandidateRepository, "update", forbidden_write)
+    monkeypatch.setattr(
+        tritalele.FilesystemCanonicalMarkdownVault, "publish", forbidden_write
+    )
+    monkeypatch.setattr(
+        tritalele.FilesystemCanonicalMarkdownVault, "verify", forbidden_write
+    )
+    monkeypatch.setattr(tritalele.VaultJsonlRefresh, "refresh", forbidden_write)
+
+    assert run_cli(["ingest", "preview", "-", "--json"]) == 0
+    payload = parsed_stdout(capsys)
+
+    assert isinstance(payload, dict)
+    assert stdin.calls == 1
+    assert payload["source"]["kind"] == "stdin"
+    assert payload["source"]["logical_name"] == "stdin"
+    assert not local_paths["candidates"].exists()
+    assert not local_paths["vault"].exists()
+    assert not local_paths["lessons"].exists()
+    assert local_paths["data"].is_dir()
+
+
+def test_preview_preserves_existing_staging_vault_and_projection_bytes(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = create_source(tmp_path)
+    local_paths["candidates"].parent.mkdir(parents=True)
+    local_paths["candidates"].write_text(
+        '{"candidates":[],"schema_version":2}\n', encoding="utf-8"
+    )
+    vault_file = local_paths["vault"] / "topic" / "lesson.md"
+    vault_file.parent.mkdir(parents=True)
+    vault_file.write_bytes(b"vault sentinel\n")
+    local_paths["lessons"].write_bytes(b"projection sentinel\n")
+    protected = (local_paths["candidates"], vault_file, local_paths["lessons"])
+    before = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in protected}
+    existing_paths = {path.relative_to(tmp_path) for path in tmp_path.rglob("*")}
+
+    assert run_cli(["ingest", "preview", str(source), "--json"]) == 0
+    parsed_stdout(capsys)
+    monkeypatch.setattr(tritalele.sys, "stdin", io.StringIO("stdin source\n"))
+    assert run_cli(["ingest", "preview", "-", "--json"]) == 0
+    parsed_stdout(capsys)
+
+    assert {
+        path: (path.read_bytes(), path.stat().st_mtime_ns) for path in protected
+    } == before
+    assert {path.relative_to(tmp_path) for path in tmp_path.rglob("*")} == existing_paths
+
+
+def test_create_is_idempotent_and_never_writes_vault(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = create_source(tmp_path)
+    argv = ["ingest", "create", str(source), "--max-characters", "16", "--json"]
+
+    assert run_cli(argv) == 0
+    first = parsed_stdout(capsys)
+    assert isinstance(first, dict)
+    assert first["created_candidate_ids"] == first["candidate_ids"]
+    assert first["skipped_candidate_ids"] == []
+    before = local_paths["candidates"].read_bytes()
+
+    assert run_cli(argv) == 0
+    second = parsed_stdout(capsys)
+    assert isinstance(second, dict)
+    assert second["candidate_ids"] == first["candidate_ids"]
+    assert second["created_candidate_ids"] == []
+    assert second["skipped_candidate_ids"] == first["candidate_ids"]
+    assert local_paths["candidates"].read_bytes() == before
+    assert not local_paths["vault"].exists()
+    assert not local_paths["lessons"].exists()
+
+
+def test_candidate_path_uses_data_dir_and_ignores_deprecated_lessons_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    data_dir = tmp_path / "configured-data"
+    monkeypatch.setenv("LELE_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("LELE_DATA_PATH", str(tmp_path / "legacy-lessons.jsonl"))
+
+    assert candidates_path() == data_dir / "candidates.json"
+
+
+def test_path_resolution_failure_is_a_controlled_configuration_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    loop = tmp_path / "data-loop"
+    loop.symlink_to(loop)
+    monkeypatch.setenv("LELE_DATA_DIR", str(loop))
+
+    assert run_cli(["candidates", "list", "--json"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == "local_configuration_unavailable"
+    assert str(loop) not in captured.err
+
+
+def test_partial_ingestion_reports_exact_recovery_ids(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = create_source(
+        tmp_path,
+        content="alpha\n\nbeta\n\ngamma\n",
+    )
+    argv = ["ingest", "preview", str(source), "--max-characters", "6", "--json"]
+    assert run_cli(argv) == 0
+    preview = parsed_stdout(capsys)
+    candidate_ids = preview["candidate_ids"]
+    assert len(candidate_ids) >= 3
+
+    original_create = JsonCandidateRepository.create
+    calls = 0
+
+    def fail_second_create(
+        self: JsonCandidateRepository, candidate: object
+    ) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise CandidateStorageError("private adapter failure")
+        return original_create(self, candidate)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(JsonCandidateRepository, "create", fail_second_create)
+    assert run_cli(
+        ["ingest", "create", str(source), "--max-characters", "6", "--json"]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    error = json.loads(captured.err)["error"]
+    assert error["code"] == "partial_ingestion"
+    assert error["details"] == {
+        "created_candidate_ids": candidate_ids[:1],
+        "failed_candidate_id": candidate_ids[1],
+        "remaining_candidate_ids": candidate_ids[2:],
+    }
+    assert "private" not in captured.err
+    assert [
+        item.candidate_id
+        for item in JsonCandidateRepository(local_paths["candidates"]).list()
+    ] == candidate_ids[:1]
+
+
+@pytest.mark.parametrize(
+    ("repository_error", "expected_exit", "expected_code"),
+    [
+        (CandidateStorageError("private storage path"), 2, "candidate_storage_unavailable"),
+        (DuplicateCandidateIdError("private identity"), 1, "ingestion_conflict"),
+    ],
+)
+def test_initial_ingestion_failures_are_controlled_and_non_mutating(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    repository_error: Exception,
+    expected_exit: int,
+    expected_code: str,
+) -> None:
+    source = create_source(tmp_path, content="one candidate\n")
+
+    def fail_create(*args: object, **kwargs: object) -> object:
+        raise repository_error
+
+    monkeypatch.setattr(JsonCandidateRepository, "create", fail_create)
+    assert run_cli(["ingest", "create", str(source), "--json"]) == expected_exit
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == expected_code
+    assert "private" not in captured.err
+    assert not local_paths["candidates"].exists()
+    assert not local_paths["vault"].exists()
+    assert not local_paths["lessons"].exists()
+
+
+def test_list_show_filters_empty_and_malformed_storage_are_controlled(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert run_cli(["candidates", "list", "--json"]) == 0
+    assert parsed_stdout(capsys) == {"count": 0, "candidates": []}
+
+    markdown_id = create_one_candidate(tmp_path, capsys)
+    text_id = create_one_candidate(
+        tmp_path,
+        capsys,
+        name="two.txt",
+        content="Another useful lesson.\n",
+    )
+    assert run_cli(["candidates", "list", "--json"]) == 0
+    listed = parsed_stdout(capsys)
+    assert isinstance(listed, dict)
+    assert [item["candidate_id"] for item in listed["candidates"]] == sorted(
+        [markdown_id, text_id]
+    )
+
+    assert run_cli(
+        ["candidates", "list", "--source-kind", "plain_text", "--chunk-index", "0", "--json"]
+    ) == 0
+    filtered = parsed_stdout(capsys)
+    assert isinstance(filtered, dict)
+    assert [item["candidate_id"] for item in filtered["candidates"]] == [text_id]
+
+    assert run_cli(["candidates", "show", markdown_id, "--json"]) == 0
+    shown = parsed_stdout(capsys)
+    assert isinstance(shown, dict)
+    assert shown["state"] == "staged"
+    assert shown["revision"] == 0
+    assert shown["original_text"] == "A useful lesson.\n"
+    assert shown["effective_text"] == shown["original_text"]
+    assert shown["provenance"]["source_logical_name"] == "one.md"
+    assert shown["review_history"] == []
+
+    local_paths["candidates"].write_text("{broken", encoding="utf-8")
+    assert run_cli(["candidates", "list", "--json"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    error = json.loads(captured.err)
+    assert error["error"]["code"] == "candidate_storage_unavailable"
+    assert str(local_paths["candidates"]) not in captured.err
+
+
+def test_update_revises_once_preserves_source_and_enforces_inputs(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    candidate_id = create_one_candidate(tmp_path, capsys)
+    argv = [
+        "candidates",
+        "update",
+        candidate_id,
+        "--revision",
+        "0",
+        "--text",
+        "A clearer lesson.",
+        *complete_metadata_args(),
+        "--reason",
+        "prepared",
+        "--json",
+    ]
+    assert run_cli(argv) == 0
+    updated = parsed_stdout(capsys)
+    assert isinstance(updated, dict)
+    assert updated["revision"] == 1
+    assert updated["state"] == "staged"
+    assert updated["original_text"] == "A useful lesson.\n"
+    assert updated["proposed_text"] == "A clearer lesson."
+    assert updated["proposed_metadata"] == {
+        "topic": "architecture",
+        "source": "book",
+        "importance": 4,
+        "tags": ["design", "boundaries"],
+        "date": "2026-07-22",
+        "title": "Ports and Adapters",
+    }
+    provenance = updated["provenance"]
+
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "1",
+            "--text",
+            "Final text.",
+            "--json",
+        ]
+    ) == 0
+    text_only = parsed_stdout(capsys)
+    assert isinstance(text_only, dict)
+    assert text_only["revision"] == 2
+    assert text_only["proposed_metadata"] == updated["proposed_metadata"]
+    assert text_only["provenance"] == provenance
+    assert text_only["original_text"] == updated["original_text"]
+
+    before = local_paths["candidates"].read_bytes()
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "2",
+            "--topic",
+            "incomplete",
+            "--json",
+        ]
+    ) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "invalid_cli_input"
+    assert local_paths["candidates"].read_bytes() == before
+
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "0",
+            "--text",
+            "stale",
+            "--json",
+        ]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "stale_candidate_revision"
+    assert local_paths["candidates"].read_bytes() == before
+
+
+def test_metadata_only_update_and_noop_updates_preserve_storage_and_clock(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    candidate_id = create_one_candidate(tmp_path, capsys)
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "0",
+            "--text",
+            "A reviewed proposal.",
+            "--json",
+        ]
+    ) == 0
+    text_only = parsed_stdout(capsys)
+    assert text_only["revision"] == 1
+    assert text_only["proposed_metadata"] is None
+
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "1",
+            *complete_metadata_args(),
+            "--json",
+        ]
+    ) == 0
+    metadata_only = parsed_stdout(capsys)
+    assert metadata_only["revision"] == 2
+    assert metadata_only["proposed_text"] == text_only["proposed_text"]
+    before = local_paths["candidates"].read_bytes()
+
+    class CountingClock:
+        calls = 0
+
+        def __call__(self) -> object:
+            self.calls += 1
+            raise AssertionError("a rejected update must not call the clock")
+
+    clock = CountingClock()
+    monkeypatch.setattr(tritalele, "_utc_now", clock)
+
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "2",
+            *complete_metadata_args(),
+            "--json",
+        ]
+    ) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "invalid_candidate_input"
+    assert local_paths["candidates"].read_bytes() == before
+
+    assert run_cli(
+        ["candidates", "update", candidate_id, "--revision", "2", "--json"]
+    ) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "invalid_cli_input"
+    assert local_paths["candidates"].read_bytes() == before
+
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "0",
+            "--text",
+            "stale",
+            "--json",
+        ]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "stale_candidate_revision"
+    assert local_paths["candidates"].read_bytes() == before
+    assert clock.calls == 0
+
+
+def test_accept_reject_transitions_and_revisions_are_explicit(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    candidate_id = create_one_candidate(tmp_path, capsys)
+
+    assert run_cli(
+        ["candidates", "accept", candidate_id, "--revision", "0", "--json"]
+    ) == 0
+    accepted = parsed_stdout(capsys)
+    assert accepted == {
+        "candidate_id": candidate_id,
+        "revision": 1,
+        "state": "in_review",
+    }
+    before = local_paths["candidates"].read_bytes()
+
+    assert run_cli(
+        ["candidates", "accept", candidate_id, "--revision", "1", "--json"]
+    ) == 1
+    assert json.loads(capsys.readouterr().err)["error"]["code"] == (
+        "invalid_candidate_transition"
+    )
+    assert local_paths["candidates"].read_bytes() == before
+
+    assert run_cli(
+        [
+            "candidates",
+            "reject",
+            candidate_id,
+            "--revision",
+            "1",
+            "--reason",
+            "not suitable",
+            "--json",
+        ]
+    ) == 0
+    rejected = parsed_stdout(capsys)
+    assert rejected == {
+        "candidate_id": candidate_id,
+        "revision": 2,
+        "state": "rejected",
+    }
+
+    assert run_cli(
+        ["candidates", "reject", candidate_id, "--revision", "1", "--json"]
+    ) == 1
+    assert json.loads(capsys.readouterr().err)["error"]["code"] == (
+        "stale_candidate_revision"
+    )
+
+
+def test_full_happy_path_approval_refresh_and_idempotency(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = create_source(
+        tmp_path,
+        name="workflow.md",
+        content="# Boundary\n\nKeep application logic out of adapters.\n",
+    )
+
+    def forbidden_http_client(*args: object, **kwargs: object) -> object:
+        raise AssertionError("local TritaLeLe commands must not create httpx.Client")
+
+    monkeypatch.setattr(lele_cli.httpx, "Client", forbidden_http_client)
+
+    assert run_cli(["ingest", "preview", str(source), "--json"]) == 0
+    preview = parsed_stdout(capsys)
+    assert isinstance(preview, dict)
+    assert not local_paths["candidates"].exists()
+
+    assert run_cli(["ingest", "create", str(source), "--json"]) == 0
+    created = parsed_stdout(capsys)
+    assert isinstance(created, dict)
+    candidate_id = created["candidate_ids"][0]
+    assert candidate_id == preview["candidate_ids"][0]
+    assert not local_paths["vault"].exists()
+
+    assert run_cli(["candidates", "list", "--state", "staged", "--json"]) == 0
+    listed = parsed_stdout(capsys)
+    assert listed["candidates"][0]["candidate_id"] == candidate_id
+    assert run_cli(["candidates", "show", candidate_id, "--json"]) == 0
+    shown = parsed_stdout(capsys)
+    assert shown["revision"] == 0
+
+    proposal_file = tmp_path / "proposal.txt"
+    proposal_file.write_text("Keep domain logic behind ports.\n", encoding="utf-8")
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "0",
+            "--text-file",
+            str(proposal_file),
+            *complete_metadata_args(),
+            "--json",
+        ]
+    ) == 0
+    assert parsed_stdout(capsys)["revision"] == 1
+    assert run_cli(
+        ["candidates", "accept", candidate_id, "--revision", "1", "--json"]
+    ) == 0
+    assert parsed_stdout(capsys)["state"] == "in_review"
+
+    original_refresh = tritalele.VaultJsonlRefresh.refresh
+
+    def checked_refresh(self: object) -> object:
+        assert list(local_paths["vault"].rglob("*.md"))
+        persisted = JsonCandidateRepository(local_paths["candidates"]).get(candidate_id)
+        assert persisted.state is CandidateState.APPROVED
+        assert persisted.revision == 3
+        return original_refresh(self)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(tritalele.VaultJsonlRefresh, "refresh", checked_refresh)
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "2", "--json"]
+    ) == 0
+    approved = parsed_stdout(capsys)
+    assert approved["candidate_id"] == candidate_id
+    assert approved["candidate_revision"] == 3
+    assert approved["vault_write_outcome"] == "created"
+    assert approved["candidate_state_changed"] is True
+    assert approved["refresh_outcome"] == {"refreshed": True}
+
+    vault_path = local_paths["vault"] / approved["relative_vault_path"]
+    assert vault_path.is_file()
+    markdown = vault_path.read_text(encoding="utf-8")
+    assert "Keep domain logic behind ports." in markdown
+    assert local_paths["lessons"].is_file()
+    projection_rows = [
+        json.loads(line)
+        for line in local_paths["lessons"].read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["id"] for row in projection_rows] == [approved["lesson_id"]]
+    assert JsonCandidateRepository(local_paths["candidates"]).get(
+        candidate_id
+    ).state is CandidateState.APPROVED
+
+    before_markdown = vault_path.read_bytes()
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "3", "--json"]
+    ) == 0
+    repeated = parsed_stdout(capsys)
+    assert repeated["candidate_revision"] == 3
+    assert repeated["vault_write_outcome"] == "identical"
+    assert repeated["candidate_state_changed"] is False
+    assert vault_path.read_bytes() == before_markdown
+
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "2", "--json"]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "stale_candidate_revision"
+
+
+def test_partial_approval_reports_recovery_data_and_retry_is_idempotent(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    candidate_id = prepare_candidate_for_approval(
+        tmp_path,
+        capsys,
+        name="partial-approval.md",
+    )
+    local_paths["data"].chmod(0o500)
+    try:
+        assert run_cli(
+            ["candidates", "approve", candidate_id, "--revision", "2", "--json"]
+        ) == 1
+    finally:
+        local_paths["data"].chmod(0o700)
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    error = json.loads(captured.err)["error"]
+    assert error["code"] == "partial_approval"
+    details = error["details"]
+    assert details["candidate_id"] == candidate_id
+    assert details["vault_write_outcome"] == "created"
+    assert details["candidate_state_changed"] is None
+    assert details["refresh_outcome"] == {"refreshed": False}
+    assert str(local_paths["data"]) not in captured.err
+    assert str(local_paths["vault"]) not in captured.err
+    assert (local_paths["vault"] / details["relative_vault_path"]).is_file()
+    staged = JsonCandidateRepository(local_paths["candidates"]).get(candidate_id)
+    assert staged.state is CandidateState.IN_REVIEW
+    assert staged.revision == 2
+    assert not local_paths["lessons"].exists()
+
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "2", "--json"]
+    ) == 0
+    recovered = parsed_stdout(capsys)
+    assert recovered["candidate_revision"] == 3
+    assert recovered["vault_write_outcome"] == "identical"
+    assert recovered["candidate_state_changed"] is True
+    assert local_paths["lessons"].is_file()
+
+
+def test_partial_approval_lost_response_does_not_claim_candidate_state(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    candidate_id = prepare_candidate_for_approval(
+        tmp_path,
+        capsys,
+        name="lost-approval-response.md",
+    )
+    original_update = JsonCandidateRepository.update
+
+    def persist_then_lose_response(
+        self: JsonCandidateRepository,
+        candidate_id: str,
+        candidate: object,
+        *,
+        expected_revision: int,
+    ) -> object:
+        original_update(
+            self,
+            candidate_id,
+            candidate,  # type: ignore[arg-type]
+            expected_revision=expected_revision,
+        )
+        raise CandidateRevisionConflictError("private lost response")
+
+    monkeypatch.setattr(
+        JsonCandidateRepository,
+        "update",
+        persist_then_lose_response,
+    )
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "2", "--json"]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    error = json.loads(captured.err)["error"]
+    assert error["code"] == "partial_approval"
+    assert error["details"]["candidate_state_changed"] is None
+    assert "candidates show" in error["message"]
+    assert "stessa revisione" not in error["message"]
+    assert "private" not in captured.err
+    persisted = JsonCandidateRepository(local_paths["candidates"]).get(candidate_id)
+    assert persisted.state is CandidateState.APPROVED
+    assert persisted.revision == 3
+    assert not local_paths["lessons"].exists()
+
+    monkeypatch.setattr(JsonCandidateRepository, "update", original_update)
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "3", "--json"]
+    ) == 0
+    recovered = parsed_stdout(capsys)
+    assert recovered["candidate_state_changed"] is False
+    assert recovered["vault_write_outcome"] == "identical"
+    assert local_paths["lessons"].is_file()
+
+
+def test_partial_refresh_json_and_human_output_expose_stable_recovery_data(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    candidate_id = prepare_candidate_for_approval(
+        tmp_path,
+        capsys,
+        name="partial-refresh.md",
+    )
+    local_paths["lessons"].mkdir()
+
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "2", "--json"]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    error = json.loads(captured.err)["error"]
+    assert error["code"] == "partial_refresh"
+    details = error["details"]
+    assert details["candidate_id"] == candidate_id
+    assert details["candidate_revision"] == 3
+    assert details["vault_write_outcome"] == "created"
+    assert details["candidate_state_changed"] is True
+    assert details["refresh_outcome"] == {"refreshed": False}
+    assert str(local_paths["data"]) not in captured.err
+    assert str(local_paths["vault"]) not in captured.err
+    persisted = JsonCandidateRepository(local_paths["candidates"]).get(candidate_id)
+    assert persisted.state is CandidateState.APPROVED
+    assert persisted.revision == 3
+    assert (local_paths["vault"] / details["relative_vault_path"]).is_file()
+
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "3"]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "[errore]" in captured.err
+    for stable_value in (
+        candidate_id,
+        details["lesson_id"],
+        details["relative_vault_path"],
+        "candidate_revision: 3",
+        "vault_write_outcome: identical",
+    ):
+        assert str(stable_value) in captured.err
+    assert str(local_paths["data"]) not in captured.err
+    assert str(local_paths["vault"]) not in captured.err
+
+    local_paths["lessons"].rmdir()
+    assert run_cli(
+        ["candidates", "approve", candidate_id, "--revision", "3", "--json"]
+    ) == 0
+    recovered = parsed_stdout(capsys)
+    assert recovered["candidate_revision"] == 3
+    assert recovered["vault_write_outcome"] == "identical"
+    assert recovered["candidate_state_changed"] is False
+    assert local_paths["lessons"].is_file()
+
+
+def test_approval_missing_metadata_and_vault_collision_are_controlled(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_metadata_id = create_one_candidate(tmp_path, capsys, name="missing.md")
+    assert run_cli(
+        [
+            "candidates",
+            "accept",
+            missing_metadata_id,
+            "--revision",
+            "0",
+            "--json",
+        ]
+    ) == 0
+    parsed_stdout(capsys)
+    assert run_cli(
+        [
+            "candidates",
+            "approve",
+            missing_metadata_id,
+            "--revision",
+            "1",
+            "--json",
+        ]
+    ) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "invalid_approval_metadata"
+    assert not local_paths["vault"].exists()
+
+    collision_id = create_one_candidate(
+        tmp_path, capsys, name="collision.md", content="Collision candidate.\n"
+    )
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            collision_id,
+            "--revision",
+            "0",
+            *complete_metadata_args(),
+            "--json",
+        ]
+    ) == 0
+    parsed_stdout(capsys)
+    before_lifecycle = local_paths["candidates"].read_bytes()
+    assert run_cli(
+        ["candidates", "approve", collision_id, "--revision", "1", "--json"]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == (
+        "invalid_candidate_transition"
+    )
+    assert local_paths["candidates"].read_bytes() == before_lifecycle
+    assert not local_paths["vault"].exists()
+    assert run_cli(
+        ["candidates", "accept", collision_id, "--revision", "1", "--json"]
+    ) == 0
+    parsed_stdout(capsys)
+
+    repository = JsonCandidateRepository(local_paths["candidates"])
+    spec = canonical_lesson_for(repository.get(collision_id))
+    occupied = local_paths["vault"] / spec.relative_path
+    occupied.parent.mkdir(parents=True)
+    occupied.write_text("occupied", encoding="utf-8")
+    before = local_paths["candidates"].read_bytes()
+
+    assert run_cli(
+        ["candidates", "approve", collision_id, "--revision", "2", "--json"]
+    ) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "vault_path_collision"
+    assert occupied.read_text(encoding="utf-8") == "occupied"
+    assert local_paths["candidates"].read_bytes() == before
+    assert not local_paths["lessons"].exists()
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_code"),
+    [
+        (["ingest", "preview", "unsupported.pdf", "--json"], "unsupported_source"),
+        (
+            ["ingest", "preview", "missing.md", "--json"],
+            "source_unavailable",
+        ),
+        (
+            [
+                "ingest",
+                "preview",
+                "source.md",
+                "--max-characters",
+                "0",
+                "--json",
+            ],
+            "invalid_cli_input",
+        ),
+    ],
+)
+def test_invalid_ingestion_inputs_have_controlled_json_errors(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+    expected_code: str,
+) -> None:
+    create_source(tmp_path)
+    resolved_argv = [str(tmp_path / item) if item == "source.md" else item for item in argv]
+
+    assert run_cli(resolved_argv) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    payload = json.loads(captured.err)
+    assert payload["error"]["code"] == expected_code
+    assert not local_paths["candidates"].exists()
+    assert not local_paths["vault"].exists()
+    assert not local_paths["lessons"].exists()
+
+
+def test_invalid_utf8_sources_and_proposed_text_files_are_controlled(
+    tmp_path: Path,
+    local_paths: dict[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    invalid_source = tmp_path / "invalid.txt"
+    invalid_source.write_bytes(b"\xff")
+    assert run_cli(["ingest", "preview", str(invalid_source), "--json"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "invalid_source_encoding"
+    assert not local_paths["candidates"].exists()
+
+    candidate_id = create_one_candidate(tmp_path, capsys)
+    before = local_paths["candidates"].read_bytes()
+    invalid_proposal = tmp_path / "invalid-proposal.txt"
+    invalid_proposal.write_bytes(b"\xff")
+    assert run_cli(
+        [
+            "candidates",
+            "update",
+            candidate_id,
+            "--revision",
+            "0",
+            "--text-file",
+            str(invalid_proposal),
+            "--json",
+        ]
+    ) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert json.loads(captured.err)["error"]["code"] == "invalid_cli_input"
+    assert local_paths["candidates"].read_bytes() == before


### PR DESCRIPTION
## Summary

- expose the complete non-HTTP TritaLeLe workflow through local CLI commands;
- support deterministic preview and candidate staging from Markdown, plain text and stdin;
- add candidate list, inspection, revision, acceptance, rejection and approval commands;
- compose the existing ingestion, review and approval application services locally;
- preserve optimistic concurrency through explicit candidate revisions;
- publish approved candidates to the canonical Markdown vault before refreshing derived JSONL data;
- provide stable human-readable and JSON output with controlled exit codes.

## Command surface

- `lele ingest preview <path|-> [--max-characters N] [--json]`
- `lele ingest create <path|-> [--max-characters N] [--json]`
- `lele candidates list [filters] [--json]`
- `lele candidates show <id> [--json]`
- `lele candidates update <id> --revision N [proposal options] [--json]`
- `lele candidates accept <id> --revision N [--reason TEXT] [--json]`
- `lele candidates reject <id> --revision N [--reason TEXT] [--json]`
- `lele candidates approve <id> --revision N [--json]`

## Safety and behavior

- preview never stages, publishes or refreshes data;
- ingestion never approves candidates;
- approval always requires one explicit candidate ID;
- expected revisions are mandatory for every mutation;
- incomplete canonical metadata is rejected before mutation;
- identical proposal revisions are rejected without clock or storage writes;
- partial ingestion, approval and refresh outcomes expose safe recovery information;
- local TritaLeLe commands do not instantiate or call `httpx.Client`;
- existing CLI and API behavior remains unchanged.

## Exit codes

- `0`: success;
- `1`: operation failure, conflict, stale revision, invalid lifecycle transition or partial completion;
- `2`: invalid input or unavailable/malformed local configuration or storage.

## Validation

- focused CLI tests: `29 passed`;
- requested domain/application/CLI contract suite: `216 passed`;
- candidate review and CLI verification: `63 passed`;
- existing CLI compatibility selection: passed;
- Ruff: passed;
- Mypy: passed for 54 source files;
- `git diff --check`: passed.

The complete local pytest run is currently affected by a FastAPI/Starlette
`TestClient` hang at `tests/test_api_basic.py::test_health_without_data_and_model`.
The same isolated timeout and equivalent faulthandler state were reproduced in
the untouched `main` worktree, so it is not an issue-124 regression.

Closes #124
