### PR TITLE
feat(api): expose TritaLeLe candidate workflow

### DIFF
--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -42,6 +42,7 @@ from lele_manager.ml.topic_model import (
     train_topic_model,
 )
 from lele_manager.ml.similarity_service import similar_by_text, similar_by_lesson_id
+from lele_manager.api.tritalele import router as tritalele_router
 
 
 # Override espliciti (usati nei test via monkeypatch) — se None si usa default_*_path()
@@ -83,6 +84,7 @@ app = FastAPI(
     description="API per gestire e cercare le Lesson Learned (LeLe).",
     version=__version__,
 )
+app.include_router(tritalele_router)
 
 # -----------------------------------------------------------------------------
 # Schemi Pydantic

--- a/src/lele_manager/api/tritalele.py
+++ b/src/lele_manager/api/tritalele.py
@@ -1,0 +1,793 @@
+"""Versioned HTTP boundary for the TritaLeLe candidate workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+import math
+from typing import Annotated, Any, NoReturn
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from lele_manager.adapters.canonical_markdown_vault import (
+    FilesystemCanonicalMarkdownVault,
+)
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.adapters.vault_jsonl_refresh import VaultJsonlRefresh
+from lele_manager.application.candidate_approval import (
+    ApprovalCandidatePersistenceError,
+    ApprovalCollisionError,
+    ApprovalIdentityCollisionError,
+    ApprovalPathCollisionError,
+    ApprovalRefreshError,
+    ApprovalResult,
+    ApprovalVaultStorageError,
+    CandidateApprovalError,
+    CandidateApprovalNotFoundError,
+    CandidateApprovalService,
+    InvalidApprovalInputError,
+    InvalidApprovalLifecycleError,
+    InvalidApprovalMetadataError,
+    PartialApprovalError,
+    PartialRefreshError,
+    StaleApprovalRevisionError,
+)
+from lele_manager.application.candidate_review import (
+    CandidateReviewConflictError,
+    CandidateReviewError,
+    CandidateReviewFilter,
+    CandidateReviewService,
+    CandidateReviewStorageError,
+    InvalidCandidateReviewInputError,
+    InvalidCandidateTransitionError,
+    ReviewCandidateNotFoundError,
+    StaleCandidateRevisionError,
+)
+from lele_manager.application.lesson_candidate import (
+    CandidateRepository,
+    CandidateState,
+    LessonCandidate,
+)
+from lele_manager.application.raw_source import RawSource, SourceKind
+from lele_manager.application.raw_source_chunking import (
+    ChunkingSettings,
+    DeterministicRawSourceChunker,
+)
+from lele_manager.application.raw_source_ingestion import (
+    IngestionConflictError,
+    IngestionPlanError,
+    IngestionStagingError,
+    PartialIngestionError,
+    RawSourceIngestionError,
+    RawSourceIngestionResult,
+    RawSourceIngestionService,
+)
+from lele_manager.core.paths import candidates_path, lessons_path
+from lele_manager.core.vault import resolve_vault_dir
+
+
+router = APIRouter(prefix="/api/v1/tritalele", tags=["tritalele"])
+
+
+class _StrictRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class RawSourceRequest(_StrictRequest):
+    content: str
+    source_kind: SourceKind
+    logical_name: str
+    max_characters: int = Field(default=2_000, strict=True)
+
+
+class CanonicalMetadataRequest(_StrictRequest):
+    topic: str = Field(min_length=1)
+    source: str = Field(min_length=1)
+    importance: int = Field(ge=1, le=5, strict=True)
+    tags: list[Annotated[str, Field(min_length=1)]] = Field(min_length=1)
+    date: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+
+
+class CandidateRevisionRequest(_StrictRequest):
+    expected_revision: int = Field(ge=0, strict=True)
+    proposed_text: str | None = Field(default=None, min_length=1)
+    proposed_metadata: CanonicalMetadataRequest | None = None
+    reason: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def require_proposal(self) -> CandidateRevisionRequest:
+        if self.proposed_text is None and self.proposed_metadata is None:
+            raise ValueError("proposed_text or proposed_metadata is required")
+        return self
+
+
+class CandidateTransitionRequest(_StrictRequest):
+    expected_revision: int = Field(ge=0, strict=True)
+    reason: str | None = Field(default=None, min_length=1)
+
+
+class CandidateApprovalRequest(_StrictRequest):
+    expected_revision: int = Field(ge=0, strict=True)
+
+
+class SourceSpanResponse(BaseModel):
+    start: int
+    end: int
+
+
+class CandidateProvenanceResponse(BaseModel):
+    source_kind: str
+    source_logical_name: str
+    source_fingerprint: str
+    ingested_at: str
+    chunk_index: int | None
+    source_span: SourceSpanResponse | None
+    run_metadata: dict[str, Any]
+    transformations: list[dict[str, Any]]
+
+
+class CandidateReviewEventResponse(BaseModel):
+    revision: int
+    action: str
+    occurred_at: str
+    previous_state: str
+    resulting_state: str
+    reason: str | None
+
+
+class CandidateResponse(BaseModel):
+    candidate_id: str
+    state: str
+    revision: int
+    original_text: str
+    proposed_text: str | None
+    effective_text: str
+    proposed_metadata: dict[str, Any] | None
+    provenance: CandidateProvenanceResponse
+    review_history: list[CandidateReviewEventResponse]
+
+
+class CandidateListResponse(BaseModel):
+    count: int
+    candidates: list[CandidateResponse]
+
+
+class IngestionSourceResponse(BaseModel):
+    kind: str
+    logical_name: str
+    fingerprint: str
+
+
+class IngestionChunkingResponse(BaseModel):
+    max_characters: int
+
+
+class IngestionCountsResponse(BaseModel):
+    planned: int
+    created: int
+    skipped: int
+    pending: int
+
+
+class IngestionResultResponse(BaseModel):
+    preview: bool
+    source: IngestionSourceResponse
+    chunking: IngestionChunkingResponse
+    candidate_ids: list[str]
+    created_candidate_ids: list[str]
+    skipped_candidate_ids: list[str]
+    pending_candidate_ids: list[str]
+    counts: IngestionCountsResponse
+    candidates: list[CandidateResponse]
+
+
+class RefreshOutcomeResponse(BaseModel):
+    refreshed: bool
+
+
+class ApprovalResultResponse(BaseModel):
+    candidate_id: str
+    candidate_revision: int
+    lesson_id: str
+    relative_vault_path: str
+    vault_write_outcome: str
+    candidate_state_changed: bool
+    refresh_outcome: RefreshOutcomeResponse
+
+
+class APIErrorDetail(BaseModel):
+    code: str
+    message: str
+    recovery: dict[str, Any] | None = None
+
+
+class APIErrorResponse(BaseModel):
+    detail: APIErrorDetail
+
+
+_ERROR_DESCRIPTIONS = {
+    400: "The request is structurally valid but violates the workflow input contract.",
+    404: "The requested candidate does not exist.",
+    409: "The operation conflicts with candidate state, revision, or canonical identity.",
+    500: "The ingestion plan violated an application invariant.",
+    503: "A configured workflow storage operation is unavailable or partially completed.",
+}
+
+
+def _error_responses(*statuses: int) -> dict[int | str, dict[str, Any]]:
+    return {
+        status: {"model": APIErrorResponse, "description": _ERROR_DESCRIPTIONS[status]}
+        for status in statuses
+    }
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _raise_api_error(
+    status_code: int,
+    code: str,
+    message: str,
+    recovery: dict[str, Any] | None = None,
+) -> NoReturn:
+    detail: dict[str, Any] = {"code": code, "message": message}
+    if recovery is not None:
+        detail["recovery"] = recovery
+    raise HTTPException(status_code=status_code, detail=detail) from None
+
+
+def get_candidate_repository() -> CandidateRepository:
+    """Build a fresh repository for the configured local staging document."""
+    try:
+        path = candidates_path()
+    except (OSError, RuntimeError):
+        _raise_api_error(
+            503,
+            "candidate_storage_unavailable",
+            "Candidate staging storage is unavailable.",
+        )
+    return JsonCandidateRepository(path)
+
+
+def get_ingestion_service(
+    repository: Annotated[CandidateRepository, Depends(get_candidate_repository)],
+) -> RawSourceIngestionService:
+    return RawSourceIngestionService(
+        DeterministicRawSourceChunker(), repository, _utc_now
+    )
+
+
+def get_review_service(
+    repository: Annotated[CandidateRepository, Depends(get_candidate_repository)],
+) -> CandidateReviewService:
+    return CandidateReviewService(repository, _utc_now)
+
+
+def get_approval_service(
+    repository: Annotated[CandidateRepository, Depends(get_candidate_repository)],
+) -> CandidateApprovalService:
+    try:
+        vault_dir = resolve_vault_dir()
+        projection_path = lessons_path()
+    except (OSError, RuntimeError):
+        _raise_api_error(
+            503,
+            "approval_storage_unavailable",
+            "Canonical approval storage is unavailable.",
+        )
+    return CandidateApprovalService(
+        repository,
+        FilesystemCanonicalMarkdownVault(vault_dir),
+        VaultJsonlRefresh(vault_dir, projection_path),
+        _utc_now,
+    )
+
+
+def _json_value(value: object) -> Any:
+    """Copy immutable domain JSON values into transport-native containers."""
+    if value is None or type(value) in (bool, int, str):
+        return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise TypeError("response contains a non-finite number")
+        return value
+    if isinstance(value, Mapping):
+        if not all(type(key) is str for key in value):
+            raise TypeError("response mapping keys must be strings")
+        return {key: _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    raise TypeError("response contains a non-JSON value")
+
+
+def _candidate_response(candidate: LessonCandidate) -> CandidateResponse:
+    provenance = candidate.provenance
+    span = provenance.source_span
+    proposed_metadata = _json_value(candidate.proposed_metadata)
+    run_metadata = _json_value(provenance.run_metadata)
+    transformations = _json_value(provenance.transformations)
+    assert proposed_metadata is None or isinstance(proposed_metadata, dict)
+    assert isinstance(run_metadata, dict)
+    assert isinstance(transformations, list)
+    return CandidateResponse(
+        candidate_id=candidate.candidate_id,
+        state=candidate.state.value,
+        revision=candidate.revision,
+        original_text=candidate.text,
+        proposed_text=candidate.proposed_text,
+        effective_text=candidate.effective_text,
+        proposed_metadata=proposed_metadata,
+        provenance=CandidateProvenanceResponse(
+            source_kind=provenance.source_kind.value,
+            source_logical_name=provenance.source_logical_name,
+            source_fingerprint=provenance.source_fingerprint,
+            ingested_at=provenance.ingested_at.isoformat(),
+            chunk_index=provenance.chunk_index,
+            source_span=(
+                None if span is None else SourceSpanResponse(start=span.start, end=span.end)
+            ),
+            run_metadata=run_metadata,
+            transformations=transformations,
+        ),
+        review_history=[
+            CandidateReviewEventResponse(
+                revision=event.revision,
+                action=event.action.value,
+                occurred_at=event.occurred_at.isoformat(),
+                previous_state=event.previous_state.value,
+                resulting_state=event.resulting_state.value,
+                reason=event.reason,
+            )
+            for event in candidate.review_history
+        ],
+    )
+
+
+def _ingestion_response(
+    result: RawSourceIngestionResult,
+    source: RawSource,
+    settings: ChunkingSettings,
+) -> IngestionResultResponse:
+    return IngestionResultResponse(
+        preview=result.preview,
+        source=IngestionSourceResponse(
+            kind=source.kind.value,
+            logical_name=source.logical_name,
+            fingerprint=result.source_fingerprint,
+        ),
+        chunking=IngestionChunkingResponse(max_characters=settings.max_characters),
+        candidate_ids=list(result.candidate_ids),
+        created_candidate_ids=list(result.created_candidate_ids),
+        skipped_candidate_ids=list(result.skipped_candidate_ids),
+        pending_candidate_ids=list(result.pending_candidate_ids),
+        counts=IngestionCountsResponse(
+            planned=len(result.planned_candidates),
+            created=result.created_count,
+            skipped=result.skipped_count,
+            pending=result.pending_count,
+        ),
+        candidates=[_candidate_response(item) for item in result.planned_candidates],
+    )
+
+
+def _approval_response(result: ApprovalResult) -> ApprovalResultResponse:
+    return ApprovalResultResponse(
+        candidate_id=result.candidate_id,
+        candidate_revision=result.candidate_revision,
+        lesson_id=result.lesson_id,
+        relative_vault_path=result.relative_vault_path,
+        vault_write_outcome=result.vault_write_outcome.value,
+        candidate_state_changed=result.candidate_state_changed,
+        refresh_outcome=RefreshOutcomeResponse(
+            refreshed=result.refresh_outcome.refreshed
+        ),
+    )
+
+
+def _raise_ingestion_error(error: RawSourceIngestionError) -> NoReturn:
+    if isinstance(error, PartialIngestionError):
+        _raise_api_error(
+            503,
+            "partial_ingestion",
+            "Candidate staging stopped after a partial ingestion.",
+            {
+                "created_candidate_ids": list(error.created_candidate_ids),
+                "failed_candidate_id": error.failed_candidate_id,
+                "remaining_candidate_ids": list(error.remaining_candidate_ids),
+            },
+        )
+    if isinstance(error, IngestionConflictError):
+        recovery: dict[str, Any] = {}
+        if error.candidate_id is not None:
+            recovery["candidate_id"] = error.candidate_id
+        if error.created_candidate_ids:
+            recovery["created_candidate_ids"] = list(error.created_candidate_ids)
+        _raise_api_error(
+            409,
+            "ingestion_conflict",
+            "Candidate identity conflicts with staged content.",
+            recovery or None,
+        )
+    if isinstance(error, IngestionPlanError):
+        _raise_api_error(
+            500,
+            "invalid_ingestion_plan",
+            "The ingestion plan failed an application invariant.",
+        )
+    if isinstance(error, IngestionStagingError):
+        recovery = {}
+        if error.failed_candidate_id is not None:
+            recovery["failed_candidate_id"] = error.failed_candidate_id
+        if error.remaining_candidate_ids:
+            recovery["remaining_candidate_ids"] = list(error.remaining_candidate_ids)
+        _raise_api_error(
+            503,
+            "candidate_storage_unavailable",
+            "Candidate staging storage is unavailable.",
+            recovery or None,
+        )
+    _raise_api_error(
+        503,
+        "ingestion_unavailable",
+        "Raw-source ingestion is unavailable.",
+    )
+
+
+def _raise_review_error(error: CandidateReviewError) -> NoReturn:
+    if isinstance(error, ReviewCandidateNotFoundError):
+        _raise_api_error(404, "candidate_not_found", "Candidate was not found.")
+    if isinstance(error, StaleCandidateRevisionError):
+        _raise_api_error(
+            409,
+            "stale_candidate_revision",
+            "Candidate revision is stale.",
+        )
+    if isinstance(error, InvalidCandidateTransitionError):
+        _raise_api_error(
+            409,
+            "invalid_candidate_transition",
+            "Candidate transition is not allowed.",
+        )
+    if isinstance(error, CandidateReviewConflictError):
+        _raise_api_error(
+            409,
+            "candidate_review_conflict",
+            "Candidate staging contains a conflicting identity.",
+        )
+    if isinstance(error, InvalidCandidateReviewInputError):
+        _raise_api_error(
+            400,
+            "invalid_candidate_review_input",
+            "Candidate review input is invalid.",
+        )
+    if isinstance(error, CandidateReviewStorageError):
+        _raise_api_error(
+            503,
+            "candidate_storage_unavailable",
+            "Candidate staging storage is unavailable.",
+        )
+    _raise_api_error(
+        503,
+        "candidate_review_unavailable",
+        "Candidate review is unavailable.",
+    )
+
+
+def _raise_approval_error(error: CandidateApprovalError) -> NoReturn:
+    if isinstance(error, PartialApprovalError):
+        _raise_api_error(
+            503,
+            "partial_approval",
+            "The canonical lesson exists, but candidate persistence may be unknown.",
+            {
+                "candidate_id": error.candidate_id,
+                "lesson_id": error.lesson_id,
+                "relative_vault_path": error.relative_vault_path,
+                "vault_write_outcome": error.vault_write_outcome.value,
+                "candidate_persistence_state": "unknown",
+            },
+        )
+    if isinstance(error, PartialRefreshError):
+        partial = _approval_response(error.partial_result)
+        _raise_api_error(
+            503,
+            "partial_refresh",
+            (
+                "The canonical lesson and candidate approval succeeded, but the "
+                "derived projection refresh failed."
+            ),
+            {
+                "partial_approval_result": partial.model_dump(mode="json"),
+                "canonical_lesson_persisted": True,
+                "candidate_approval_persisted": True,
+                "projection_refreshed": False,
+            },
+        )
+    if isinstance(error, CandidateApprovalNotFoundError):
+        _raise_api_error(404, "candidate_not_found", "Candidate was not found.")
+    if isinstance(error, StaleApprovalRevisionError):
+        _raise_api_error(
+            409,
+            "stale_approval_revision",
+            "Candidate approval revision is stale.",
+        )
+    if isinstance(error, InvalidApprovalLifecycleError):
+        _raise_api_error(
+            409,
+            "invalid_approval_lifecycle",
+            "Candidate is not in an approvable state.",
+        )
+    if isinstance(error, ApprovalPathCollisionError):
+        _raise_api_error(
+            409,
+            "approval_path_collision",
+            "Canonical lesson path is already occupied.",
+        )
+    if isinstance(error, ApprovalIdentityCollisionError):
+        _raise_api_error(
+            409,
+            "approval_identity_collision",
+            "Canonical lesson identity already exists at another path.",
+        )
+    if isinstance(error, ApprovalCollisionError):
+        _raise_api_error(
+            409,
+            "approval_collision",
+            "Canonical lesson publication conflicts with existing content.",
+        )
+    if isinstance(error, InvalidApprovalMetadataError):
+        _raise_api_error(
+            400,
+            "invalid_approval_metadata",
+            "Candidate approval metadata is invalid.",
+        )
+    if isinstance(error, InvalidApprovalInputError):
+        _raise_api_error(
+            400,
+            "invalid_approval_input",
+            "Candidate approval input is invalid.",
+        )
+    if isinstance(error, ApprovalVaultStorageError):
+        _raise_api_error(
+            503,
+            "vault_storage_unavailable",
+            "Canonical vault storage is unavailable.",
+        )
+    if isinstance(error, ApprovalCandidatePersistenceError):
+        _raise_api_error(
+            503,
+            "candidate_approval_persistence_unavailable",
+            "Candidate approval persistence is unavailable.",
+        )
+    if isinstance(error, ApprovalRefreshError):
+        _raise_api_error(
+            503,
+            "derived_refresh_unavailable",
+            "Derived lesson projection refresh is unavailable.",
+        )
+    _raise_api_error(
+        503,
+        "candidate_approval_unavailable",
+        "Candidate approval is unavailable.",
+    )
+
+
+def _run_ingestion(
+    body: RawSourceRequest,
+    service: RawSourceIngestionService,
+    *,
+    preview: bool,
+) -> IngestionResultResponse:
+    try:
+        source = RawSource(body.content, body.source_kind, body.logical_name)
+    except (TypeError, ValueError, UnicodeError):
+        _raise_api_error(
+            400,
+            "invalid_raw_source",
+            "Raw source input is invalid.",
+        )
+    try:
+        settings = ChunkingSettings(max_characters=body.max_characters)
+    except (TypeError, ValueError):
+        _raise_api_error(
+            400,
+            "invalid_chunking_settings",
+            "Chunking settings are invalid.",
+        )
+    try:
+        result = service.ingest(source, settings, preview=preview)
+    except RawSourceIngestionError as error:
+        _raise_ingestion_error(error)
+    return _ingestion_response(result, source, settings)
+
+
+@router.post(
+    "/ingestion/preview",
+    response_model=IngestionResultResponse,
+    responses=_error_responses(400, 409, 500, 503),
+    summary="Preview raw-source ingestion",
+    description="Plan deterministic candidates without mutating staging, vault, or projection storage.",
+    operation_id="tritalele_preview_ingestion",
+)
+def preview_ingestion(
+    body: RawSourceRequest,
+    service: Annotated[RawSourceIngestionService, Depends(get_ingestion_service)],
+) -> IngestionResultResponse:
+    return _run_ingestion(body, service, preview=True)
+
+
+@router.post(
+    "/ingestion/stage",
+    response_model=IngestionResultResponse,
+    responses=_error_responses(400, 409, 500, 503),
+    summary="Stage raw-source candidates",
+    description="Create only missing deterministic candidates in local staging.",
+    operation_id="tritalele_stage_ingestion",
+)
+def stage_ingestion(
+    body: RawSourceRequest,
+    service: Annotated[RawSourceIngestionService, Depends(get_ingestion_service)],
+) -> IngestionResultResponse:
+    return _run_ingestion(body, service, preview=False)
+
+
+@router.get(
+    "/candidates",
+    response_model=CandidateListResponse,
+    responses=_error_responses(400, 409, 503),
+    summary="List staged candidates",
+    description="List candidates in deterministic order with optional review filters.",
+    operation_id="tritalele_list_candidates",
+)
+def list_candidates(
+    service: Annotated[CandidateReviewService, Depends(get_review_service)],
+    state: Annotated[CandidateState | None, Query()] = None,
+    source_kind: Annotated[SourceKind | None, Query()] = None,
+    source_fingerprint: Annotated[str | None, Query(min_length=1)] = None,
+    source_logical_name: Annotated[str | None, Query(min_length=1)] = None,
+    chunk_index: Annotated[int | None, Query(ge=0)] = None,
+) -> CandidateListResponse:
+    try:
+        filters = CandidateReviewFilter(
+            state=state,
+            source_kind=source_kind,
+            source_fingerprint=source_fingerprint,
+            source_logical_name=source_logical_name,
+            chunk_index=chunk_index,
+        )
+        candidates = service.list_candidates(filters)
+    except CandidateReviewError as error:
+        _raise_review_error(error)
+    return CandidateListResponse(
+        count=len(candidates),
+        candidates=[_candidate_response(item) for item in candidates],
+    )
+
+
+@router.get(
+    "/candidates/{candidate_id}",
+    response_model=CandidateResponse,
+    responses=_error_responses(400, 404, 409, 503),
+    summary="Get one candidate",
+    description="Return the stable review representation of one staged candidate.",
+    operation_id="tritalele_get_candidate",
+)
+def get_candidate(
+    candidate_id: str,
+    service: Annotated[CandidateReviewService, Depends(get_review_service)],
+) -> CandidateResponse:
+    try:
+        candidate = service.get_candidate(candidate_id)
+    except CandidateReviewError as error:
+        _raise_review_error(error)
+    return _candidate_response(candidate)
+
+
+@router.patch(
+    "/candidates/{candidate_id}",
+    response_model=CandidateResponse,
+    responses=_error_responses(400, 404, 409, 503),
+    summary="Revise one candidate",
+    description="Revise proposed text or complete canonical metadata using optimistic concurrency.",
+    operation_id="tritalele_revise_candidate",
+)
+def revise_candidate(
+    candidate_id: str,
+    body: CandidateRevisionRequest,
+    service: Annotated[CandidateReviewService, Depends(get_review_service)],
+) -> CandidateResponse:
+    try:
+        current = service.get_candidate(candidate_id)
+        proposed_text = (
+            current.proposed_text
+            if body.proposed_text is None
+            else body.proposed_text
+        )
+        proposed_metadata: Mapping[str, object] | None = (
+            current.proposed_metadata
+            if body.proposed_metadata is None
+            else body.proposed_metadata.model_dump()
+        )
+        revised = service.revise_candidate(
+            candidate_id,
+            expected_revision=body.expected_revision,
+            proposed_text=proposed_text,
+            proposed_metadata=proposed_metadata,
+            reason=body.reason,
+        )
+    except CandidateReviewError as error:
+        _raise_review_error(error)
+    return _candidate_response(revised)
+
+
+@router.post(
+    "/candidates/{candidate_id}/accept",
+    response_model=CandidateResponse,
+    responses=_error_responses(400, 404, 409, 503),
+    summary="Accept one candidate",
+    description="Move one staged candidate into review using its expected revision.",
+    operation_id="tritalele_accept_candidate",
+)
+def accept_candidate(
+    candidate_id: str,
+    body: CandidateTransitionRequest,
+    service: Annotated[CandidateReviewService, Depends(get_review_service)],
+) -> CandidateResponse:
+    try:
+        accepted = service.accept_candidate(
+            candidate_id,
+            expected_revision=body.expected_revision,
+            reason=body.reason,
+        )
+    except CandidateReviewError as error:
+        _raise_review_error(error)
+    return _candidate_response(accepted)
+
+
+@router.post(
+    "/candidates/{candidate_id}/reject",
+    response_model=CandidateResponse,
+    responses=_error_responses(400, 404, 409, 503),
+    summary="Reject one candidate",
+    description="Reject one staged or in-review candidate using its expected revision.",
+    operation_id="tritalele_reject_candidate",
+)
+def reject_candidate(
+    candidate_id: str,
+    body: CandidateTransitionRequest,
+    service: Annotated[CandidateReviewService, Depends(get_review_service)],
+) -> CandidateResponse:
+    try:
+        rejected = service.reject_candidate(
+            candidate_id,
+            expected_revision=body.expected_revision,
+            reason=body.reason,
+        )
+    except CandidateReviewError as error:
+        _raise_review_error(error)
+    return _candidate_response(rejected)
+
+
+@router.post(
+    "/candidates/{candidate_id}/approve",
+    response_model=ApprovalResultResponse,
+    responses=_error_responses(400, 404, 409, 503),
+    summary="Approve one candidate",
+    description="Publish one accepted candidate and refresh the derived lesson projection.",
+    operation_id="tritalele_approve_candidate",
+)
+def approve_candidate(
+    candidate_id: str,
+    body: CandidateApprovalRequest,
+    service: Annotated[CandidateApprovalService, Depends(get_approval_service)],
+) -> ApprovalResultResponse:
+    try:
+        result = service.approve(
+            candidate_id, expected_revision=body.expected_revision
+        )
+    except CandidateApprovalError as error:
+        _raise_approval_error(error)
+    return _approval_response(result)

--- a/tests/test_api_tritalele.py
+++ b/tests/test_api_tritalele.py
@@ -1,0 +1,908 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from lele_manager.api import tritalele
+from lele_manager.api.server import app
+from lele_manager.application.candidate_approval import (
+    ApprovalResult,
+    PartialApprovalError,
+    PartialRefreshError,
+    RefreshOutcome,
+    VaultWriteOutcome,
+    canonical_lesson_for,
+)
+from lele_manager.application.candidate_review import (
+    CandidateReviewFilter,
+    CandidateReviewStorageError,
+)
+from lele_manager.application.lesson_candidate import CandidateState
+from lele_manager.application.raw_source import SourceKind
+from lele_manager.application.raw_source_ingestion import PartialIngestionError
+from lele_manager.core.paths import candidates_path
+from lele_manager.core.vault import write_lesson_markdown
+
+
+API = "/api/v1/tritalele"
+EXPECTED_PATHS = {
+    f"{API}/ingestion/preview": {"post"},
+    f"{API}/ingestion/stage": {"post"},
+    f"{API}/candidates": {"get"},
+    f"{API}/candidates/{{candidate_id}}": {"get", "patch"},
+    f"{API}/candidates/{{candidate_id}}/accept": {"post"},
+    f"{API}/candidates/{{candidate_id}}/reject": {"post"},
+    f"{API}/candidates/{{candidate_id}}/approve": {"post"},
+}
+
+
+@pytest.fixture(autouse=True)
+def isolated_api_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    app.dependency_overrides.clear()
+    monkeypatch.setenv("LELE_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("LELE_VAULT_DIR", str(tmp_path / "vault"))
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def raw_payload(
+    content: str = "Alpha paragraph.\n\nBeta paragraph.",
+    *,
+    source_kind: str = "plain_text",
+    logical_name: str = "notes.txt",
+    max_characters: int = 18,
+) -> dict[str, object]:
+    return {
+        "content": content,
+        "source_kind": source_kind,
+        "logical_name": logical_name,
+        "max_characters": max_characters,
+    }
+
+
+def metadata(
+    *, topic: str = "python", title: str = "Stable API"
+) -> dict[str, object]:
+    return {
+        "topic": topic,
+        "source": "api-test",
+        "importance": 4,
+        "tags": ["api", "review"],
+        "date": "2026-07-22",
+        "title": title,
+    }
+
+
+def stage_one(
+    client: TestClient,
+    *,
+    content: str = "One complete candidate.",
+    logical_name: str = "one.txt",
+) -> dict[str, object]:
+    response = client.post(
+        f"{API}/ingestion/stage",
+        json=raw_payload(
+            content,
+            logical_name=logical_name,
+            max_characters=2_000,
+        ),
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def candidate_id(result: dict[str, object]) -> str:
+    ids = result["candidate_ids"]
+    assert isinstance(ids, list) and len(ids) == 1
+    return str(ids[0])
+
+
+def prepare_accepted_candidate(
+    client: TestClient,
+    *,
+    logical_name: str = "approval.txt",
+    topic: str = "python",
+    title: str = "Approval",
+) -> tuple[str, int]:
+    created = stage_one(client, logical_name=logical_name)
+    item_id = candidate_id(created)
+    revised = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={"expected_revision": 0, "proposed_metadata": metadata(topic=topic, title=title)},
+    )
+    assert revised.status_code == 200, revised.text
+    accepted = client.post(
+        f"{API}/candidates/{item_id}/accept",
+        json={"expected_revision": 1, "reason": "ready"},
+    )
+    assert accepted.status_code == 200, accepted.text
+    return item_id, int(accepted.json()["revision"])
+
+
+def test_openapi_exposes_exact_versioned_surface_and_schemas() -> None:
+    document = app.openapi()
+    expected_operations = {
+        (path, method)
+        for path, methods in EXPECTED_PATHS.items()
+        for method in methods
+    }
+    actual_operations = {
+        (path, method)
+        for path, path_item in document["paths"].items()
+        if path.startswith(API)
+        for method in path_item
+        if method in {"get", "patch", "post", "put", "delete"}
+    }
+
+    assert actual_operations == expected_operations
+    for existing_path in (
+        "/health",
+        "/lessons",
+        "/integrations/v1/lessons",
+        "/vault/status",
+    ):
+        assert existing_path in document["paths"]
+
+    schemas = document["components"]["schemas"]
+    for schema in (
+        "RawSourceRequest",
+        "CanonicalMetadataRequest",
+        "CandidateRevisionRequest",
+        "CandidateResponse",
+        "CandidateListResponse",
+        "IngestionResultResponse",
+        "ApprovalResultResponse",
+        "APIErrorResponse",
+    ):
+        assert schema in schemas
+
+    operation_ids: list[str] = []
+    for path, method in expected_operations:
+        operation = document["paths"][path][method]
+        operation_ids.append(operation["operationId"])
+        assert operation["operationId"].startswith("tritalele_")
+        assert operation["responses"]["200"]["content"]["application/json"][
+            "schema"
+        ]["$ref"].startswith("#/components/schemas/")
+        for status, response in operation["responses"].items():
+            if status in {"200", "422"}:
+                continue
+            assert response["content"]["application/json"]["schema"] == {
+                "$ref": "#/components/schemas/APIErrorResponse"
+            }
+        if method in {"patch", "post"}:
+            assert operation["requestBody"]["content"]["application/json"][
+                "schema"
+            ]["$ref"].startswith("#/components/schemas/")
+    assert len(operation_ids) == len(set(operation_ids))
+
+
+def test_unknown_request_fields_are_rejected(client: TestClient) -> None:
+    payload = raw_payload()
+    payload["server_path"] = "/private/source.md"
+
+    response = client.post(f"{API}/ingestion/preview", json=payload)
+
+    assert response.status_code == 422
+    assert "server_path" in response.text
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        raw_payload(logical_name=""),
+        raw_payload(max_characters=0),
+    ],
+)
+def test_domain_level_raw_source_inputs_return_structured_400(
+    client: TestClient, payload: dict[str, object]
+) -> None:
+    response = client.post(f"{API}/ingestion/preview", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["code"] in {
+        "invalid_raw_source",
+        "invalid_chunking_settings",
+    }
+
+
+@pytest.mark.parametrize(
+    ("source_kind", "logical_name", "content"),
+    [
+        ("markdown", "lesson.md", "# One\n\nBody\n\n## Two\n\nMore"),
+        ("plain_text", "notes.txt", "One paragraph.\n\nTwo paragraph."),
+        ("stdin", "stdin", "Pasted from standard input.\n\nSecond block."),
+    ],
+)
+def test_preview_is_deterministic_and_never_mutates_storage(
+    client: TestClient,
+    tmp_path: Path,
+    source_kind: str,
+    logical_name: str,
+    content: str,
+) -> None:
+    candidate_file = tmp_path / "data" / "candidates.json"
+    vault = tmp_path / "vault"
+    projection = tmp_path / "data" / "lessons.jsonl"
+    payload = raw_payload(
+        content,
+        source_kind=source_kind,
+        logical_name=logical_name,
+        max_characters=16,
+    )
+
+    first = client.post(f"{API}/ingestion/preview", json=payload)
+    second = client.post(f"{API}/ingestion/preview", json=payload)
+
+    assert first.status_code == second.status_code == 200
+    first_body = first.json()
+    second_body = second.json()
+    assert first_body["preview"] is True
+    assert first_body["candidate_ids"] == second_body["candidate_ids"]
+    assert first_body["candidate_ids"] == sorted(
+        first_body["candidate_ids"],
+        key=lambda item: next(
+            candidate["provenance"]["chunk_index"]
+            for candidate in first_body["candidates"]
+            if candidate["candidate_id"] == item
+        ),
+    )
+    assert first_body["created_candidate_ids"] == []
+    assert first_body["pending_candidate_ids"] == first_body["candidate_ids"]
+    assert not candidate_file.exists()
+    assert not vault.exists()
+    assert not projection.exists()
+
+
+def test_preview_preserves_existing_artifacts_byte_for_byte(
+    client: TestClient, tmp_path: Path
+) -> None:
+    existing = stage_one(client, content="Existing staged source.")
+    assert existing["counts"]["created"] == 1  # type: ignore[index]
+    candidate_file = tmp_path / "data" / "candidates.json"
+    before_candidates = candidate_file.read_bytes()
+    vault_file = tmp_path / "vault" / "keep.md"
+    vault_file.parent.mkdir(parents=True)
+    vault_file.write_text("keep-vault", encoding="utf-8")
+    projection = tmp_path / "data" / "lessons.jsonl"
+    projection.write_text("keep-projection\n", encoding="utf-8")
+
+    response = client.post(
+        f"{API}/ingestion/preview",
+        json=raw_payload("A different source.", logical_name="different.txt"),
+    )
+
+    assert response.status_code == 200
+    assert candidate_file.read_bytes() == before_candidates
+    assert vault_file.read_text(encoding="utf-8") == "keep-vault"
+    assert projection.read_text(encoding="utf-8") == "keep-projection\n"
+
+
+def test_stage_creates_only_candidates_and_replay_is_idempotent(
+    client: TestClient, tmp_path: Path
+) -> None:
+    payload = raw_payload(
+        "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.",
+        max_characters=19,
+    )
+
+    first = client.post(f"{API}/ingestion/stage", json=payload)
+    second = client.post(f"{API}/ingestion/stage", json=payload)
+    preview_existing = client.post(f"{API}/ingestion/preview", json=payload)
+
+    assert first.status_code == second.status_code == 200
+    first_body = first.json()
+    second_body = second.json()
+    assert first_body["created_candidate_ids"] == first_body["candidate_ids"]
+    assert first_body["skipped_candidate_ids"] == []
+    assert second_body["candidate_ids"] == first_body["candidate_ids"]
+    assert second_body["created_candidate_ids"] == []
+    assert second_body["skipped_candidate_ids"] == first_body["candidate_ids"]
+    assert preview_existing.status_code == 200
+    assert preview_existing.json()["skipped_candidate_ids"] == first_body["candidate_ids"]
+    assert preview_existing.json()["pending_candidate_ids"] == []
+    assert (tmp_path / "data" / "candidates.json").is_file()
+    assert not (tmp_path / "vault").exists()
+    assert not (tmp_path / "data" / "lessons.jsonl").exists()
+
+
+def test_missing_candidate_staging_lists_as_empty(client: TestClient) -> None:
+    response = client.get(f"{API}/candidates")
+
+    assert response.status_code == 200
+    assert response.json() == {"count": 0, "candidates": []}
+
+
+def test_candidate_filters_are_passed_to_review_service(client: TestClient) -> None:
+    seen: list[CandidateReviewFilter] = []
+
+    class RecordingReviewService:
+        def list_candidates(
+            self, filters: CandidateReviewFilter
+        ) -> tuple[object, ...]:
+            seen.append(filters)
+            return ()
+
+    app.dependency_overrides[tritalele.get_review_service] = RecordingReviewService
+
+    response = client.get(
+        f"{API}/candidates",
+        params={
+            "state": "staged",
+            "source_kind": "markdown",
+            "source_fingerprint": "sha256:source",
+            "source_logical_name": "lesson.md",
+            "chunk_index": 3,
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(seen) == 1
+    assert seen[0] == CandidateReviewFilter(
+        state=CandidateState.STAGED,
+        source_kind=SourceKind.MARKDOWN,
+        source_fingerprint="sha256:source",
+        source_logical_name="lesson.md",
+        chunk_index=3,
+    )
+
+
+def test_candidate_list_filtering_and_order_are_deterministic(
+    client: TestClient,
+) -> None:
+    first = stage_one(client, content="# Markdown candidate", logical_name="a.md")
+    second = stage_one(client, content="Plain candidate", logical_name="b.txt")
+
+    all_candidates = client.get(f"{API}/candidates")
+    filtered = client.get(
+        f"{API}/candidates", params={"source_logical_name": "a.md"}
+    )
+
+    assert all_candidates.status_code == filtered.status_code == 200
+    ids = [item["candidate_id"] for item in all_candidates.json()["candidates"]]
+    assert ids == sorted(ids)
+    assert set(ids) == {candidate_id(first), candidate_id(second)}
+    assert filtered.json()["count"] == 1
+    assert filtered.json()["candidates"][0]["candidate_id"] == candidate_id(first)
+
+
+def test_malformed_staging_is_a_sanitized_operational_error(
+    client: TestClient, tmp_path: Path
+) -> None:
+    path = tmp_path / "data" / "candidates.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("not-json /private/secret", encoding="utf-8")
+
+    response = client.get(f"{API}/candidates")
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "candidate_storage_unavailable"
+    assert "/private/secret" not in response.text
+    assert "MalformedStagingDataError" not in response.text
+
+
+def test_candidate_retrieval_has_stable_transport_only_representation(
+    client: TestClient, tmp_path: Path
+) -> None:
+    created = stage_one(client)
+    item_id = candidate_id(created)
+
+    response = client.get(f"{API}/candidates/{item_id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body) == {
+        "candidate_id",
+        "state",
+        "revision",
+        "original_text",
+        "proposed_text",
+        "effective_text",
+        "proposed_metadata",
+        "provenance",
+        "review_history",
+    }
+    assert body["candidate_id"] == item_id
+    assert body["original_text"] == body["effective_text"]
+    assert body["provenance"]["ingested_at"].endswith("+00:00")
+    assert set(body["provenance"]) == {
+        "source_kind",
+        "source_logical_name",
+        "source_fingerprint",
+        "ingested_at",
+        "chunk_index",
+        "source_span",
+        "run_metadata",
+        "transformations",
+    }
+    assert str(tmp_path) not in response.text
+    assert "JsonCandidateRepository" not in response.text
+    assert "MappingProxyType" not in response.text
+
+
+def test_missing_candidate_returns_structured_404(client: TestClient) -> None:
+    response = client.get(f"{API}/candidates/sha256:{'0' * 64}")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "detail": {"code": "candidate_not_found", "message": "Candidate was not found."}
+    }
+
+
+def test_revision_supports_text_metadata_and_complete_updates(
+    client: TestClient,
+) -> None:
+    text_item = candidate_id(stage_one(client, logical_name="text.txt"))
+    metadata_item = candidate_id(stage_one(client, logical_name="metadata.txt"))
+    complete_item = candidate_id(stage_one(client, logical_name="complete.txt"))
+
+    initial_metadata = client.patch(
+        f"{API}/candidates/{text_item}",
+        json={
+            "expected_revision": 0,
+            "proposed_metadata": metadata(title="Preserved metadata"),
+        },
+    )
+    text_response = client.patch(
+        f"{API}/candidates/{text_item}",
+        json={"expected_revision": 1, "proposed_text": "Rewritten text."},
+    )
+    initial_text = client.patch(
+        f"{API}/candidates/{metadata_item}",
+        json={"expected_revision": 0, "proposed_text": "Preserved text."},
+    )
+    metadata_response = client.patch(
+        f"{API}/candidates/{metadata_item}",
+        json={"expected_revision": 1, "proposed_metadata": metadata(title="Metadata")},
+    )
+    complete_response = client.patch(
+        f"{API}/candidates/{complete_item}",
+        json={
+            "expected_revision": 0,
+            "proposed_text": "Complete rewrite.",
+            "proposed_metadata": metadata(title="Complete"),
+            "reason": "editorial pass",
+        },
+    )
+
+    assert initial_metadata.status_code == initial_text.status_code == 200
+    assert text_response.status_code == 200
+    assert text_response.json()["proposed_text"] == "Rewritten text."
+    assert text_response.json()["proposed_metadata"] == initial_metadata.json()[
+        "proposed_metadata"
+    ]
+    assert metadata_response.status_code == 200
+    assert metadata_response.json()["proposed_text"] == "Preserved text."
+    assert metadata_response.json()["proposed_metadata"]["title"] == "Metadata"
+    assert complete_response.status_code == 200
+    assert complete_response.json()["effective_text"] == "Complete rewrite."
+    assert complete_response.json()["review_history"][-1]["reason"] == "editorial pass"
+
+
+def test_revision_rejects_incomplete_noop_and_identical_proposals(
+    client: TestClient,
+) -> None:
+    item_id = candidate_id(stage_one(client))
+
+    incomplete = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={"expected_revision": 0, "proposed_metadata": {"topic": "python"}},
+    )
+    no_op = client.patch(
+        f"{API}/candidates/{item_id}", json={"expected_revision": 0}
+    )
+    first = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={"expected_revision": 0, "proposed_text": "Changed."},
+    )
+    identical = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={"expected_revision": 1, "proposed_text": "Changed."},
+    )
+
+    assert incomplete.status_code == 422
+    assert no_op.status_code == 422
+    assert first.status_code == 200
+    assert identical.status_code == 400
+    assert identical.json()["detail"]["code"] == "invalid_candidate_review_input"
+    current = client.get(f"{API}/candidates/{item_id}").json()
+    assert current["revision"] == 1
+
+
+def test_stale_revision_does_not_mutate_source_or_provenance(
+    client: TestClient,
+) -> None:
+    item_id = candidate_id(stage_one(client))
+    original = client.get(f"{API}/candidates/{item_id}").json()
+    first = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={"expected_revision": 0, "proposed_text": "First edit."},
+    )
+    stale = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={"expected_revision": 0, "proposed_text": "Stale edit."},
+    )
+    current = client.get(f"{API}/candidates/{item_id}").json()
+
+    assert first.status_code == 200
+    assert stale.status_code == 409
+    assert stale.json()["detail"]["code"] == "stale_candidate_revision"
+    assert current["revision"] == 1
+    assert current["proposed_text"] == "First edit."
+    assert current["original_text"] == original["original_text"]
+    assert current["provenance"] == original["provenance"]
+
+
+def test_accept_and_reject_enforce_lifecycle_and_expected_revision(
+    client: TestClient,
+) -> None:
+    accepted_id = candidate_id(stage_one(client, logical_name="accept.txt"))
+    rejected_id = candidate_id(stage_one(client, logical_name="reject.txt"))
+
+    accepted = client.post(
+        f"{API}/candidates/{accepted_id}/accept",
+        json={"expected_revision": 0, "reason": "good"},
+    )
+    repeated_accept = client.post(
+        f"{API}/candidates/{accepted_id}/accept",
+        json={"expected_revision": 1},
+    )
+    rejected = client.post(
+        f"{API}/candidates/{rejected_id}/reject",
+        json={"expected_revision": 0},
+    )
+    repeated_reject = client.post(
+        f"{API}/candidates/{rejected_id}/reject",
+        json={"expected_revision": 1},
+    )
+    stale = client.post(
+        f"{API}/candidates/{accepted_id}/reject",
+        json={"expected_revision": 0},
+    )
+
+    assert accepted.status_code == rejected.status_code == 200
+    assert accepted.json()["state"] == "in_review"
+    assert rejected.json()["state"] == "rejected"
+    assert repeated_accept.status_code == repeated_reject.status_code == 409
+    assert repeated_accept.json()["detail"]["code"] == "invalid_candidate_transition"
+    assert stale.status_code == 409
+    assert stale.json()["detail"]["code"] == "stale_candidate_revision"
+
+
+def test_approval_is_ordered_and_idempotent(client: TestClient, tmp_path: Path) -> None:
+    item_id, revision = prepare_accepted_candidate(client)
+    projection = tmp_path / "data" / "lessons.jsonl"
+    vault = tmp_path / "vault"
+    assert not projection.exists()
+
+    approved = client.post(
+        f"{API}/candidates/{item_id}/approve",
+        json={"expected_revision": revision},
+    )
+
+    assert approved.status_code == 200, approved.text
+    result = approved.json()
+    artifact = vault / result["relative_vault_path"]
+    assert artifact.is_file()
+    assert result["vault_write_outcome"] == "created"
+    assert result["candidate_state_changed"] is True
+    assert result["refresh_outcome"] == {"refreshed": True}
+    assert projection.is_file()
+    records = [json.loads(line) for line in projection.read_text(encoding="utf-8").splitlines()]
+    assert [record["id"] for record in records] == [result["lesson_id"]]
+    assert client.get(f"{API}/candidates/{item_id}").json()["state"] == "approved"
+    assert len(list(vault.rglob("*.md"))) == 1
+
+    repeated = client.post(
+        f"{API}/candidates/{item_id}/approve",
+        json={"expected_revision": result["candidate_revision"]},
+    )
+    assert repeated.status_code == 200
+    assert repeated.json()["vault_write_outcome"] == "identical"
+    assert repeated.json()["candidate_state_changed"] is False
+    assert len(list(vault.rglob("*.md"))) == 1
+
+
+def test_approval_does_not_auto_accept_and_validates_metadata_and_revision(
+    client: TestClient,
+) -> None:
+    staged_id = candidate_id(stage_one(client, logical_name="staged.txt"))
+    revised = client.patch(
+        f"{API}/candidates/{staged_id}",
+        json={"expected_revision": 0, "proposed_metadata": metadata()},
+    )
+    staged_approval = client.post(
+        f"{API}/candidates/{staged_id}/approve",
+        json={"expected_revision": 1},
+    )
+
+    missing_metadata_id = candidate_id(
+        stage_one(client, logical_name="missing-metadata.txt")
+    )
+    accepted = client.post(
+        f"{API}/candidates/{missing_metadata_id}/accept",
+        json={"expected_revision": 0},
+    )
+    missing_metadata = client.post(
+        f"{API}/candidates/{missing_metadata_id}/approve",
+        json={"expected_revision": 1},
+    )
+    stale = client.post(
+        f"{API}/candidates/{missing_metadata_id}/approve",
+        json={"expected_revision": 0},
+    )
+
+    assert revised.status_code == accepted.status_code == 200
+    assert staged_approval.status_code == 409
+    assert staged_approval.json()["detail"]["code"] == "invalid_approval_lifecycle"
+    assert client.get(f"{API}/candidates/{staged_id}").json()["state"] == "staged"
+    assert missing_metadata.status_code == 400
+    assert missing_metadata.json()["detail"]["code"] == "invalid_approval_metadata"
+    assert stale.status_code == 409
+    assert stale.json()["detail"]["code"] == "stale_approval_revision"
+
+
+def test_approval_path_and_identity_collisions_are_controlled(
+    client: TestClient, tmp_path: Path
+) -> None:
+    path_id, path_revision = prepare_accepted_candidate(
+        client, logical_name="path.txt", title="Path collision"
+    )
+    repository = tritalele.get_candidate_repository()
+    path_lesson = canonical_lesson_for(repository.get(path_id))
+    destination = tmp_path / "vault" / path_lesson.relative_path
+    destination.parent.mkdir(parents=True)
+    destination.write_text("occupied", encoding="utf-8")
+
+    path_response = client.post(
+        f"{API}/candidates/{path_id}/approve",
+        json={"expected_revision": path_revision},
+    )
+
+    identity_id, identity_revision = prepare_accepted_candidate(
+        client, logical_name="identity.txt", title="Identity collision"
+    )
+    identity_lesson = canonical_lesson_for(repository.get(identity_id))
+    write_lesson_markdown(
+        tmp_path / "vault",
+        lesson_id=identity_lesson.lesson_id,
+        body=identity_lesson.body,
+        topic=identity_lesson.topic,
+        source=identity_lesson.source,
+        importance=identity_lesson.importance,
+        tags=list(identity_lesson.tags),
+        date=identity_lesson.date,
+        title=identity_lesson.title,
+        provenance=dict(identity_lesson.provenance),
+        relative_path="elsewhere/identity.md",
+    )
+    identity_response = client.post(
+        f"{API}/candidates/{identity_id}/approve",
+        json={"expected_revision": identity_revision},
+    )
+
+    assert path_response.status_code == 409
+    assert path_response.json()["detail"]["code"] == "approval_path_collision"
+    assert identity_response.status_code == 409
+    assert identity_response.json()["detail"]["code"] == "approval_identity_collision"
+
+
+def test_partial_ingestion_exposes_stable_recovery_payload(client: TestClient) -> None:
+    class FailingIngestionService:
+        def ingest(self, source: object, settings: object, preview: bool = False) -> None:
+            raise PartialIngestionError(
+                created_candidate_ids=("created-a",),
+                failed_candidate_id="failed-b",
+                remaining_candidate_ids=("remaining-c",),
+            )
+
+    app.dependency_overrides[tritalele.get_ingestion_service] = FailingIngestionService
+
+    response = client.post(f"{API}/ingestion/stage", json=raw_payload())
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "detail": {
+            "code": "partial_ingestion",
+            "message": "Candidate staging stopped after a partial ingestion.",
+            "recovery": {
+                "created_candidate_ids": ["created-a"],
+                "failed_candidate_id": "failed-b",
+                "remaining_candidate_ids": ["remaining-c"],
+            },
+        }
+    }
+
+
+@pytest.mark.parametrize("kind", ["approval", "refresh"])
+def test_partial_approval_failures_expose_sanitized_recovery(
+    client: TestClient, kind: str
+) -> None:
+    partial_result = ApprovalResult(
+        candidate_id=f"sha256:{'1' * 64}",
+        candidate_revision=3,
+        lesson_id="python/lesson",
+        relative_vault_path="python/lesson.md",
+        vault_write_outcome=VaultWriteOutcome.CREATED,
+        candidate_state_changed=True,
+        refresh_outcome=RefreshOutcome(refreshed=False),
+    )
+    error = (
+        PartialApprovalError(
+            partial_result.candidate_id,
+            partial_result.lesson_id,
+            partial_result.relative_vault_path,
+            partial_result.vault_write_outcome,
+        )
+        if kind == "approval"
+        else PartialRefreshError(partial_result)
+    )
+
+    class FailingApprovalService:
+        def approve(self, candidate_id: str, *, expected_revision: int) -> None:
+            raise error
+
+    app.dependency_overrides[tritalele.get_approval_service] = FailingApprovalService
+
+    response = client.post(
+        f"{API}/candidates/{partial_result.candidate_id}/approve",
+        json={"expected_revision": 2},
+    )
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["code"] == f"partial_{kind}"
+    assert "/tmp/" not in response.text
+    assert "Partial" not in response.text
+    if kind == "approval":
+        assert detail["recovery"] == {
+            "candidate_id": partial_result.candidate_id,
+            "lesson_id": partial_result.lesson_id,
+            "relative_vault_path": partial_result.relative_vault_path,
+            "vault_write_outcome": "created",
+            "candidate_persistence_state": "unknown",
+        }
+        assert "retry" not in response.text.lower()
+    else:
+        assert detail["recovery"] == {
+            "partial_approval_result": {
+                "candidate_id": partial_result.candidate_id,
+                "candidate_revision": partial_result.candidate_revision,
+                "lesson_id": partial_result.lesson_id,
+                "relative_vault_path": partial_result.relative_vault_path,
+                "vault_write_outcome": "created",
+                "candidate_state_changed": True,
+                "refresh_outcome": {"refreshed": False},
+            },
+            "canonical_lesson_persisted": True,
+            "candidate_approval_persisted": True,
+            "projection_refreshed": False,
+        }
+
+
+def test_storage_failure_never_leaks_paths_or_exception_details(
+    client: TestClient,
+) -> None:
+    class FailingReviewService:
+        def list_candidates(self, filters: CandidateReviewFilter) -> None:
+            raise CandidateReviewStorageError(
+                "JsonCandidateRepository failed at /private/candidates.json: secret"
+            )
+
+    app.dependency_overrides[tritalele.get_review_service] = FailingReviewService
+
+    response = client.get(f"{API}/candidates")
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["code"] == "candidate_storage_unavailable"
+    assert "/private/candidates.json" not in response.text
+    assert "secret" not in response.text
+    assert "CandidateReviewStorageError" not in response.text
+
+
+def test_full_api_happy_path(client: TestClient, tmp_path: Path) -> None:
+    payload = raw_payload(
+        "# API boundary\n\nA complete lesson candidate.",
+        source_kind="markdown",
+        logical_name="api-boundary.md",
+        max_characters=2_000,
+    )
+    preview = client.post(f"{API}/ingestion/preview", json=payload)
+    stage = client.post(f"{API}/ingestion/stage", json=payload)
+    assert preview.status_code == stage.status_code == 200
+    assert preview.json()["candidate_ids"] == stage.json()["candidate_ids"]
+    item_id = candidate_id(stage.json())
+
+    listed = client.get(f"{API}/candidates")
+    fetched = client.get(f"{API}/candidates/{item_id}")
+    revised = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={
+            "expected_revision": 0,
+            "proposed_text": "Use a stable, versioned API boundary.",
+            "proposed_metadata": metadata(title="Versioned boundary"),
+        },
+    )
+    accepted = client.post(
+        f"{API}/candidates/{item_id}/accept", json={"expected_revision": 1}
+    )
+    approved = client.post(
+        f"{API}/candidates/{item_id}/approve", json={"expected_revision": 2}
+    )
+
+    assert listed.status_code == fetched.status_code == 200
+    assert listed.json()["count"] == 1
+    assert revised.status_code == accepted.status_code == approved.status_code == 200
+    approval = approved.json()
+    markdown = tmp_path / "vault" / approval["relative_vault_path"]
+    assert markdown.is_file()
+    markdown_text = markdown.read_text(encoding="utf-8")
+    assert f"id: {approval['lesson_id']}" in markdown_text
+    assert "Use a stable, versioned API boundary." in markdown_text
+    final_candidate = client.get(f"{API}/candidates/{item_id}").json()
+    assert final_candidate["state"] == "approved"
+    projection = tmp_path / "data" / "lessons.jsonl"
+    assert projection.is_file()
+    assert approval["lesson_id"] in projection.read_text(encoding="utf-8")
+
+
+def test_existing_api_paths_remain_compatible(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from lele_manager.api import server
+
+    data_path = tmp_path / "legacy-lessons.jsonl"
+    monkeypatch.setattr(server, "DATA_PATH", data_path)
+
+    health = client.get("/health")
+    lessons = client.get("/lessons")
+    integration = client.get("/integrations/v1/lessons")
+
+    assert health.status_code == lessons.status_code == integration.status_code == 200
+    assert health.json()["status"] == "ok"
+    assert lessons.json() == []
+    assert integration.json()["lessons"] == []
+    openapi_paths = app.openapi()["paths"]
+    for path in ("/health", "/lessons", "/integrations/v1/lessons", "/vault/status"):
+        assert path in openapi_paths
+
+
+def test_boundary_isolation_and_no_forbidden_framework_leakage() -> None:
+    root = Path(__file__).parents[1]
+    api_source = (root / "src/lele_manager/api/tritalele.py").read_text(
+        encoding="utf-8"
+    )
+    server_source = (root / "src/lele_manager/api/server.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "cli.tritalele" not in api_source
+    assert "api.server" not in api_source
+    assert "RawSourceIngestionService" in api_source
+    assert "DeterministicRawSourceChunker" in api_source
+    assert "hashlib" not in api_source
+    assert "include_router(tritalele_router)" in server_source
+
+    for directory in ("application", "core"):
+        for module in (root / f"src/lele_manager/{directory}").glob("*.py"):
+            source = module.read_text(encoding="utf-8")
+            assert "from fastapi" not in source
+            assert "import fastapi" not in source
+            assert "from pydantic" not in source
+            assert "import pydantic" not in source
+
+
+def test_dependency_overrides_are_cleared_after_each_test() -> None:
+    assert app.dependency_overrides == {}
+    assert candidates_path().name == "candidates.json"


### PR DESCRIPTION
## Summary

- expose the TritaLeLe candidate workflow through a dedicated versioned FastAPI router;
- keep ingestion preview, staging, review, rejection and approval as separate operations;
- delegate all business behavior to the existing ingestion, review and approval application services;
- provide strict request models, stable response schemas and structured error payloads;
- preserve optimistic concurrency through explicit expected revisions;
- keep existing API contracts compatible.

## Architecture

The new API boundary lives in `lele_manager.api.tritalele` and is registered
by the main FastAPI application without adding the complete workflow to the
existing `server.py` module.

The router:

- is synchronous because the underlying services and filesystem adapters are synchronous;
- uses per-request dependency composition;
- does not import the CLI boundary;
- does not expose server filesystem paths as ingestion inputs;
- does not leak FastAPI or Pydantic into domain or application modules;
- does not duplicate chunking, candidate identity, filtering, lifecycle or approval rules.

## Endpoint surface

- `POST /api/v1/tritalele/ingestion/preview`
- `POST /api/v1/tritalele/ingestion/stage`
- `GET /api/v1/tritalele/candidates`
- `GET /api/v1/tritalele/candidates/{candidate_id}`
- `PATCH /api/v1/tritalele/candidates/{candidate_id}`
- `POST /api/v1/tritalele/candidates/{candidate_id}/accept`
- `POST /api/v1/tritalele/candidates/{candidate_id}/reject`
- `POST /api/v1/tritalele/candidates/{candidate_id}/approve`

There is no combined ingest-and-approve operation and no bulk approval.

## Safety and contracts

- preview does not create or mutate candidate, vault or projection artifacts;
- staging creates candidates only;
- approval requires one explicit candidate ID and expected revision;
- staged candidates are never accepted automatically;
- canonical Markdown publication, candidate persistence and JSONL refresh retain their established ordering;
- unknown request fields are rejected;
- incomplete canonical metadata is rejected;
- controlled failures return sanitized machine-readable errors;
- partial-operation errors expose stable recovery information without internal paths or exception details.

## Error statuses

- `400`: invalid source, chunking, review or approval input;
- `404`: missing candidate;
- `409`: stale revision, lifecycle conflict, identity conflict or publication collision;
- `500`: ingestion-plan invariant failure;
- `503`: storage, publication, persistence, refresh or partial-operation failure;
- `422`: FastAPI/Pydantic structural request validation.

## Local validation

Completed successfully:

- 3 locally executable API/OpenAPI/boundary tests;
- 216 domain, application and CLI regression tests;
- Python compilation;
- Ruff;
- Mypy across 55 source files;
- tracked and untracked whitespace checks;
- two independent implementation audits.

The focused API file contains 30 tests. In the current local environment,
27 HTTP executions block in the existing FastAPI/Starlette `TestClient`
worker-thread path. The same isolated `/health` test and the same stack state
were reproduced in the untouched `main` worktree with identical interpreter,
flags and timeout.

No production or dependency workaround was added for that baseline environment
problem. The complete GitHub Actions result is therefore a mandatory merge
gate for this pull request.

Closes #125
