### PR TITLE
docs: establish English-canonical bilingual documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,45 +5,45 @@ body:
   - type: markdown
     attributes:
       value: |
-        Grazie! Per velocizzare la diagnosi, compila i campi sotto con dettagli riproducibili.
+        Thank you. Provide reproducible details and remove sensitive data.
   - type: textarea
     id: what-happened
     attributes:
-      label: Cosa è successo?
-      description: Cosa ti aspettavi e cosa hai ottenuto.
-      placeholder: "Mi aspettavo X, invece ho visto Y..."
+      label: What happened?
+      description: Describe what you expected and what you observed.
+      placeholder: "I expected X, but observed Y..."
     validations:
       required: true
   - type: textarea
     id: repro
     attributes:
-      label: Come riprodurre
-      description: Passi minimi + comandi + input.
+      label: How to reproduce
+      description: Provide minimal steps, commands, and input.
       placeholder: |
-        1) ...
-        2) ...
-        3) ...
+        1. ...
+        2. ...
+        3. ...
     validations:
       required: true
   - type: textarea
     id: logs
     attributes:
-      label: Log / output
-      description: Incolla output rilevante (senza dati sensibili).
+      label: Logs or output
+      description: Paste relevant output without sensitive data.
       render: shell
     validations:
       required: false
   - type: input
     id: python
     attributes:
-      label: Versione Python
-      placeholder: "es. 3.12.2"
+      label: Python version
+      placeholder: "For example: 3.12.2"
     validations:
       required: false
   - type: input
     id: os
     attributes:
-      label: OS
-      placeholder: "es. Ubuntu 24.04 / macOS / Windows"
+      label: Operating system
+      placeholder: "For example: Ubuntu 24.04, macOS, or Windows"
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,34 +1,34 @@
 name: Feature request
-description: Proponi una feature o miglioramento
+description: Propose a feature or improvement
 labels: ["enhancement"]
 body:
   - type: textarea
     id: problem
     attributes:
-      label: Problema / bisogno
-      description: Che problema risolve? Per chi?
-      placeholder: "Vorrei poter..."
+      label: Problem or need
+      description: What problem does this solve, and for whom?
+      placeholder: "I would like to..."
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
-      label: Proposta
-      description: Come immagini la soluzione (API/CLI/UX)?
-      placeholder: "Propongo di..."
+      label: Proposal
+      description: Describe the expected API, CLI, workflow, or user experience.
+      placeholder: "I propose..."
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternative considerate
-      placeholder: "Ho considerato anche..."
+      label: Alternatives considered
+      placeholder: "I also considered..."
     validations:
       required: false
   - type: textarea
     id: scope
     attributes:
-      label: Scope / note
-      description: Eventuali limiti, compatibilità, impatti.
+      label: Scope and notes
+      description: Describe relevant limits, compatibility constraints, or impact.
     validations:
       required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,33 @@
-## Cosa cambia
-- [ ] Bugfix
+## What changes
+
+- [ ] Bug fix
 - [ ] Feature
-- [ ] Docs
-- [ ] Refactor/tech-debt
-- [ ] Test/CI
+- [ ] Documentation
+- [ ] Refactor / technical debt
+- [ ] Test / CI
 
-## Perché
-Spiega la motivazione (contesto e impatto).
+## Why
 
-## Come verificare
-- Comandi / steps per testare localmente:
-  - `ruff check .`
-  - `pytest`
+Explain the context, motivation, and expected impact.
 
-## Note
-- Breaking change? (sì/no)
-- Docs aggiornate? (sì/no)
+## How to verify
+
+List the commands or steps used to validate the change.
+
+- [ ] `ruff check .`
+- [ ] `mypy src/lele_manager`
+- [ ] `pytest`
+- [ ] Additional relevant checks are documented below.
+
+## Documentation
+
+- [ ] User, contributor, API, or CLI documentation was updated when behavior changed.
+- [ ] Changes to canonical bilingual documentation were evaluated against the Italian mirror.
+- [ ] Required Italian mirrors were updated in this pull request, or the reason they were not needed is explained.
+- [ ] Reciprocal language links and relative Markdown links remain valid.
+
+## Notes
+
+- Breaking change: yes / no
+- Related issue:
+- Additional validation or compatibility notes:

--- a/CONTRIBUTING.it.md
+++ b/CONTRIBUTING.it.md
@@ -1,0 +1,110 @@
+# Contribuire a LeLe Manager
+
+[English](CONTRIBUTING.md) | [Italiano](CONTRIBUTING.it.md)
+
+Grazie per l'interesse. Il progetto accetta contributi di codice, test,
+documentazione e segnalazioni di bug.
+
+## Avvio rapido dello sviluppo locale
+
+Requisiti:
+
+- una versione Python supportata dal progetto; vedere `pyproject.toml`;
+- `git`.
+
+Setup tipico:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip
+pip install -e ".[dev]"
+```
+
+## Quality gate
+
+Prima di aprire una pull request eseguire:
+
+```bash
+ruff check .
+mypy src/lele_manager
+pytest
+```
+
+Le modifiche frontend o GUI possono richiedere anche:
+
+```bash
+./scripts/build-gui.sh
+cd frontend
+npm install
+npm run test:e2e
+```
+
+Durante lo sviluppo usare il più piccolo insieme di verifiche pertinente;
+prima della revisione finale eseguire tutti i gate richiesti.
+
+## Tipi di contributo
+
+- I bugfix dovrebbero includere un test che riproduce il problema quando è
+  ragionevole.
+- Le nuove feature devono restare focalizzate; aprire prima una issue quando
+  serve allineamento progettuale.
+- Le modifiche documentali devono migliorare chiarezza, esempi, navigazione o
+  troubleshooting senza alterare involontariamente il significato tecnico.
+- Le modifiche a test e CI devono migliorare copertura o affidabilità senza
+  introdurre infrastruttura non necessaria.
+
+## Issue e pull request
+
+Una issue utile include:
+
+- comportamento atteso;
+- comportamento osservato;
+- passi, comandi o input minimi per riprodurre;
+- sistema operativo e versione Python quando pertinenti.
+
+Le pull request devono:
+
+- affrontare un unico tema coerente;
+- spiegare perché la modifica è necessaria, non soltanto cosa cambia;
+- aggiornare o aggiungere test quando opportuno;
+- aggiornare la documentazione API, CLI o utente quando cambia il comportamento;
+- evitare refactor massivi non correlati.
+
+## Documentazione bilingue
+
+L'inglese è la lingua canonica della documentazione. I mirror italiani sono
+ufficialmente mantenuti per le coppie dichiarate in
+[`docs/it/documentation-policy.md`](docs/it/documentation-policy.md).
+
+Quando una pull request modifica un documento canonico bilingue:
+
+- valutare il mirror italiano nella stessa pull request;
+- aggiornare entrambe le versioni quando cambiano requisiti, esempi,
+  avvertenze, limitazioni o significato tecnico;
+- preservare i collegamenti reciproci di selezione lingua;
+- mantenere invariati comandi, opzioni, endpoint, simboli, percorsi, nomi di
+  file e snippet;
+- eseguire:
+
+```bash
+pytest tests/test_documentation.py
+```
+
+I documenti storici, generati, interni e le fonti tecniche solo inglese sono
+esclusi soltanto come dichiarato nella politica documentale.
+
+## Stile e compatibilità
+
+- Seguire lo stile già usato nell'area modificata.
+- Evitare refactor ampi dentro piccoli bugfix.
+- Preferire nomi espliciti e funzioni piccole.
+- Non committare segreti, credenziali, dati personali del vault, dataset o
+  modelli.
+- Preservare la compatibilità con le versioni Python e la toolchain frontend
+  supportate.
+
+## Licenza
+
+Contribuendo, accetti che il contributo venga rilasciato con la stessa licenza
+del progetto.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,19 @@
-# Contributing to lele-manager
-Grazie per l’interesse! Questo progetto accetta contributi di codice, test, documentazione e bug report.
+# Contributing to LeLe Manager
 
-## Quick start (sviluppo locale)
-Requisiti:
-- Python supportato dal progetto (vedi `pyproject.toml`)
-- `git`
+[English](CONTRIBUTING.md) | [Italiano](CONTRIBUTING.it.md)
 
-Setup tipico:
-1. Fork + clone
-2. Crea un virtualenv
-3. Installa le dipendenze di sviluppo (extras `dev` se presenti)
+Thank you for your interest. This project accepts code, test, documentation,
+and bug-report contributions.
 
-Esempio (adatta al tuo ambiente):
+## Local development quick start
+
+Requirements:
+
+- a Python version supported by the project; see `pyproject.toml`;
+- `git`.
+
+Typical setup:
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
@@ -19,40 +21,87 @@ python -m pip install -U pip
 pip install -e ".[dev]"
 ```
 
-Se .[dev] non è definito nel tuo pyproject.toml, installa invece da requirements-dev.txt (se presente) o segui le istruzioni nel README.
+## Quality gates
 
-## Quality gates (prima di aprire una PR)
-Il repo usa CI con lint + test. In locale, prima di aprire una PR:
-- ruff check .
-- pytest
+Before opening a pull request, run:
 
+```bash
+ruff check .
+mypy src/lele_manager
+pytest
+```
 
-Se il progetto usa anche formatting, aggiungi quel comando qui (es. ruff format .).
+Frontend or GUI changes may also require:
 
-## Tipi di contributi
-- Bugfix: con test che riproduce il bug (quando sensato).
-- Nuove feature: piccole e focalizzate; meglio aprire prima una issue per allinearci.
-- Docs: chiarimenti, esempi, troubleshooting.
-- Test/CI: miglioramenti di copertura e affidabilità.
+```bash
+./scripts/build-gui.sh
+cd frontend
+npm install
+npm run test:e2e
+```
 
-## Issue e PR: come preferiamo lavorare
-Quando apri una issue, includi:
-- cosa ti aspettavi
-- cosa hai ottenuto
-- come riprodurre (comandi / input minimi)
-- OS + versione Python (se rilevante)
+Use the smallest relevant validation set while developing, then run the full
+required gates before publishing the final revision.
 
-## Pull Request
-- PR piccole e leggibili (idealmente 1 tema per PR)
-- descrizione chiara del “perché” (non solo “cosa”)
-- test aggiornati/aggiunti quando serve
-- se tocca l’API/CLI: aggiorna anche la doc/README
+## Contribution types
 
-## Stile e compatibilità
-- Mantieni lo stile già presente nel progetto
-- Evita refactor massivi dentro a bugfix piccoli
-- Preferisci nomi espliciti e funzioni piccole
-- Nessun dato sensibile/credenziali nei commit
+- Bug fixes should include a reproducing test when practical.
+- New features should remain focused; open an issue first when design alignment
+  is useful.
+- Documentation changes should improve clarity, examples, navigation, or
+  troubleshooting without altering technical meaning accidentally.
+- Test and CI changes should improve coverage or reliability without adding
+  unnecessary infrastructure.
+
+## Issues and pull requests
+
+A useful issue includes:
+
+- expected behavior;
+- observed behavior;
+- minimal reproduction steps, commands, or input;
+- operating system and Python version when relevant.
+
+Pull requests should:
+
+- address one coherent concern;
+- explain why the change is needed, not only what changed;
+- update or add tests when appropriate;
+- update API, CLI, or user documentation when behavior changes;
+- avoid unrelated mass refactors.
+
+## Bilingual documentation
+
+English is the canonical documentation language. Italian mirrors are
+officially maintained for the pairs declared in
+[`docs/documentation-policy.md`](docs/documentation-policy.md).
+
+When a pull request changes a bilingual canonical document:
+
+- evaluate the Italian mirror in the same pull request;
+- update both versions when requirements, examples, warnings, limitations, or
+  technical meaning change;
+- preserve reciprocal language links;
+- keep commands, options, endpoints, symbols, paths, filenames, and snippets
+  unchanged;
+- run:
+
+```bash
+pytest tests/test_documentation.py
+```
+
+Historical, generated, internal, and English-only technical documents are
+excluded only as declared in the documentation policy.
+
+## Style and compatibility
+
+- Follow the style already used in the affected area.
+- Avoid broad refactors inside small bug fixes.
+- Prefer explicit names and small functions.
+- Do not commit secrets, credentials, personal vault data, datasets, or models.
+- Preserve supported Python and frontend toolchain compatibility.
 
 ## Licensing
-Contribuendo, accetti che il tuo contributo venga rilasciato sotto la stessa licenza del progetto.
+
+By contributing, you agree that your contribution is released under the same
+license as the project.

--- a/README.it.md
+++ b/README.it.md
@@ -1,0 +1,667 @@
+# LeLe Manager 🐒 — Lesson-Learned Manager
+
+[English](README.md) | [Italiano](README.it.md)
+
+[![Security](https://github.com/gcomneno/lele-manager/actions/workflows/security.yml/badge.svg)](https://github.com/gcomneno/lele-manager/actions/workflows/security.yml)
+[![CI](https://github.com/gcomneno/lele-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/gcomneno/lele-manager/actions/workflows/ci.yml)
+
+LeLe Manager è un sistema local-first end-to-end per raccogliere, validare,
+cercare e riutilizzare lesson learned testuali.
+
+Una lesson combina contenuto Markdown e metadati stabili. LeLe Manager può:
+
+- raccogliere lesson tramite flussi Markdown, CLI, GUI e API;
+- cercare per testo, topic, fonte, data, importanza e tag;
+- individuare duplicati esatti, quasi-duplicati e lesson correlate;
+- addestrare un topic model e riutilizzare la stessa pipeline di feature per la
+  similarità;
+- preservare un vault Markdown ispezionabile pubblicando dataset e modelli
+  derivati.
+
+L'inglese è la lingua canonica della documentazione. Consultare la
+[politica linguistica](docs/it/documentation-policy.md).
+
+## Quality gate
+
+- **CI:** `ruff check .`, `mypy src/lele_manager`, `pytest`, packaging smoke e
+  smoke E2E Playwright con Python 3.12 e Node.js 22.
+- **Security:** `pip-audit` e `bandit` tramite GitHub Actions.
+- **pre-commit:** pulizia whitespace e fine file, `check-yaml` e `ruff`.
+- **Documentazione:** coppie bilingui obbligatorie, selettori lingua reciproci,
+  navigazione root nella stessa lingua e link relativi.
+
+Eseguire i controlli documentali con:
+
+```bash
+pytest tests/test_documentation.py
+```
+
+## Collegamenti del progetto
+
+- Roadmap completa: [ROADMAP.it.md](ROADMAP.it.md)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)
+- Guida contributor: [CONTRIBUTING.it.md](CONTRIBUTING.it.md)
+- Politica documentale:
+  [docs/it/documentation-policy.md](docs/it/documentation-policy.md)
+- Contratto projection store:
+  [docs/it/projection-store.md](docs/it/projection-store.md)
+
+## Obiettivi principali
+
+- Raccolta veloce delle lesson tramite CLI e API.
+- Metadati stabili: data, fonte, topic, importanza, tag e titolo.
+- Ricerca full-text e tramite filtri.
+- Suggerimenti di similarità durante scrittura e revisione.
+- Authoring local-first in Markdown con JSONL e artefatti ML derivati.
+- Automazione progressiva di classificazione e ranking senza rendere opachi o
+  difficili da recuperare i dati dell'utente.
+
+## Stack tecnico
+
+- Python **3.12** in CI; testato anche con Python 3.13.
+- `pandas` e `numpy` per l'elaborazione dati.
+- `scikit-learn` per TF-IDF, classificazione e similarità.
+- FastAPI e Uvicorn per l'API HTTP.
+- Svelte, TypeScript e Vite per la GUI web.
+- Un port projection-store indipendente dal backend con JSONL come adapter di
+  compatibilità corrente. SQLite resta un obiettivo di migrazione successivo;
+  vedere il [contratto projection store](docs/it/projection-store.md) e
+  [ADR 0001](docs/adr/0001-storage-backend.md), fonte tecnica canonica inglese.
+
+## Setup
+
+Clonare il repository e creare un ambiente virtuale:
+
+```bash
+git clone git@github.com:gcomneno/lele-manager.git
+cd lele-manager
+
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+
+pip install -e .[dev]
+```
+
+Eseguire controlli statici e test Python:
+
+```bash
+ruff check .
+mypy src/lele_manager
+pytest
+```
+
+## Primi strumenti CLI
+
+Gli strumenti originali basati sui moduli restano disponibili:
+
+```bash
+# Converti un file CSV di lesson in JSON
+python -m lele_manager.cli.csv2json samples/input.csv samples/output.json
+
+# Monitora una directory per nuovi file
+python -m lele_manager.cli.file_watcher data
+
+# Importa lesson Markdown con frontmatter YAML da un vault
+python -m lele_manager.cli.import_from_dir \
+  "$LELE_VAULT_DIR" \
+  data/lessons.jsonl \
+  --on-duplicate overwrite \
+  --default-source note \
+  --default-importance 3 \
+  --write-missing-frontmatter
+```
+
+## Flusso rapido tramite CLI legacy
+
+Aggiungere una lesson:
+
+```bash
+python -m lele_manager.cli.add_lesson \
+  --text "With a src layout I must configure PYTHONPATH or use a conftest for pytest." \
+  --source chatgpt \
+  --topic python \
+  --importance 4 \
+  --tags "python,pytest,tooling"
+```
+
+Campi principali:
+
+- `text`: contenuto della lesson;
+- `source`: origine come `chatgpt`, `book`, `experiment` o `note`;
+- `topic`: topic principale come `python`, `ml`, `linux` o `writing`;
+- `importance`: importanza numerica, normalmente da 1 a 5;
+- `tags`: tag separati da virgola.
+
+Elencare le lesson:
+
+```bash
+python -m lele_manager.cli.list_lessons --limit 10
+```
+
+## LeLe Vault: Markdown e frontmatter YAML
+
+LeLe Manager supporta un vault Markdown come superficie di authoring delle
+lesson approvate.
+
+Il flusso tipico è:
+
+- scrivere e organizzare file `.md` sotto una directory come `~/LeLeVault`;
+- importarli e normalizzarli in `data/lessons.jsonl`;
+- addestrare o aggiornare i modelli derivati;
+- interrogarli tramite CLI, API o GUI.
+
+L'ID della lesson vive nel frontmatter. Nel contratto canonico del vault,
+identità e collocazione sono allineate: `topic` corrisponde alla prima
+directory relativa e `id` al percorso relativo senza `.md`. Rinominare o
+spostare un file canonico richiede quindi di aggiornare i metadati di identità.
+
+### Struttura consigliata del vault
+
+```text
+LeLeVault/
+  python/
+    2025-11-20.pytest-src-layout.md
+  cpp/
+    2025-11-20.cin-vs-getline.md
+  linux/
+    2025-11-20.rsync-dry-run-backup.md
+  writing/
+    2025-11-22.show-dont-tell.md
+```
+
+Convenzioni soft:
+
+- nome directory = topic principale;
+- nome file = `YYYY-MM-DD.slug.md`;
+- nello slug usare `.` e `-`, non `_`.
+
+### Schema di ingresso dell'importer
+
+Una lesson può iniziare con frontmatter YAML:
+
+```markdown
+---
+id: cpp/2025-11-20.cin-vs-getline
+topic: cpp
+source: book
+importance: 4
+tags: [cpp, io, strings]
+date: 2025-11-20
+title: "LL-5 — std::cin vs std::getline"
+---
+```
+
+L'importer accetta uno schema di ingresso tollerante:
+
+- `id` è opzionale e può essere derivato dal percorso relativo;
+- `topic` può provenire dal frontmatter, da `--default-topic` o dalla directory;
+- `source` identifica l'origine;
+- `importance` è normalmente un intero da 1 a 5;
+- `tags` può essere una lista o una stringa separata da virgole;
+- `date` usa una forma ISO-like e può essere derivata dal nome file;
+- `title` è opzionale per l'ingresso dell'importer.
+
+LeLe Manager calcola anche `frontmatter_hash` per diagnostica e versionamento.
+L'identità resta `id`.
+
+La tolleranza dell'importer non implica che ogni file importabile soddisfi il
+contratto canonico di `doctor`.
+
+### Schema canonico validato da `lele doctor`
+
+`lele doctor` richiede tutti e sette i campi:
+
+- `id`;
+- `topic`;
+- `source`;
+- `importance`;
+- `tags`;
+- `date`;
+- `title`.
+
+`id`, `topic`, `source` e `title` devono essere stringhe non vuote.
+`importance` deve essere un intero da 1 a 5. `date` deve essere una data valida
+`YYYY-MM-DD`. `tags` deve essere una lista non vuota di stringhe non vuote.
+Anche il body Markdown deve essere non vuoto.
+
+Quando è disponibile un contesto vault, i file selezionati devono restare
+dentro il vault dopo la risoluzione dei symlink. `topic` deve corrispondere alla
+prima directory relativa e `id` all'intero percorso relativo senza `.md`.
+
+### Validare un vault
+
+```bash
+# Valida ricorsivamente il vault configurato tramite LELE_VAULT_DIR
+lele doctor
+
+# Valida un vault specifico
+lele doctor --vault /path/to/LeLeVault
+
+# Valida file selezionati usando il vault configurato come contesto
+lele doctor "$LELE_VAULT_DIR/python/2026-07-13.example.md"
+
+# Produce JSON adatto agli script
+lele doctor --json
+```
+
+`lele doctor` legge il Markdown senza riscrivere intenzionalmente contenuto,
+timestamp o permessi. L'accesso filesystem può comunque aggiornare l'access
+time.
+
+Exit code:
+
+- `0`: report valido;
+- `1`: errori di validazione;
+- `2`: errore operativo o di utilizzo, compresa la selezione di un file esterno
+  al vault configurato.
+
+### Importare Markdown in JSONL
+
+```bash
+python -m lele_manager.cli.import_from_dir \
+  "$LELE_VAULT_DIR" \
+  data/lessons.jsonl \
+  --on-duplicate overwrite \
+  --default-source note \
+  --default-importance 3 \
+  --write-missing-frontmatter
+```
+
+L'importer:
+
+- cerca ricorsivamente file `.md`;
+- legge frontmatter e body;
+- deriva un ID mancante dal percorso relativo;
+- deriva o normalizza topic, tag, importanza e data;
+- calcola `frontmatter_hash`;
+- costruisce in memoria una mappa `id -> record`;
+- pubblica uno snapshot JSONL completo con un record per ID unico.
+
+`--write-missing-frontmatter` ripara soltanto campi di ingresso mancanti o non
+validi. Un frontmatter completo e valido non viene riscritto soltanto per
+normalizzare l'output JSONL.
+
+Il comportamento sui duplicati si seleziona con:
+
+- `--on-duplicate overwrite`: vince l'ultimo record scandito;
+- `--on-duplicate skip`: vince il primo record;
+- `--on-duplicate error`: arresto al primo ID duplicato.
+
+### Flusso di refresh consigliato
+
+1. Scrivere o organizzare le lesson Markdown in `$LELE_VAULT_DIR`.
+2. Importare il vault.
+3. Addestrare il topic model.
+4. Interrogare l'archivio.
+
+```bash
+python -m lele_manager.cli.import_from_dir \
+  "$LELE_VAULT_DIR" \
+  data/lessons.jsonl \
+  --on-duplicate overwrite \
+  --write-missing-frontmatter
+
+python -m lele_manager.cli.train_topic_model \
+  --input data/lessons.jsonl \
+  --output models/topic_model.joblib \
+  --overwrite
+
+python -m lele_manager.cli.suggest_similar \
+  --input data/lessons.jsonl \
+  --model models/topic_model.joblib \
+  --text "When std::cin reads a string, input is truncated at whitespace" \
+  --top-k 5 \
+  --min-score 0.1
+```
+
+## Topic model e similarità
+
+`train_topic_model(df)` costruisce una pipeline scikit-learn con feature TF-IDF
+e `LogisticRegression`.
+
+`LessonFeatureExtractor` combina:
+
+- feature TF-IDF dal testo della lesson;
+- lunghezza in caratteri;
+- numero di parole;
+- `importance`, quando disponibile.
+
+La stessa rappresentazione delle feature supporta classificazione del topic e
+similarità.
+
+`LessonSimilarityIndex.from_lessons(...)` e
+`LessonSimilarityIndex.from_topic_pipeline(...)` costruiscono l'indice di
+similarità. `most_similar(query_text, top_k)` restituisce ID e punteggi coseno.
+
+### Addestramento tramite CLI del modulo
+
+```bash
+python -m lele_manager.cli.train_topic_model \
+  --input data/lessons.jsonl \
+  --output models/topic_model.joblib \
+  --overwrite
+```
+
+L'ingresso JSONL deve contenere almeno `text` e `topic`.
+
+```json
+{"id": "89c6bca8-941b-4a93-a7ca-a35e584ae5ec",
+ "text": "With a src layout I must manage PYTHONPATH or use a conftest for pytest.",
+ "topic": "python",
+ "source": "chatgpt",
+ "importance": 4,
+ "tags": ["python", "pytest", "tooling"]}
+```
+
+La pipeline completa viene salvata in `models/topic_model.joblib`.
+
+### Trovare lesson simili tramite CLI del modulo
+
+Query da testo libero:
+
+```bash
+python -m lele_manager.cli.suggest_similar \
+  --input data/lessons.jsonl \
+  --model models/topic_model.joblib \
+  --text "With a src layout I must configure PYTHONPATH or use a conftest for pytest." \
+  --top-k 5 \
+  --min-score 0.1
+```
+
+Query tramite ID di una lesson esistente:
+
+```bash
+python -m lele_manager.cli.suggest_similar \
+  --input data/lessons.jsonl \
+  --model models/topic_model.joblib \
+  --from-id "89c6bca8-941b-4a93-a7ca-a35e584ae5ec" \
+  --id-column id \
+  --top-k 5 \
+  --min-score 0.1
+```
+
+L'output comprende ID della lesson, punteggio di similarità e anteprima del
+testo.
+
+## Sicurezza e pre-commit
+
+Il workflow security viene eseguito su push, pull request e con cadenza
+settimanale:
+
+- `pip-audit` controlla le dipendenze Python;
+- `bandit` controlla il codice Python sotto `src/`.
+
+Installare gli hook pre-commit locali con:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+La configurazione fornisce pulizia whitespace e newline finale, validazione
+YAML e controlli Ruff.
+
+## Dati e modelli locali
+
+- I dati personali delle lesson vivono sotto `data/`.
+- I modelli addestrati vivono sotto `models/`.
+- Entrambe le directory sono escluse dal versionamento.
+
+Il repository pubblico non contiene quindi vault personale, dataset derivato
+o modelli addestrati.
+
+## Script di utilità
+
+### Refresh completo: `scripts/lele-api-refresh.sh`
+
+Il refresh di sviluppo completo:
+
+1. importa `$LELE_VAULT_DIR` in `data/lessons.jsonl`;
+2. riaddestra `models/topic_model.joblib`;
+3. avvia il server FastAPI con Uvicorn `--reload`.
+
+```bash
+cd ~/Projects/lele-manager
+export LELE_VAULT_DIR=/home/user/LeLeVault
+./scripts/lele-api-refresh.sh
+```
+
+### Solo API: `scripts/lele-api-dev.sh`
+
+Usare questo script quando dataset e modello sono già pronti:
+
+```bash
+cd ~/Projects/lele-manager
+./scripts/lele-api-dev.sh
+```
+
+Lo script individua la root del progetto, attiva `.venv`, controlla Uvicorn e
+avvia il server su `http://127.0.0.1:8000`.
+
+## API FastAPI
+
+Gli endpoint principali comprendono:
+
+- `GET /health`;
+- `GET /lessons`;
+- `GET /lessons/{id}`;
+- `GET /lessons/{id}/similar`;
+- `GET /duplicates`;
+- `POST /similar`;
+- `POST /editor/suggest`;
+- `POST /export/search`;
+- `GET /stats/summary`;
+- `GET /stats/timeline`;
+- `POST /train/topic`;
+- `POST /lessons/search`.
+
+Gli endpoint di similarità accettano `explain=true`, dove documentato, per
+includere rank, topic e metadati sui tag condivisi.
+
+Il workflow versionato dei candidati TritaLeLe è esposto sotto
+`/api/v1/tritalele`.
+
+Avviare il flusso completo con:
+
+```bash
+./scripts/lele-api-refresh.sh
+```
+
+Oppure soltanto l'API con:
+
+```bash
+./scripts/lele-api-dev.sh
+```
+
+## GUI web
+
+Costruire il frontend Svelte e avviare l'API:
+
+```bash
+./scripts/build-gui.sh
+./scripts/lele-api-dev.sh
+# Aprire http://127.0.0.1:8000/app/
+```
+
+Viste disponibili:
+
+| Vista | Scopo |
+|---|---|
+| **Browse** | Ricerca avanzata, filtri ed export Markdown |
+| **Detail** | Contenuto completo e similarità spiegata |
+| **Editor** | Authoring Markdown con suggerimenti live |
+| **Timeline** | Timeline di acquisizione e export per bucket |
+| **Stats** | Conteggi, tag, topic e medie |
+| **Vault** | Albero filesystem reale e import |
+| **Ops** | Health, training, import vault e refresh completo |
+
+Il salvataggio dall'Editor scrive il file Markdown nel vault e aggiorna la
+proiezione JSONL tramite `PUT` o `POST /vault/lessons`.
+
+La GUI richiede `LELE_VAULT_DIR`; il default è `~/LeLeVault`.
+
+Il record di design completato resta disponibile in italiano in
+[`docs/gui-design.md`](docs/gui-design.md). È classificato come documento
+storico di design e non come manuale bilingue mantenuto.
+
+### Sviluppo frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Usare l'URL stampato da Vite. La configurazione di sviluppo inoltra le chiamate
+API quando il proxy è configurato.
+
+### Smoke E2E Playwright
+
+```bash
+./scripts/build-gui.sh
+
+cd frontend
+npm install
+npx playwright install chromium
+npm run test:e2e
+```
+
+`scripts/e2e-serve.sh` avvia Uvicorn sulla porta `8765` con dati sotto
+`.e2e-fixture/`. La CI esegue gli stessi flussi smoke dopo la build GUI e i test
+Python.
+
+## Versionamento e release
+
+LeLe Manager segue Semantic Versioning:
+
+- MAJOR: modifiche incompatibili ad API o formati;
+- MINOR: feature retrocompatibili;
+- PATCH: bugfix e miglioramenti interni.
+
+Una release stabile comprende import del vault, proiezione JSONL, modelli topic
+e similarità, endpoint FastAPI, client `lele` e test verdi.
+
+Esempio di tag annotato:
+
+```bash
+git tag -a v1.0.0 -m "LeLe Manager 1.0.0 — first stable release"
+git push origin v1.0.0
+```
+
+## Flussi di utilizzo reali
+
+### Aggiungere una LeLe Git e controllare i suggerimenti
+
+1. Creare una lesson Markdown sotto un percorso come
+   `~/LeLeVault/git/2025-12-05.local-remote-architecture.md`.
+2. Eseguire:
+
+   ```bash
+   ./scripts/lele-api-refresh.sh
+   ```
+
+3. Cercare:
+
+   ```bash
+   lele search git --topic git --limit 5
+   ```
+
+4. Trovare lesson simili:
+
+   ```bash
+   lele similar "git/2025-12-05.local-remote-architecture" --top-k 5
+   ```
+
+### Aggiornare una lesson esistente
+
+1. Modificare body Markdown o frontmatter preservando coerenza tra percorso
+   canonico, `id` e `topic`.
+2. Eseguire `./scripts/lele-api-refresh.sh`.
+3. Snapshot JSONL, topic model e API vengono aggiornati.
+4. `/lessons`, `/lessons/{id}/similar` e `lele similar` usano il nuovo
+   contenuto.
+
+### Interrogare LeLe Manager da un altro progetto
+
+Avviare l'API:
+
+```bash
+cd ~/Projects/lele-manager
+./scripts/lele-api-dev.sh
+```
+
+Interrogarla:
+
+```bash
+curl -s "http://127.0.0.1:8000/lessons/search" \
+  -H "Content-Type: application/json" \
+  -d '{"q": "git", "topic_in": ["git"], "limit": 5}'
+```
+
+Il progetto esterno può anche usare `lele` quando è nel `PATH`, oppure
+`python -m lele_manager.cli.lele`.
+
+## Client API `lele`
+
+```bash
+lele --help
+```
+
+### Suggerimenti durante la scrittura
+
+```bash
+lele suggest --text "When std::cin reads a string, input is truncated at whitespace"
+lele suggest --file note.md
+cat note.md | lele suggest
+lele suggest --watch note.md --every 2
+```
+
+### Esportare risultati di ricerca in Markdown
+
+```bash
+lele export --search "pytest" --topic python -o results.md
+lele export --search "git" -o git-lessons.md --no-frontmatter
+```
+
+### Rilevare duplicati e quasi-duplicati
+
+```bash
+lele duplicates
+lele duplicates --min-score 0.90 --limit 100
+lele duplicates --exact-only
+lele duplicates --json
+```
+
+I duplicati esatti comprendono ID ripetuti e testi uguali dopo una
+normalizzazione prudente di Unicode, line ending e spazi finali. I
+quasi-duplicati sono coppie non esatte il cui punteggio coseno raggiunge
+`--min-score` usando l'estrattore di feature fittato per la similarità.
+
+Topic, titolo, fonte, data e tag condivisi sono segnali esplicativi; da soli
+non rendono la coppia un quasi-duplicato. La soglia predefinita `0.85` è
+euristica e configurabile.
+
+Il modello addestrato è necessario per i quasi-duplicati. `--exact-only`
+funziona senza modello. Il confronto globale ha costo quadratico in tempo e
+memoria ed è destinato al dataset personale corrente, non a collezioni molto
+grandi.
+
+### Spiegare la similarità
+
+```bash
+lele similar "python/2025-01-01.slug" --explain
+lele suggest --text "pytest fixtures" --explain
+```
+
+Opzioni comuni:
+
+- `--top-k`: numero massimo di risultati, default 5;
+- `--min-score`: soglia minima di similarità, default 0.1;
+- `--json`: output JSON grezzo.
+
+Il client API usa `http://127.0.0.1:8000` per default. Avviare
+`./scripts/lele-api-dev.sh` prima di usarlo.
+
+## Contribuire
+
+Vedere [CONTRIBUTING.it.md](CONTRIBUTING.it.md).

--- a/README.md
+++ b/README.md
@@ -1,89 +1,105 @@
 # LeLe Manager 🐒 — Lesson-Learned Manager
+
+[English](README.md) | [Italiano](README.it.md)
+
 [![Security](https://github.com/gcomneno/lele-manager/actions/workflows/security.yml/badge.svg)](https://github.com/gcomneno/lele-manager/actions/workflows/security.yml)
 [![CI](https://github.com/gcomneno/lele-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/gcomneno/lele-manager/actions/workflows/ci.yml)
 
-Sistema ML end-to-end per gestire e cercare le mie *lesson learned* testuali: raccolta, tagging, ricerca e suggerimenti intelligenti.
+LeLe Manager is an end-to-end local-first system for collecting, validating,
+searching, and reusing textual lesson learned records.
 
-Ogni volta che imparo qualcosa (da ChatGPT, da libri, da esperimenti), LeLe Manager diventa il mio archivio centrale:
-- aggiungo una lesson con **testo + metadati** (data, fonte, topic, importanza);
-- posso **cercare** per testo libero, tag, periodo;
-- posso vedere **lesson simili o correlate**;
-- nel tempo il sistema impara a **classificare e suggerire** in autonomia.
+A lesson combines Markdown content with stable metadata. LeLe Manager can:
 
----
+- collect lessons through Markdown, CLI, GUI, and API workflows;
+- search by text, topic, source, date, importance, and tags;
+- find exact duplicates, near duplicates, and related lessons;
+- train a topic model and reuse the same feature pipeline for similarity;
+- preserve an inspectable Markdown vault while publishing derived datasets and
+  models.
 
-## ✅ Quality gates (quick scan)
+English is the canonical documentation language. See the
+[documentation language policy](docs/documentation-policy.md).
 
-- **CI**: `ruff check .` + `pytest` + Playwright E2E smoke (GitHub Actions, Python 3.12 + Node 22)
-- **Security**: `pip-audit` + `bandit` (GitHub Actions)
-- **pre-commit**: whitespace/end-of-file, `check-yaml`, `ruff`
+## Quality gates
 
-## 🗺️ Roadmap (quick links)
+- **CI:** `ruff check .`, `mypy src/lele_manager`, `pytest`, packaging smoke,
+  and Playwright E2E smoke with Python 3.12 and Node.js 22.
+- **Security:** `pip-audit` and `bandit` through GitHub Actions.
+- **pre-commit:** whitespace and end-of-file cleanup, `check-yaml`, and `ruff`.
+- **Documentation:** required bilingual pairs, reciprocal language selectors,
+  same-language root navigation, and relative links.
 
-- Milestone **v1.2 (stabilizzazione)**: [milestone/1](https://github.com/gcomneno/lele-manager/milestone/1)
-- Milestone **v2 (future/esperimenti)**: [milestone/2](https://github.com/gcomneno/lele-manager/milestone/2)
-- Documento completo: `ROADMAP.md`
-- Changelog: `CHANGELOG.md`
+Run the documentation checks with:
 
----
+```bash
+pytest tests/test_documentation.py
+```
 
-## ✨ Obiettivi principali
+## Project links
 
-- 📥 **Raccolta veloce** delle lesson learned via CLI e API.
-- 🏷️ **Tagging e metadati**: data, fonte, topic, importanza, tag liberi.
-- 🔍 **Ricerca** full-text e per filtri (topic, periodo, fonte).
-- 🤝 **Similarità**: suggerimento di lesson correlate a quella che sto scrivendo.
-- 🧠 In prospettiva: **classificazione automatica** per tema/cluster e ranking per importanza.
+- Full roadmap: [ROADMAP.md](ROADMAP.md)
+- Changelog: [CHANGELOG.md](CHANGELOG.md)
+- Contributor guide: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Documentation policy: [docs/documentation-policy.md](docs/documentation-policy.md)
+- Projection-store contract:
+  [docs/projection-store.md](docs/projection-store.md)
 
----
+## Main goals
 
-## 🧱 Stack tecnico
+- Fast lesson collection through CLI and API.
+- Stable metadata: date, source, topic, importance, tags, and title.
+- Full-text and filtered search.
+- Similarity recommendations while writing or reviewing.
+- Local-first Markdown authoring with derived JSONL and ML artifacts.
+- Progressive automation for classification and ranking without making user
+  data opaque or difficult to recover.
 
-- Python **3.12** (CI) — testato anche con 3.13
-- `pandas` / `numpy` per analisi dati
-- `scikit-learn` per ML classico (classificatori, KNN/similarity, ecc.)
-- (opzionale) piccolo **MLP** per migliorare embedding/scoring
-- **FastAPI + Uvicorn** per esporre API HTTP
-- Storage: port di proiezione backend-neutral con adapter **JSONL** predefinito
-  (SQLite è una fase successiva; vedi `docs/projection-store.md`)
+## Technical stack
 
----
+- Python **3.12** in CI; also tested with Python 3.13.
+- `pandas` and `numpy` for data processing.
+- `scikit-learn` for TF-IDF, classification, and similarity.
+- FastAPI and Uvicorn for the HTTP API.
+- Svelte, TypeScript, and Vite for the web GUI.
+- A backend-neutral projection-store port with JSONL as the current
+  compatibility adapter. SQLite remains a later migration target; see
+  [the projection-store contract](docs/projection-store.md) and
+  [ADR 0001](docs/adr/0001-storage-backend.md).
 
-## 🚀 Setup
+## Setup
 
-Clona il repository e crea un ambiente virtuale:
+Clone the repository and create a virtual environment:
 
 ```bash
 git clone git@github.com:gcomneno/lele-manager.git
 cd lele-manager
 
 python -m venv .venv
-source .venv/bin/activate  # su Windows: .venv\Scripts\activate
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
 
 pip install -e .[dev]
 ```
 
-Verifica statica dell'intero package Python usando Python 3.12,
-la stessa versione adottata dalla CI:
+Run the Python static checks and tests:
 
 ```bash
+ruff check .
 mypy src/lele_manager
+pytest
 ```
 
----
+## First CLI tools
 
-## 🛠️ Primi tool CLI (palestra)
-
-Alcuni comandi base già disponibili:
+The original module-level tools remain available:
 
 ```bash
-# Converti un CSV di lesson in JSON
+# Convert a lesson CSV file to JSON
 python -m lele_manager.cli.csv2json samples/input.csv samples/output.json
 
-# Monitora una directory (es. data/) per nuovi file
+# Watch a directory for new files
 python -m lele_manager.cli.file_watcher data
 
-# Importa LeLe da una directory Markdown con frontmatter YAML nel vault personale
+# Import Markdown lessons with YAML frontmatter from a vault
 python -m lele_manager.cli.import_from_dir \
   "$LELE_VAULT_DIR" \
   data/lessons.jsonl \
@@ -93,48 +109,51 @@ python -m lele_manager.cli.import_from_dir \
   --write-missing-frontmatter
 ```
 
----
+## Quick lesson workflow through the legacy CLI
 
-## 📝 Uso rapido – Lesson Learned via CLI
-
-Aggiungere una lesson:
+Add a lesson:
 
 ```bash
 python -m lele_manager.cli.add_lesson \
-  --text "Con layout src/ devo configurare PYTHONPATH o usare un conftest per pytest." \
+  --text "With a src layout I must configure PYTHONPATH or use a conftest for pytest." \
   --source chatgpt \
   --topic python \
   --importance 4 \
   --tags "python,pytest,tooling"
 ```
 
-Campi principali:
+Main fields:
 
-- `text`: contenuto testuale della lesson
-- `source`: origine (`chatgpt`, `libro`, `esperimento`, ecc.)
-- `topic`: macro-tema (es. `python`, `ml`, `linux`, `writing`)
-- `importance`: scala numerica (es. 1–5)
-- `tags`: lista di tag separati da virgola
+- `text`: lesson content;
+- `source`: origin such as `chatgpt`, `book`, `experiment`, or `note`;
+- `topic`: primary topic such as `python`, `ml`, `linux`, or `writing`;
+- `importance`: numeric importance, normally from 1 to 5;
+- `tags`: comma-separated tags.
 
-Elencare le lesson:
+List lessons:
 
 ```bash
 python -m lele_manager.cli.list_lessons --limit 10
 ```
 
----
+## LeLe Vault: Markdown and YAML frontmatter
 
-## 📂 LeLe Vault (Markdown + YAML frontmatter)
+LeLe Manager supports a Markdown vault as the authoring surface for approved
+lessons.
 
-Oltre al salvataggio diretto via CLI, LeLe Manager supporta un **vault di file Markdown** con frontmatter YAML.
+A typical flow is:
 
-L’idea:
+- write and organize `.md` files under a directory such as `~/LeLeVault`;
+- import and normalize them into `data/lessons.jsonl`;
+- train or refresh derived models;
+- query them through CLI, API, or GUI.
 
-- scrivi e organizzi le LeLe come file `.md` nella tua cartella (es. `~/LeLeVault` o `/home/utente/Uploads/LeLe-Vault`);
-- uno script (`import_from_dir`) li legge, normalizza i metadati e genera `data/lessons.jsonl`;
-- l’ID della LeLe vive nel **frontmatter**, non nel path → puoi correggere e spostare i file senza perdere l’identità.
+The lesson ID lives in frontmatter. In the canonical vault contract, identity
+and location are aligned: `topic` matches the first relative directory and
+`id` matches the relative path without `.md`. Renaming or moving a canonical
+file therefore requires updating its identity metadata.
 
-### Struttura consigliata del vault
+### Recommended vault structure
 
 ```text
 LeLeVault/
@@ -148,91 +167,92 @@ LeLeVault/
     2025-11-22.show-dont-tell.md
 ```
 
-Convenzioni (soft):
+Soft filename conventions:
 
-- directory = **topic** principale (`python`, `cpp`, `linux`, `writing`, …);
-- filename = `YYYY-MM-DD.slug.md` (senza underscore, usa `.` e `-`).
+- directory name = primary topic;
+- filename = `YYYY-MM-DD.slug.md`;
+- use `.` and `-`, not `_`, in the slug.
 
-### Frontmatter YAML: schema accettato dall'importer
+### Importer input schema
 
-Ogni LeLe può avere in testa un frontmatter YAML:
+A lesson may start with YAML frontmatter:
 
 ```markdown
 ---
 id: cpp/2025-11-20.cin-vs-getline
 topic: cpp
-source: libro
+source: book
 importance: 4
-tags: [cpp, io, stringhe]
+tags: [cpp, io, strings]
 date: 2025-11-20
 title: "LL-5 — std::cin vs std::getline"
 ---
 ```
 
-L'importer accetta uno schema tollerante. I campi sono opzionali; quando `id`
-manca viene generato dal percorso:
+The importer accepts a tolerant input schema:
 
-- `id` (str) → identità stabile della LeLe
-  - se non presente, viene derivato dal path relativo, es. `cpp/2025-11-20.cin-vs-getline`;
-  - una volta generato, conviene non toccarlo a mano.
-- `topic` (str) → se manca, può essere dedotto dal nome della directory (`python`, `cpp`, etc.) o da `--default-topic`.
-- `source` (str) → es. `chatgpt`, `libro`, `esperimento`, `note`.
-- `importance` (int) → tipicamente 1–5.
-- `tags` (lista o stringa) → es. `["python", "pytest", "tooling"]` oppure `"python, pytest, tooling"`.
-- `date` (str, ISO-like) → es. `2025-11-20`. Se mancante, può essere dedotta dal filename `YYYY-MM-DD.slug.md`.
-- `title` (str) → titolo umano della LeLe (opzionale).
+- `id` is optional and may be derived from the relative path;
+- `topic` may be read from frontmatter, `--default-topic`, or the directory;
+- `source` identifies the origin;
+- `importance` is normally an integer from 1 to 5;
+- `tags` may be a list or a comma-separated string;
+- `date` is ISO-like and may be derived from the filename;
+- `title` is optional for importer input.
 
-Internamente LeLe Manager calcola anche un `frontmatter_hash` (hash del solo frontmatter) utile per debug/versioning, ma l’identità resta sempre `id`.
+LeLe Manager also calculates `frontmatter_hash` for diagnostics and
+versioning. The identity remains `id`.
 
-Questo è lo schema di ingresso accettato dall'importer, non una garanzia che ogni
-file importabile superi anche i controlli canonici di `doctor`.
+Importer tolerance does not mean every importable file satisfies the canonical
+`doctor` contract.
 
-### Schema canonico validato da doctor
+### Canonical schema validated by `lele doctor`
 
-`lele doctor` applica uno schema distinto e rigoroso. Richiede tutti e sette i
-campi `id`, `topic`, `source`, `importance`, `tags`, `date` e `title`; `id`,
-`topic`, `source` e `title` devono essere stringhe non vuote, `importance` un
-intero tra 1 e 5, `date` una data valida `YYYY-MM-DD` e `tags` una lista non
-vuota composta da stringhe non vuote. Richiede inoltre un body Markdown non
-vuoto.
+`lele doctor` requires all seven fields:
 
-Quando è disponibile un contesto vault, ogni file selezionato deve appartenere
-alla sua radice, anche dopo la risoluzione dei symlink. Nel vault canonico,
-`topic` deve corrispondere alla prima directory del percorso relativo e `id` al
-percorso relativo senza estensione `.md`. Di conseguenza, dopo aver spostato un
-file occorre riallineare anche il suo `id` (e il `topic`, se cambia directory)
-perché superi `doctor`. Soltanto la validazione locale senza alcun contesto vault
-omette i controlli basati sul percorso.
+- `id`;
+- `topic`;
+- `source`;
+- `importance`;
+- `tags`;
+- `date`;
+- `title`.
 
-### Controllo locale del vault
+`id`, `topic`, `source`, and `title` must be non-empty strings.
+`importance` must be an integer from 1 to 5. `date` must be a valid
+`YYYY-MM-DD` date. `tags` must be a non-empty list of non-empty strings. The
+Markdown body must also be non-empty.
 
-`lele doctor` verifica i file Markdown localmente, senza richiedere il server API e
-senza scrivere o riserializzare i Markdown. Non modifica intenzionalmente
-contenuto, mtime o permessi; la lettura può però causare l'aggiornamento
-dell'access time da parte del filesystem.
+When a vault context is available, selected files must remain inside the vault
+after symlink resolution. `topic` must match the first relative directory and
+`id` must match the full relative path without `.md`.
+
+### Validate a vault
 
 ```bash
-# Controlla ricorsivamente il vault configurato in LELE_VAULT_DIR
+# Recursively validate the vault configured through LELE_VAULT_DIR
 lele doctor
 
-# Controlla ricorsivamente un vault specifico
+# Validate a specific vault
 lele doctor --vault /path/to/LeLeVault
 
-# Controlla soltanto uno o più file (usando il vault configurato come contesto)
+# Validate selected files using the configured vault as context
 lele doctor "$LELE_VAULT_DIR/python/2026-07-13.example.md"
 
-# Produce un report JSON adatto agli script
+# Produce script-friendly JSON
 lele doctor --json
 ```
 
-Il controllo valida frontmatter e body e cerca ID duplicati nell'intero vault
-disponibile. L'exit code è `0` per un report valido, `1` per errori di
-validazione e `2` per errori operativi o di utilizzo, inclusa la selezione di un
-file esterno al vault configurato.
+`lele doctor` reads Markdown without intentionally rewriting content,
+timestamps, or permissions. Filesystem access may still update access time.
 
-### Import da vault Markdown → JSONL
+Exit codes:
 
-Per costruire `data/lessons.jsonl` a partire dalla cartella del vault:
+- `0`: valid report;
+- `1`: validation errors;
+- `2`: operational or usage error, including a selected file outside the
+  configured vault.
+
+### Import Markdown to JSONL
 
 ```bash
 python -m lele_manager.cli.import_from_dir \
@@ -244,117 +264,71 @@ python -m lele_manager.cli.import_from_dir \
   --write-missing-frontmatter
 ```
 
-Cosa fa:
+The importer:
 
-- scandisce ricorsivamente `$LELE_VAULT_DIR` alla ricerca di `.md`;
-- per ogni file:
-  - legge frontmatter YAML + body;
-  - se manca `id`, lo genera dal path (`topic/YYYY-MM-DD.slug`) e, con `--write-missing-frontmatter`, lo scrive nel file;
-  - deduce `topic` (frontmatter → `--default-topic` → nome directory);
-  - normalizza `tags`, `importance`, `date`;
-  - calcola un `frontmatter_hash` (solo metadati);
-- crea in RAM una mappa `id → record`;
-- scrive da zero `data/lessons.jsonl` con una riga per ogni `id` unico.
+- scans recursively for `.md` files;
+- reads frontmatter and body;
+- derives a missing ID from the relative path;
+- derives or normalizes topic, tags, importance, and date;
+- calculates `frontmatter_hash`;
+- builds an in-memory `id -> record` map;
+- publishes a complete JSONL snapshot with one record per unique ID.
 
-Il flag `--write-missing-frontmatter` completa o ripara soltanto i campi mancanti o
-non validi nei file Markdown. Un frontmatter già completo e valido non viene
-riscritto: le normalizzazioni necessarie al JSONL avvengono esclusivamente in RAM.
+`--write-missing-frontmatter` repairs only missing or invalid input fields.
+Valid complete frontmatter is not rewritten merely to normalize JSONL output.
 
-### Gestione dei duplicati: `--on-duplicate`
+Duplicate behavior is selected with:
 
-L’identità delle LeLe è l’`id` nel frontmatter.
-Se durante l’import compaiono più file con lo stesso `id`, il comportamento si controlla con:
+- `--on-duplicate overwrite`: the last scanned record wins;
+- `--on-duplicate skip`: the first record wins;
+- `--on-duplicate error`: stop at the first duplicate ID.
 
-- `--on-duplicate overwrite` (default) → l’ultimo file letto vince;
-- `--on-duplicate skip` → la prima occorrenza vince, le successive vengono ignorate;
-- `--on-duplicate error` → il comando fallisce appena trova un `id` duplicato.
+### Recommended refresh flow
 
-### Flusso consigliato
+1. Write or organize Markdown lessons in `$LELE_VAULT_DIR`.
+2. Import the vault.
+3. Train the topic model.
+4. Query the archive.
 
-1. Scrivi/organizzi le LeLe nel vault Markdown (`$LELE_VAULT_DIR`).
-2. Lanci l’import:
+```bash
+python -m lele_manager.cli.import_from_dir \
+  "$LELE_VAULT_DIR" \
+  data/lessons.jsonl \
+  --on-duplicate overwrite \
+  --write-missing-frontmatter
 
-   ```bash
-   python -m lele_manager.cli.import_from_dir \
-     "$LELE_VAULT_DIR" \
-     data/lessons.jsonl \
-     --on-duplicate overwrite \
-     --write-missing-frontmatter
-   ```
+python -m lele_manager.cli.train_topic_model \
+  --input data/lessons.jsonl \
+  --output models/topic_model.joblib \
+  --overwrite
 
-3. Alleni il topic model:
+python -m lele_manager.cli.suggest_similar \
+  --input data/lessons.jsonl \
+  --model models/topic_model.joblib \
+  --text "When std::cin reads a string, input is truncated at whitespace" \
+  --top-k 5 \
+  --min-score 0.1
+```
 
-   ```bash
-   python -m lele_manager.cli.train_topic_model \
-     --input data/lessons.jsonl \
-     --output models/topic_model.joblib \
-     --overwrite
-   ```
+## Topic model and similarity
 
-4. Esplori l’archivio con la similarità:
+`train_topic_model(df)` builds a scikit-learn pipeline using TF-IDF features
+and `LogisticRegression`.
 
-   ```bash
-   python -m lele_manager.cli.suggest_similar \
-     --input data/lessons.jsonl \
-     --model models/topic_model.joblib \
-     --text "Quando uso std::cin >> su una string, l'input viene troncato agli spazi" \
-     --top-k 5 \
-     --min-score 0.1
-   ```
+`LessonFeatureExtractor` combines:
 
----
+- TF-IDF features from lesson text;
+- character length;
+- word count;
+- `importance`, when available.
 
-## 🧠 ML classico: topic + similarità
+The same feature representation supports topic classification and similarity.
 
-LeLe Manager include una prima infrastruttura ML testuale.
+`LessonSimilarityIndex.from_lessons(...)` and
+`LessonSimilarityIndex.from_topic_pipeline(...)` build the similarity index.
+`most_similar(query_text, top_k)` returns lesson IDs and cosine scores.
 
-### Classificatore di topic
-
-Funzione interna:
-
-- `train_topic_model(df)`
-
-Caratteristiche:
-
-- TF-IDF (unigrammi + bigrammi) sul testo delle lesson.
-- `LogisticRegression` per predire il campo `topic`.
-
-### Estrattore di feature unificato
-
-Classe:
-
-- `LessonFeatureExtractor`
-
-Produce una matrice di feature combinando:
-
-- TF-IDF del testo (`text`);
-- meta-feature numeriche:
-  - lunghezza in caratteri,
-  - numero di parole,
-  - `importance` (se presente).
-
-Questo estrattore è usato sia per la classificazione di topic sia per l’indice di similarità.
-
-### Indice di similarità tra lesson
-
-Classe:
-
-- `LessonSimilarityIndex.from_lessons(...)` / `from_topic_pipeline(...)`
-
-Metodo principale:
-
-- `most_similar(query_text, top_k)` → restituisce gli ID delle lesson più simili e il relativo score (coseno).
-
-Uso previsto:
-
-- raccomandare lesson correlate quando ne aggiungo una nuova;
-- in futuro, auto-proporre topic/cluster a partire dal testo.
-
----
-
-## 🧪 Training del topic model (CLI)
-
-Per addestrare il topic model a partire dal tuo archivio JSONL:
+### Train through the module CLI
 
 ```bash
 python -m lele_manager.cli.train_topic_model \
@@ -363,48 +337,33 @@ python -m lele_manager.cli.train_topic_model \
   --overwrite
 ```
 
-Requisiti del file `data/lessons.jsonl`:
-
-- formato JSONL (una lesson per riga),
-- colonne minime:
-  - `text`: testo della lesson,
-  - `topic`: label di training (stringa).
-
-Esempio di riga:
+The JSONL input must contain at least `text` and `topic`.
 
 ```json
 {"id": "89c6bca8-941b-4a93-a7ca-a35e584ae5ec",
- "text": "Con layout src/ devo gestire PYTHONPATH o usare un conftest per pytest.",
+ "text": "With a src layout I must manage PYTHONPATH or use a conftest for pytest.",
  "topic": "python",
  "source": "chatgpt",
  "importance": 4,
  "tags": ["python", "pytest", "tooling"]}
 ```
 
-L’output è una pipeline sklearn completa (feature + modello) salvata in:
+The complete pipeline is stored in `models/topic_model.joblib`.
 
-- `models/topic_model.joblib`
+### Find similar lessons through the module CLI
 
----
-
-## 🔍 Suggerire lesson simili (CLI)
-
-Nota: via API è disponibile anche `POST /similar` per confrontare testo libero senza ID.
-
-### Query da testo libero
+Free-text query:
 
 ```bash
 python -m lele_manager.cli.suggest_similar \
   --input data/lessons.jsonl \
   --model models/topic_model.joblib \
-  --text "Con layout src/ devo configurare PYTHONPATH o usare un conftest per pytest." \
+  --text "With a src layout I must configure PYTHONPATH or use a conftest for pytest." \
   --top-k 5 \
   --min-score 0.1
 ```
 
-### Query a partire da una lesson esistente
-
-Se nel dataset hai una colonna `id` (UUID, string o int), puoi usare una lesson come query:
+Query by an existing lesson ID:
 
 ```bash
 python -m lele_manager.cli.suggest_similar \
@@ -416,335 +375,247 @@ python -m lele_manager.cli.suggest_similar \
   --min-score 0.1
 ```
 
-L’output mostra:
+Output includes the lesson ID, similarity score, and a text preview.
 
-- ID della lesson,
-- score di similarità,
-- anteprima del testo.
+## Security and pre-commit
 
----
+The security workflow runs on pushes, pull requests, and a weekly schedule:
 
-## 🔐 Sicurezza
+- `pip-audit` checks Python dependencies;
+- `bandit` checks Python code under `src/`.
 
-LeLe Manager non è mission-critical, ma l’obiettivo è non far uscire la scimmia senza casco.
-
-### Security workflow GitHub Actions
-
-Workflow `.github/workflows/security.yml` che gira su push/PR + scan settimanale:
-
-- `pip-audit` per vulnerabilità sulle dipendenze Python.
-- `bandit` per analisi statica del codice sotto `src/`.
-
-### ✅ pre-commit minimal ma ad alto valore
-
-File `.pre-commit-config.yaml` con hook:
-
-- cleanup di base (spazi a fine riga, newline finale),
-- `check-yaml` per non rompere i workflow,
-- `ruff` per lint/fix del codice Python.
-
-Attivazione locale:
+Install local pre-commit hooks with:
 
 ```bash
 pip install pre-commit
 pre-commit install
 ```
 
----
+The configuration provides whitespace and final-newline cleanup, YAML
+validation, and Ruff checks.
 
-## 📂 Dati e modelli locali
+## Local data and models
 
-- I file reali delle lesson learned vivono in `data/`.
-- I modelli allenati vivono in `models/`.
-- `data/` e `models/` sono esclusi dal versioning (vedi `.gitignore`).
+- Personal lesson data lives under `data/`.
+- Trained models live under `models/`.
+- Both directories are excluded from version control.
 
-Risultato: l’archivio personale e i modelli restano fuori dal repo pubblico.
+The public repository therefore does not contain the personal vault, derived
+dataset, or trained models.
 
----
+## Utility scripts
 
-## 🔧 Script di utilità (`scripts/`)
+### Full refresh: `scripts/lele-api-refresh.sh`
 
-### `scripts/lele-api-refresh.sh`
+The complete development refresh:
 
-Script “tasto F5” completo:
-
-1. importa le LeLe dal vault Markdown (`$LELE_VAULT_DIR`) in `data/lessons.jsonl`;
-2. riallena il topic model in `models/topic_model.joblib`;
-3. avvia LeLe API in dev con Uvicorn (`--reload`).
-
-Uso tipico:
+1. imports `$LELE_VAULT_DIR` into `data/lessons.jsonl`;
+2. retrains `models/topic_model.joblib`;
+3. starts the FastAPI server with Uvicorn `--reload`.
 
 ```bash
-cd ~/Progetti/lele-manager
-export LELE_VAULT_DIR=/home/utente/Uploads/LeLe-Vault  # adattare al proprio path
+cd ~/Projects/lele-manager
+export LELE_VAULT_DIR=/home/user/LeLeVault
 ./scripts/lele-api-refresh.sh
 ```
 
-### `scripts/lele-api-dev.sh`
+### API only: `scripts/lele-api-dev.sh`
 
-Script leggero per avviare solo le API FastAPI (senza re-importare né riallenare):
+Use this when dataset and model are already ready:
 
 ```bash
-cd ~/Progetti/lele-manager
+cd ~/Projects/lele-manager
 ./scripts/lele-api-dev.sh
 ```
 
-Fa:
+The script locates the project root, activates `.venv`, checks for Uvicorn, and
+starts the server on `http://127.0.0.1:8000`.
 
-- individua la root del progetto;
-- attiva `.venv` (se manca segnala come crearla);
-- controlla che `uvicorn` sia installato nella venv;
-- avvia il server su `http://127.0.0.1:8000` con `--reload`.
+## FastAPI API
 
----
+Main endpoints include:
 
-## 🌐 API FastAPI
+- `GET /health`;
+- `GET /lessons`;
+- `GET /lessons/{id}`;
+- `GET /lessons/{id}/similar`;
+- `GET /duplicates`;
+- `POST /similar`;
+- `POST /editor/suggest`;
+- `POST /export/search`;
+- `GET /stats/summary`;
+- `GET /stats/timeline`;
+- `POST /train/topic`;
+- `POST /lessons/search`.
 
-LeLe Manager espone un’API HTTP (FastAPI) sopra il motore interno:
+Similarity endpoints accept `explain=true` where documented to include rank,
+topic, and shared-tag metadata.
 
-- lettura e ricerca delle LeLe,
-- training del topic model,
-- similarità tra lesson.
+The versioned TritaLeLe candidate workflow is exposed below
+`/api/v1/tritalele`.
 
-### Avvio del server API
-
-Modalità “giro completo” (vault → JSONL → modello → API):
+Start the full flow with:
 
 ```bash
 ./scripts/lele-api-refresh.sh
 ```
 
-Modalità “solo API” (dataset e modello già pronti):
+Or start only the API with:
 
 ```bash
 ./scripts/lele-api-dev.sh
 ```
 
-### Endpoints principali
+## Web GUI
 
-- `GET /health` → stato rapido del servizio (dati/modello presenti).
-- `GET /lessons` → lista/ricerca delle LeLe (query param base).
-- `GET /lessons/{id}` → dettaglio di una LeLe.
-- `GET /lessons/{id}/similar` → LeLe simili (`?explain=true` per rank, topic, tag overlap).
-- `GET /duplicates` → report read-only di duplicati esatti e quasi-duplicati
-  (`min_score`, `limit`, `exact_only`).
-- `POST /similar`, `POST /editor/suggest` → similarità da testo (`?explain=true` opzionale).
-- `POST /export/search` → export risultati ricerca in Markdown (`?format=markdown|json`).
-- `GET /stats/summary`, `GET /stats/timeline` → statistiche e timeline.
-- `POST /train/topic` → (ri)allena il topic model a partire da `data/lessons.jsonl`.
-- `POST /lessons/search` → ricerca avanzata con payload JSON (testo + filtri).
-
----
-
-## 🖥️ GUI Web (v2.0 alpha)
-
-Oltre alla CLI e al PoC legacy (`GET /ui`), LeLe Manager include una **GUI Svelte** servita dall'API:
+Build the Svelte frontend and start the API:
 
 ```bash
-# 1) Build frontend (Vite + Svelte)
 ./scripts/build-gui.sh
-
-# 2) Avvia API
 ./scripts/lele-api-dev.sh
-
-# 3) Apri browser
-# http://127.0.0.1:8000/app/
+# Open http://127.0.0.1:8000/app/
 ```
 
-### Viste disponibili
+Available views:
 
-| Vista | Cosa fa |
-|-------|---------|
-| **Browse** | Ricerca avanzata + filtri + **Esporta .md** (v1.9) |
-| **Detail** | Lettura LeLe + pannello **“Perché simile?”** con explain (v1.9) |
-| **Editor** | Scrittura con suggest live + explain nel pannello simili |
-| **Timeline** | Acquisizione conoscenza + export per bucket (v1.9) |
-| **Stats** | Dashboard: conteggi, tag, topic, medie |
-| **Vault** | Albero filesystem reale (`GET /vault/tree`) + import |
-| **Ops** | Health + retrain + **import vault** + **refresh completo** |
+| View | Purpose |
+|---|---|
+| **Browse** | Advanced search, filters, and Markdown export |
+| **Detail** | Full lesson content and explained similarity |
+| **Editor** | Markdown authoring with live suggestions |
+| **Timeline** | Knowledge-acquisition timeline and bucket export |
+| **Stats** | Counts, tags, topics, and averages |
+| **Vault** | Real filesystem tree and import |
+| **Ops** | Health, training, vault import, and full refresh |
 
-**Salvataggio:** Editor → **Salva nel vault** scrive il file `.md` e risincronizza il JSONL (`PUT` / `POST /vault/lessons`).
+Saving from the Editor writes the Markdown file into the vault and refreshes
+the JSONL projection through `PUT` or `POST /vault/lessons`.
 
-Richiede `LELE_VAULT_DIR` (default `~/LeLeVault`).
+The GUI requires `LELE_VAULT_DIR`; the default is `~/LeLeVault`.
 
-Design completo: [`docs/gui-design.md`](docs/gui-design.md)
+The completed design record remains available in Italian at
+[`docs/gui-design.md`](docs/gui-design.md). It is classified as a historical
+design document rather than a maintained bilingual manual.
 
-`GET /ui` (PoC legacy) reindirizza a `/app/`.
-
-**Dev frontend** (hot reload, proxy API):
+### Frontend development
 
 ```bash
 cd frontend
 npm install
 npm run dev
-# apri l'URL indicato da Vite (proxy verso :8000 se configurato)
 ```
 
-### Test E2E (Playwright)
+Use the URL printed by Vite. The development configuration proxies the API when
+configured.
 
-Smoke test sulla GUI servita dall'API (fixture JSONL + topic model dedicati):
+### Playwright E2E smoke
 
 ```bash
-# prerequisiti: Python venv con pip install -e ".[dev]", GUI buildata
 ./scripts/build-gui.sh
 
 cd frontend
 npm install
-npx playwright install chromium   # prima volta
+npx playwright install chromium
 npm run test:e2e
 ```
 
-Lo script `scripts/e2e-serve.sh` avvia uvicorn su `:8765` con dataset `.e2e-fixture/`.
-In CI il job `e2e` esegue gli stessi test dopo build GUI + `pytest`.
+`scripts/e2e-serve.sh` starts Uvicorn on port `8765` with data under
+`.e2e-fixture/`. CI runs the same smoke flows after building the GUI and running
+the Python tests.
 
----
+## Versioning and releases
 
-## 📦 Versioni & release
+LeLe Manager follows Semantic Versioning:
 
-LeLe Manager segue il versioning semantico (SemVer):
+- MAJOR: incompatible API or format changes;
+- MINOR: backward-compatible features;
+- PATCH: bug fixes and internal improvements.
 
-- MAJOR: cambiamenti incompatibili nelle API/nei formati (es. 1.x → 2.0.0).
-- MINOR: nuove funzionalità retro-compatibili (es. 1.0.0 → 1.1.0).
-- PATCH: bugfix o piccoli miglioramenti interni (es. 1.0.0 → 1.0.1).
+A stable release includes vault import, JSONL projection, topic and similarity
+models, FastAPI endpoints, the `lele` client, and a green test suite.
 
-Per l’uso quotidiano:
-
-- lavori normalmente sul branch `main`;
-- quando uno stato è “buono per un lungo periodo”, viene taggato (`vX.Y.Z`) e usato come release;
-- il primo stato considerato “strumento 1.0 stabile” è quello con:
-  - import dal vault Markdown (`import_from_dir`),
-  - dataset JSONL (`data/lessons.jsonl`),
-  - topic model + similarità (`models/topic_model.joblib`),
-  - API FastAPI (`/lessons`, `/lessons/search`, `/lessons/{id}/similar`, ecc.),
-  - client CLI `lele` funzionante,
-  - tests `pytest` verdi.
-
-Esempio di creazione di una release dall’ultimo commit stabile:
+Example annotated tag:
 
 ```bash
-git tag -a v1.0.0 -m "LeLe Manager 1.0.0 – primo rilascio stabile"
+git tag -a v1.0.0 -m "LeLe Manager 1.0.0 — first stable release"
 git push origin v1.0.0
 ```
 
----
+## Real usage flows
 
-## 👤 User stories (come lo uso davvero)
+### Add a Git lesson and inspect suggestions
 
-### 1) Aggiungo una nuova LeLe Git e vedo i suggerimenti
-
-1. Scrivo una nuova LeLe nel vault, es.
-   `~/Uploads/LeLe-Vault/git/2025-12-05.architettura-locale-remoto.md`
-   con frontmatter YAML (`topic: git`, `importance: 5`, ecc.).
-2. Lancio:
+1. Create a Markdown lesson under a path such as
+   `~/LeLeVault/git/2025-12-05.local-remote-architecture.md`.
+2. Run:
 
    ```bash
    ./scripts/lele-api-refresh.sh
    ```
 
-   che fa in sequenza:
-   - import dal vault → `data/lessons.jsonl`,
-   - training del topic model → `models/topic_model.joblib`,
-   - avvio di Uvicorn con LeLe API su `http://127.0.0.1:8000`.
-3. Cerco dal client CLI:
+3. Search:
 
    ```bash
    lele search git --topic git --limit 5
    ```
 
-4. Se voglio le LeLe più simili a quella che ho appena scritto:
+4. Find similar lessons:
 
    ```bash
-   lele similar "git/2025-12-05.architettura-locale-remoto" --top-k 5
+   lele similar "git/2025-12-05.local-remote-architecture" --top-k 5
    ```
 
-### 2) Aggiorno una LeLe esistente e allineo il modello
+### Update an existing lesson
 
-1. Modifico il contenuto di una LeLe già esistente nel vault (stesso `id` nel frontmatter YAML).
-2. Rilancio:
+1. Edit its Markdown body or frontmatter while preserving a coherent canonical
+   path, `id`, and `topic`.
+2. Run `./scripts/lele-api-refresh.sh`.
+3. The JSONL snapshot, topic model, and API are refreshed.
+4. `/lessons`, `/lessons/{id}/similar`, and `lele similar` use the new content.
 
-   ```bash
-   ./scripts/lele-api-refresh.sh
-   ```
+### Query LeLe Manager from another project
 
-3. Il comando:
-   - riscrive il JSONL,
-   - riallena il topic model,
-   - riavvia l’API.
-4. Da qui in poi:
-   - `/lessons` restituisce il nuovo testo,
-   - `/lessons/{id}/similar` e `lele similar` lavorano sul contenuto aggiornato.
+Start the API:
 
-### 3) Uso LeLe Manager da un altro progetto
+```bash
+cd ~/Projects/lele-manager
+./scripts/lele-api-dev.sh
+```
 
-1. Avvio LeLe API in una shell:
+Then query it:
 
-   ```bash
-   cd ~/Progetti/lele-manager
-   ./scripts/lele-api-dev.sh
-   ```
+```bash
+curl -s "http://127.0.0.1:8000/lessons/search" \
+  -H "Content-Type: application/json" \
+  -d '{"q": "git", "topic_in": ["git"], "limit": 5}'
+```
 
-2. Dal progetto esterno, interrogo le API, ad esempio:
+The external project may also use `lele` when it is on `PATH`, or
+`python -m lele_manager.cli.lele`.
 
-   ```bash
-   curl -s "http://127.0.0.1:8000/lessons/search" \
-     -H "Content-Type: application/json" \
-     -d '{"q": "git", "topic_in": ["git"], "limit": 5}'
-   ```
-
-3. Oppure, sempre dall’altro repo, uso direttamente il client CLI `lele`
-   (se è nel PATH, o via `python -m lele_manager.cli.lele`).
-
-## Contributing
-See [`CONTRIBUTING.md`](CONTRIBUTING.md).
-
-
----
-
-## 🧩 Nuovo CLI: `lele` (API client)
-
-Oltre agli script tecnici (`python -m lele_manager.cli.*`), è disponibile un client CLI più ergonomico:
+## `lele` API client
 
 ```bash
 lele --help
 ```
 
-### 🔍 Suggerire LeLe simili mentre scrivi
-
-Query da testo libero (via API `POST /similar`):
+### Suggest while writing
 
 ```bash
-lele suggest --text "Quando uso std::cin >> su una string, l'input viene troncato agli spazi"
-```
-
-Da file:
-
-```bash
+lele suggest --text "When std::cin reads a string, input is truncated at whitespace"
 lele suggest --file note.md
-```
-
-Da stdin:
-
-```bash
 cat note.md | lele suggest
-```
-
-Modalità watch (ogni 2 secondi):
-
-```bash
 lele suggest --watch note.md --every 2
 ```
 
-### 📤 Export ricerca in Markdown (v1.9)
+### Export search results to Markdown
 
 ```bash
 lele export --search "pytest" --topic python -o results.md
 lele export --search "git" -o git-lessons.md --no-frontmatter
 ```
 
-### 🧬 Rilevare duplicati e quasi-duplicati
-
-`lele duplicates` analizza globalmente il dataset tramite l'API, senza modificare
-JSONL, vault o modelli:
+### Detect duplicates and near duplicates
 
 ```bash
 lele duplicates
@@ -753,30 +624,36 @@ lele duplicates --exact-only
 lele duplicates --json
 ```
 
-I duplicati `exact` comprendono ID ripetuti e testi uguali dopo una
-normalizzazione prudente di Unicode, line ending e spazi finali. I candidati
-`near` sono invece coppie non esatte il cui punteggio cosine, calcolato con lo
-stesso estrattore fittato usato dalla similarità esistente, raggiunge
-`--min-score`. Topic, titolo, fonte, data e tag condivisi sono segnali
-esplicativi: da soli non rendono una coppia `near`.
+Exact duplicates include repeated IDs and text equal after conservative Unicode,
+line-ending, and trailing-space normalization. Near duplicates are non-exact
+pairs whose cosine score reaches `--min-score` using the fitted similarity
+feature extractor.
 
-La soglia predefinita `0.85` è euristica e configurabile. Il modello addestrato
-è necessario per i `near`; `--exact-only` funziona senza modello. Il confronto
-globale usa tempo e memoria quadratici rispetto al numero di lesson ed è
-destinato all'attuale dataset personale, non a collezioni molto grandi.
+Topic, title, source, date, and shared tags are explanatory signals; they do not
+make a pair a near duplicate by themselves. The default threshold `0.85` is
+heuristic and configurable.
 
-### 🔬 Explain similarity (v1.9)
+The trained model is required for near-duplicate detection.
+`--exact-only` works without a model. Global comparison has quadratic time and
+memory cost and targets the current personal dataset, not very large
+collections.
+
+### Explain similarity
 
 ```bash
 lele similar "python/2025-01-01.slug" --explain
 lele suggest --text "pytest fixtures" --explain
 ```
 
-Opzioni principali:
+Common options:
 
-- `--top-k` → numero massimo risultati (default 5)
-- `--min-score` → soglia minima di similarità (default 0.1)
-- `--json` → output JSON grezzo
+- `--top-k`: maximum result count, default 5;
+- `--min-score`: minimum similarity score, default 0.1;
+- `--json`: raw JSON output.
 
-Questo comando usa l’API locale (default `http://127.0.0.1:8000`).
-Assicurati che il server sia attivo (`./scripts/lele-api-dev.sh`).
+The API client uses `http://127.0.0.1:8000` by default. Start
+`./scripts/lele-api-dev.sh` before using it.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/ROADMAP.it.md
+++ b/ROADMAP.it.md
@@ -1,0 +1,265 @@
+# LeLe Manager — Roadmap e stato attuale
+
+[English](ROADMAP.md) | [Italiano](ROADMAP.it.md)
+
+> Knowledge base personale per lesson learned testuali:
+> vault Markdown → projection store / JSONL → ML (topic e similarità) →
+> API FastAPI e GUI.
+
+## 1. Obiettivo del progetto
+
+LeLe Manager è il motore centrale per le lesson learned personali:
+
+- le lesson vengono scritte come file Markdown organizzati per topic;
+- LeLe Manager le importa, valida, normalizza ed espone per:
+  - ricerca full-text e tramite filtri;
+  - classificazione per topic;
+  - suggerimenti di lesson simili;
+  - revisione, export e integrazioni downstream.
+
+L'obiettivo è uno strumento local-first stabile per l'uso quotidiano, con dati
+recuperabili e una base ML capace di evolvere senza diventare la fonte
+autorevole.
+
+## 2. Step originali e avanzamento
+
+La roadmap originale comprendeva:
+
+1. **Setup Python e tooling** — ambiente, struttura del progetto e primi
+   strumenti CLI.
+2. **Dati e analisi esplorativa** — formato delle lesson, storage, ingestione e
+   prime analisi.
+3. **ML classico** — classificazione topic e similarità basata su TF-IDF.
+4. **Pipeline e feature engineering** — feature condivise, pipeline
+   scikit-learn e strumenti CLI ML.
+5. **FastAPI e capstone end-to-end** — endpoint API, script di sviluppo e
+   successiva integrazione GUI.
+
+### 2.1 Fondamenta completate
+
+- **Setup Python e tooling**
+  - layout del package `src/lele_manager/`;
+  - `pyproject.toml`, extra di sviluppo e flusso ambiente virtuale;
+  - primi strumenti CLI come `csv2json` e `file_watcher`;
+  - hook pre-commit per whitespace, YAML e Ruff.
+
+- **Dati e ingestione delle lesson**
+  - campi principali: `id`, `text`, `topic`, `source`, `importance`, `tags`,
+    `date` e `title`;
+  - vault Markdown con frontmatter YAML;
+  - dataset di compatibilità JSONL;
+  - ingestione da CSV e altre fonti;
+  - chunking deterministico delle fonti grezze e staging candidati TritaLeLe.
+
+- **ML classico**
+  - `train_topic_model(df)` con TF-IDF e `LogisticRegression`;
+  - pipeline scikit-learn serializzata in `models/topic_model.joblib`;
+  - `LessonSimilarityIndex`;
+  - similarità da testo e da ID;
+  - backend di similarità LSA opzionale.
+
+- **Pipeline di feature condivisa**
+  - `LessonFeatureExtractor`;
+  - TF-IDF del testo, numero caratteri, numero parole e `importance`;
+  - `TopicModelConfig`, `build_topic_pipeline` ed errori di training robusti;
+  - comportamento condiviso tra classificazione topic e similarità.
+
+- **LeLe Vault**
+  - root configurabile tramite `LELE_VAULT_DIR`;
+  - ingresso importer tollerante e validazione canonica rigorosa con
+    `lele doctor`;
+  - verifica canonica di `topic` e `id` rispetto al percorso relativo;
+  - gestione duplicati con `overwrite`, `skip` ed `error`;
+  - hash SHA-256 del frontmatter;
+  - serializzazione robusta delle date YAML;
+  - write-back Markdown e flussi di refresh del vault.
+
+- **FastAPI e script di sviluppo**
+  - endpoint principali per lesson, ricerca, training, similarità, duplicati,
+    analytics, export, vault e operazioni;
+  - workflow versionato dei candidati TritaLeLe sotto `/api/v1/tritalele`;
+  - `scripts/lele-api-dev.sh`;
+  - `scripts/lele-api-refresh.sh`;
+  - serving statico della GUI e composizione applicativa.
+
+- **GUI web**
+  - SPA Svelte con Browse, Detail, Editor, Vault, Ops, Timeline e Stats;
+  - suggerimenti live e similarità spiegata;
+  - export Markdown;
+  - write-back nel vault;
+  - smoke test E2E Playwright.
+
+- **Confine projection store**
+  - port tipizzato indipendente dal backend;
+  - snapshot coerenti e immutabili;
+  - ordinamento, conteggi e generazione del contenuto deterministici;
+  - pubblicazione validata e atomica dell'intero snapshot;
+  - adapter di compatibilità JSONL;
+  - facade esplicita per il legacy append.
+
+## 3. Stato attuale del prodotto
+
+LeLe Manager fornisce oggi:
+
+- un vault Markdown canonico per l'authoring delle lesson approvate;
+- un knowledge doctor locale rigoroso;
+- una proiezione JSONL derivata usata dai flussi di compatibilità e ML;
+- classificazione topic e similarità su dati reali;
+- report di duplicati esatti e quasi-duplicati;
+- un server FastAPI;
+- il client CLI `lele` orientato alle API;
+- una GUI Svelte;
+- flussi TritaLeLe per ingestione fonti grezze, revisione candidati e
+  approvazione;
+- test deterministici sui confini domain, storage, API, CLI e GUI.
+
+Il progetto è utilizzabile come strumento personale in produzione, mentre la
+migrazione storage e alcune pulizie architetturali restano attività aperte.
+
+## 4. Lavoro prodotto e qualità completato
+
+### 4.1 Test automatici
+
+La copertura comprende:
+
+- comportamento dell'importer e riparazione frontmatter;
+- validazione canonica del vault e ID duplicati;
+- successo e fallimenti del training topic model;
+- equivalenza ed edge case del servizio di similarità;
+- health API, ricerca, dettaglio, similarità, analytics, export e vault;
+- contratto projection store;
+- ingestione, review, approval, CLI e API TritaLeLe;
+- build GUI e smoke test Playwright.
+
+### 4.2 Ricerca avanzata
+
+- `POST /lessons/search`;
+- filtri per topic, source, importance e testo;
+- record normalizzati e ordinamento deterministico;
+- consumer CLI e GUI.
+
+### 4.3 CLI orientata alle API
+
+- `lele search`;
+- `lele show`;
+- `lele similar`;
+- `lele train-topic`;
+- `lele suggest`;
+- `lele export`;
+- `lele duplicates`;
+- `lele doctor`;
+- comandi candidati TritaLeLe;
+- configurazione `LELE_API_URL` dove applicabile.
+
+### 4.4 Documentazione e igiene release
+
+- Semantic Versioning;
+- `CHANGELOG.md`;
+- licenza MIT;
+- guida contributor;
+- politica documentale bilingue con inglese canonico;
+- mirror inglese/italiano mantenuti per i documenti principali utente e
+  contributor;
+- test documentali mirati;
+- workflow release e packaging.
+
+Resta da definire il pinning delle dipendenze o una strategia lockfile
+giustificata.
+
+## 5. Direzione architetturale attiva
+
+### 5.1 Contenuto canonico e proiezioni
+
+La separazione obiettivo è:
+
+- **vault Markdown:** contenuto autorevole delle lesson approvate;
+- **projection store:** vista applicativa interrogabile;
+- **JSONL:** snapshot derivato per interoperabilità, fixture, export e ML;
+- **modelli ML:** artefatti rigenerabili legati a una generazione del dataset.
+
+L'adapter corrente resta JSONL per compatibilità. SQLite è il backend locale
+interrogabile previsto dopo il lavoro di parità, migrazione e riconciliazione
+descritto da [ADR 0001](docs/adr/0001-storage-backend.md), fonte tecnica
+canonica inglese.
+
+### 5.2 Ingestione TritaLeLe
+
+Il flusso obiettivo è:
+
+```text
+source material
+  → deterministic chunks
+  → staged candidates
+  → explicit human review
+  → approval
+  → canonical Markdown vault
+  → projection refresh
+  → export and ML derivatives
+```
+
+I candidati non sono lesson approvate. Restano isolati dal vault canonico e
+dal dataset ML fino al completamento di un'approvazione esplicita.
+
+### 5.3 Documentazione
+
+L'inglese è canonico e predefinito. L'italiano è ufficialmente mantenuto per le
+coppie elencate nella
+[politica documentale](docs/it/documentation-policy.md).
+
+Record storici, artefatti generati e fonti tecniche selezionate sono esclusi
+soltanto tramite classificazione e motivazione esplicite.
+
+## 6. Priorità pratiche
+
+1. **Mantenere stabile il sistema corrente**
+   - preservare contratti domain e storage deterministici;
+   - mantenere verdi lint, typing, test, packaging, security ed E2E;
+   - sincronizzare le coppie documentali.
+
+2. **Completare l'evoluzione storage**
+   - riconciliare record presenti solo nel vault o solo in JSONL;
+   - introdurre e validare l'adapter SQLite;
+   - dimostrare parità con il backend di compatibilità JSONL;
+   - esporre esplicitamente lo stato stale della proiezione;
+   - effettuare il cutover gradualmente senza creare una seconda autorità.
+
+3. **Completare l'integrazione prodotto TritaLeLe**
+   - collegare il workflow candidati alla GUI;
+   - preservare review e approval esplicite;
+   - rendere visibili provenance e recupero dai fallimenti;
+   - evitare la promozione diretta dei candidati nei dataset canonici.
+
+4. **Migliorare la manutenibilità**
+   - dividere i moduli FastAPI sovradimensionati in router e servizi focalizzati;
+   - definire pinning dipendenze o politica lockfile;
+   - mantenere espliciti i confini tra authoring, sincronizzazione, proiezione,
+     export e ML.
+
+5. **Espandere le integrazioni quando giustificato**
+   - integrazioni editor come VS Code o Obsidian;
+   - consumer esterni per quiz e review;
+   - embedding o ranking più ricchi solo dopo benefici misurabili;
+   - strumenti analitici come DuckDB solo per workload dimostrati.
+
+## 7. Ricerca nice-to-have
+
+- embedding densi alternativi o retrieval ibrido;
+- ranking personalizzato della priorità di revisita;
+- explainability più ricca per similarità e duplicati;
+- flussi nativi negli editor;
+- contratti versionati per consumer esterni;
+- analytics su snapshot esportati più grandi.
+
+Questi elementi non devono indebolire recuperabilità local-first, comportamento
+deterministico o autorità del contenuto Markdown revisionato.
+
+## 8. Non priorità esplicite
+
+Il progetto attuale non necessita di:
+
+- database distribuito;
+- servizio document store remoto;
+- approvazione automatica non revisionata dei candidati;
+- traduzione automatica opaca;
+- piattaforma documentale pesante;
+- infrastruttura sproporzionata rispetto al workload personale local-first.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,208 +1,260 @@
-# LeLe Manager – Roadmap & stato d'arte
-> Knowledge base personale per Lesson Learned testuali:
-> Vault Markdown → JSONL → ML (topic/similarità) → API FastAPI.
+# LeLe Manager — Roadmap and current status
 
----
+[English](ROADMAP.md) | [Italiano](ROADMAP.it.md)
 
-## 1. Obiettivo del progetto
-LeLe Manager vuole essere il **motore centrale** per le mie *lesson learned*:
+> Personal knowledge base for textual lesson learned records:
+> Markdown vault → projection store / JSONL → ML (topic and similarity) →
+> FastAPI API and GUI.
 
-- scrivo le LeLe come file Markdown, organizzate in cartelle (per topic, ecc.);
-- LeLe Manager le importa, normalizza e le usa per:
-  - **ricerca** (testo libero + filtri),
-  - **classificazione per topic**,
-  - **suggerimento di lesson simili**.
+## 1. Project objective
 
-Target: **strumento 1.0 stabile** per uso personale quotidiano, con una base ML estendibile in futuro.
+LeLe Manager is the central engine for personal lesson learned records:
 
----
+- lessons are authored as Markdown files organized by topic;
+- LeLe Manager imports, validates, normalizes, and exposes them for:
+  - full-text and filtered search;
+  - topic classification;
+  - similar-lesson recommendations;
+  - review, export, and downstream integrations.
 
-## 2. Step originali & stato di avanzamento
-Roadmap originale:
+The target is a stable local-first daily tool with recoverable data and an ML
+foundation that can evolve without becoming the source of truth.
 
-1. **Step 1 – Setup Python & tooling**
-   Ambiente, struttura progetto, primi tool CLI.
-2. **Step 2 – Data & EDA sulle lesson learned**
-   Formato di storage (JSONL/SQLite), ingest, prime analisi.
-3. **Step 3 – ML classico**
-   Topic model + similarità base (TF-IDF + k-NN/logistic).
-4. **Step 4 – Pipeline & feature engineering**
-   Feature condivise, pipeline sklearn, CLI ML.
-5. **Step 5 – API & capstone end-to-end**
-   FastAPI, endpoints, script dev, (eventuale Docker/UI).
+## 2. Original steps and progress
 
-### 2.1. Step completati ✅
-- ✅ **Step 1 – Setup Python & tooling**
-  - Struttura progetto (`src/lele_manager/…`).
-  - `pyproject.toml`, dipendenze, ambiente virtuale, `pip install -e .[dev]`.
-  - primi CLI di prova (`csv2json`, `file_watcher`, ecc.).
-  - pre-commit con:
-    - whitespace cleanup,
-    - `check-yaml`,
-    - `ruff`.
+The original roadmap consisted of:
 
-- ✅ **Step 2 – Data & formato lesson learned**
-  *(EDA notebook rinviata a fase successiva)*
-  - Definizione schema minimo LeLe:
-    - `id`, `text`, `topic`, `source`, `importance`, `tags`, `date`, `title`.
-  - Storage principale: **JSONL** (`data/lessons.jsonl`).
-  - Funzioni di ingest da CSV / altre fonti.
+1. **Python setup and tooling** — environment, project structure, and initial
+   CLI tools.
+2. **Data and exploratory analysis** — lesson format, storage, ingestion, and
+   initial analysis.
+3. **Classic ML** — topic classification and TF-IDF-based similarity.
+4. **Pipeline and feature engineering** — shared features, scikit-learn
+   pipelines, and ML CLI tools.
+5. **FastAPI and end-to-end capstone** — API endpoints, development scripts,
+   and later GUI integration.
 
-- ✅ **Step 3 – ML classico (topic/similarità)**
-  - Topic model:
-    - `train_topic_model(df)` con TF-IDF + `LogisticRegression`.
-    - pipeline sklearn salvata in `models/topic_model.joblib`.
-  - Similarità:
-    - `LessonSimilarityIndex` con TF-IDF (e meta-feature nella versione più recente),
-    - CLI `suggest_similar` (da testo o da `id` esistente).
+### 2.1 Completed foundations
 
-- ✅ **Step 4 – Pipeline & feature engineering + LeLe Vault**
-  - `LessonFeatureExtractor`:
-    - TF-IDF sul testo,
-    - meta-feature (lunghezza, n° parole, importance).
-  - `TopicModelConfig`, `build_topic_pipeline`, `train_topic_model`:
-    - pipeline unificata: feature extractor + modello.
-    - **hardening**: errore leggibile se il dataset ha un solo `topic`.
-  - **LeLe Vault (Markdown + YAML)**:
-    - directory radice configurabile (`LELE_VAULT_DIR`, es. `/home/baltimora/Uploads/LeLe-Vault`),
-    - file `.md` con frontmatter YAML:
-      - `id`, `topic`, `source`, `importance`, `tags`, `date`, `title`.
-    - CLI `import_from_dir`:
-      - scansiona il vault,
-      - genera/sincronizza frontmatter (`--write-missing-frontmatter`),
-      - gestisce duplicati con `--on-duplicate {overwrite,skip,error}`,
-      - scrive il dataset in `data/lessons.jsonl`.
-    - Bugfix:
-      - hash frontmatter con **SHA-256** (Bandit felice),
-      - serializzazione robusta delle `date` YAML (`datetime.date` → stringa JSON).
+- **Python setup and tooling**
+  - `src/lele_manager/` package layout;
+  - `pyproject.toml`, development extras, virtual environment workflow;
+  - early CLI tools such as `csv2json` and `file_watcher`;
+  - pre-commit hooks for whitespace, YAML, and Ruff.
 
-- ✅ **Step 5 – API FastAPI (base) & script dev**
-  - Server `lele_manager.api.server:app` con endpoint:
-    - `GET /health`
-    - `GET /lessons`
-    - `GET /lessons/{id}`
-    - `GET /lessons/{id}/similar`
-    - `POST /train/topic`
-  - Robustezza API:
-    - normalizzazione di `NaN` / `NaT` / valori strani → `Optional[str]`,
-    - niente più 500 casuali per colpa di `date/title` sporchi.
-  - **Script dev**:
-    - `scripts/lele-api-refresh.sh`:
-      1. importa dal vault → `data/lessons.jsonl`,
-      2. allena topic model → `models/topic_model.joblib`,
-      3. avvia FastAPI con Uvicorn (`--reload`).
-    - alias `lele-refresh` per avere *import + train + server* in un solo comando.
-  - README aggiornato con:
-    - sezione LeLe Vault,
-    - sezione API (FastAPI) + esempi `curl`.
+- **Lesson data and ingestion**
+  - core fields: `id`, `text`, `topic`, `source`, `importance`, `tags`,
+    `date`, and `title`;
+  - Markdown vault input with YAML frontmatter;
+  - JSONL compatibility dataset;
+  - ingestion from CSV and other sources;
+  - deterministic raw-source chunking and TritaLeLe candidate staging.
 
----
+- **Classic ML**
+  - `train_topic_model(df)` with TF-IDF and `LogisticRegression`;
+  - a serialized scikit-learn pipeline in `models/topic_model.joblib`;
+  - `LessonSimilarityIndex`;
+  - text- and ID-based similarity;
+  - optional LSA similarity backend.
 
-## 3. Stato attuale (LeLe Manager “1.0”)
+- **Shared feature pipeline**
+  - `LessonFeatureExtractor`;
+  - text TF-IDF plus character count, word count, and `importance`;
+  - `TopicModelConfig`, `build_topic_pipeline`, and hardened training errors;
+  - shared behavior across topic classification and similarity.
 
-In pratica oggi ho:
-- **Vault Markdown** organizzato (es. `git/`, `cpp/`, `python/`…) in `LELE_VAULT_DIR`.
-- Un **importer** stabile dal vault a JSONL (`import_from_dir`).
-- Un **topic model** che funziona su dati reali (py, C++, git, ecc.).
-- Un **indice di similarità** usabile (CLI + API).
-- Un **server FastAPI** che espone:
-  - lettura & ricerca,
-  - similarità,
-  - retraining.
-- Uno **script dev** (`lele-refresh`) che riallinea tutto: vault → JSONL → modello → API.
+- **LeLe Vault**
+  - configurable root through `LELE_VAULT_DIR`;
+  - tolerant importer input and strict canonical `lele doctor` validation;
+  - canonical `topic` and `id` checks against the relative path;
+  - duplicate handling with `overwrite`, `skip`, and `error`;
+  - SHA-256 frontmatter hashing;
+  - robust YAML date serialization;
+  - Markdown write-back and vault refresh workflows.
 
-È, di fatto, un **LeLe Manager 1.0 usabile in produzione personale**.
+- **FastAPI and development scripts**
+  - core lesson, search, training, similarity, duplicate, analytics, export,
+    vault, and operations endpoints;
+  - versioned TritaLeLe candidate workflow under `/api/v1/tritalele`;
+  - `scripts/lele-api-dev.sh`;
+  - `scripts/lele-api-refresh.sh`;
+  - GUI static serving and application composition.
 
----
+- **Web GUI**
+  - Svelte SPA with Browse, Detail, Editor, Vault, Ops, Timeline, and Stats;
+  - live suggestions and explained similarity;
+  - Markdown export;
+  - vault write-back;
+  - Playwright E2E smoke tests.
 
-## 4. TODO “assoluti” — stato aggiornato (2026-07)
+- **Projection-store boundary**
+  - backend-neutral typed port;
+  - coherent immutable snapshots;
+  - deterministic ordering, counts, and content generation;
+  - validated atomic whole-snapshot publication;
+  - JSONL compatibility adapter;
+  - explicit legacy append facade.
 
-La maggior parte dei TODO originali è **completata**. Questa sezione riflette lo stato reale del codice su `main`.
+## 3. Current product state
 
-### 4.1. Test automatici minimi ✅
+LeLe Manager currently provides:
 
-**Obiettivo:** evitare che una modifica futura spacchi in silenzio il flusso base.
+- a canonical Markdown vault for approved lesson authoring;
+- a strict local knowledge doctor;
+- a derived JSONL projection used by compatibility and ML flows;
+- topic classification and similarity over real lesson data;
+- exact- and near-duplicate reporting;
+- a FastAPI server;
+- an API-oriented `lele` CLI client;
+- a Svelte GUI;
+- TritaLeLe raw-source ingestion, candidate review, and approval workflows;
+- deterministic tests across domain, storage, API, CLI, and GUI boundaries.
 
-- [x] **Test `import_from_dir`** (`test_import_from_dir.py`, `test_import_from_dir_cli.py`, `test_frontmatter_hash.py`)
-  - [x] frontmatter mancante → viene creato correttamente
-  - [x] `date` YAML → stringa `"YYYY-MM-DD"` nel JSONL
-  - [x] `--on-duplicate overwrite` / `skip` / `error`
-  - [x] hash frontmatter (SHA-256) stabile
+The project is usable as a personal production tool, while storage migration
+and a few architectural cleanups remain active work.
 
-- [x] **Test `train_topic_model`** (`test_train_topic_model_cli.py`, `test_text_ml.py`)
-  - [x] dataset con due topic → training ok
-  - [x] dataset con un solo topic → `ValueError` leggibile
-  - [x] dataset senza colonna `topic` → errore chiaro
+## 4. Completed quality and product work
 
-- [x] **Test API base** (`test_api_basic.py`, `test_search_api.py`, `test_api_similar_edgecases.py`, …)
-  - [x] `GET /health` (dataset/modello presenti o mancanti)
-  - [x] `GET /lessons` con `NaN`/`NaT` e `tags` non lista
-  - [x] `GET /lessons/{id}` → 200 / 404
-  - [x] `GET /lessons/{id}/similar` → ok o 503 se modello mancante
+### 4.1 Automated tests
 
-Suite attuale: **~36 file di test, ~75 casi** — copertura ben oltre il minimo originale.
+Coverage includes:
 
-### 4.2. Endpoint di ricerca avanzata ✅
+- importer behavior and frontmatter repair;
+- canonical vault validation and duplicate IDs;
+- topic-model training success and failure modes;
+- similarity service equivalence and edge cases;
+- API health, search, details, similarity, analytics, export, and vault flows;
+- projection-store contract behavior;
+- TritaLeLe ingestion, review, approval, CLI, and API workflows;
+- GUI build and Playwright smoke tests.
 
-- [x] `POST /lessons/search` con payload JSON (`topic_in`, `source_in`, `importance_gte/lte`, `limit`, …)
-- [x] Filtri lato server con DataFrame normalizzato + ordinamento deterministico
-- [x] Esempi nel README
+### 4.2 Advanced search
 
-### 4.3. Client CLI sopra le API ✅
+- `POST /lessons/search`;
+- topic, source, importance, and text filters;
+- normalized records and deterministic ordering;
+- CLI and GUI consumers.
 
-- [x] `lele search "pytest" --topic python --limit 10`
-- [x] `lele show <id>`
-- [x] `lele similar <id> --top-k 5 --min-score 0.1`
-- [x] `lele train-topic`
-- [x] `lele suggest` (`--text`, `--file`, stdin, `--watch`)
-- [x] Configurazione via `LELE_API_URL` (default `http://127.0.0.1:8000`)
+### 4.3 API-oriented CLI
 
-### 4.4. Documentazione & versioni ✅ (con piccoli residui)
+- `lele search`;
+- `lele show`;
+- `lele similar`;
+- `lele train-topic`;
+- `lele suggest`;
+- `lele export`;
+- `lele duplicates`;
+- `lele doctor`;
+- TritaLeLe candidate commands;
+- `LELE_API_URL` configuration where applicable.
 
-- [x] Sezione **Versioni** nel README + `CHANGELOG.md`
-- [x] User stories complete nel README
-- [x] `LICENSE` (MIT)
-- [ ] Pin dipendenze in `pyproject.toml` (reproducibilità build)
-- [x] Tag `v1.5.0` per le feature post-1.4.1
+### 4.4 Documentation and release hygiene
 
----
+- Semantic Versioning;
+- `CHANGELOG.md`;
+- MIT license;
+- contributor guide;
+- English-canonical bilingual documentation policy;
+- maintained English/Italian mirrors for primary user and contributor docs;
+- focused documentation tests;
+- release and packaging workflows.
 
-## 5. Evoluzione futura (nice-to-have)
-Queste sono le idee “da laboratorio” — alcune già parzialmente realizzate.
+Remaining release-hygiene work includes dependency pinning or a justified
+lockfile strategy.
 
-### 5.1. ML più ricco
-- [x] Embedding densi (SVD) come backend opt-in (`LsaSimilarityBackend`, TF-IDF + TruncatedSVD).
-- [ ] doc2vec / altri embedding al posto/insieme di TF-IDF.
-- [ ] MLP o altro modellino leggero sopra le feature attuali per:
-  * migliorare similarità,
-  * stimare una “priorità di revisita” della LeLe (ranking personalizzato).
+## 5. Active architecture direction
 
-### 5.2. UX & interfacce
-- [x] Mini UI web (`GET /ui`) con ricerca e similarità free-text.
-- [x] Integrazione editor: `POST /editor/suggest` per similarità live mentre si scrive.
-- [ ] Plugin editor nativo (VS Code / Obsidian) che chiama l’API in background.
+### 5.1 Canonical content and projections
 
-### 5.3. Architettura & distribuzione
-- [x] Separazione in moduli (`core`, `ml`, `cli`, `api`).
-- [x] Packaging smoke test + release workflow (PyPI gated da `PYPI_ENABLED`).
-- [ ] Refactor `server.py` in router FastAPI separati.
-- [ ] Pubblicazione effettiva su PyPI.
-- [ ] Pin dipendenze per build riproducibili.
+The target separation is:
 
----
+- **Markdown vault:** authoritative approved lesson content;
+- **projection store:** queryable application view;
+- **JSONL:** derived interoperability, fixture, export, and ML snapshot;
+- **ML models:** rebuildable derived artifacts tied to a dataset generation.
 
-## 6. Priorità operative (in ordine pratico)
-1. ✅ Vault + import + ML + API + `lele-refresh`.
-2. ✅ Test minimi, `POST /lessons/search`, client CLI `lele`.
-3. ✅ UI minimale, similarity service boundary, backend abstraction, LSA opt-in.
-4. 🔴 **Prossimi passi sensati**:
-   1. Tag release `v1.5.0` (feature post-1.4.1 documentate in `CHANGELOG.md`).
-   2. Pin dipendenze (`pyproject.toml` o lockfile).
-   3. Split `server.py` in router (manutenibilità).
-5. 🟢 **Ricerca & giocattoni**:
-   * embedding più sofisticati (doc2vec, ecc.),
-   * ranking personalizzato,
-   * plugin editor,
-   * integrazione con altri progetti (GYTE, ecc.).
+The current adapter remains JSONL for compatibility. SQLite is the intended
+local query backend after parity, migration, and reconciliation work described
+by [ADR 0001](docs/adr/0001-storage-backend.md).
 
----
+### 5.2 TritaLeLe ingestion
+
+The target workflow is:
+
+```text
+source material
+  → deterministic chunks
+  → staged candidates
+  → explicit human review
+  → approval
+  → canonical Markdown vault
+  → projection refresh
+  → export and ML derivatives
+```
+
+Candidates are not approved lessons. They remain isolated from the canonical
+vault and ML dataset until explicit approval succeeds.
+
+### 5.3 Documentation
+
+English is canonical and default. Italian is officially maintained for the
+document pairs listed in
+[the documentation policy](docs/documentation-policy.md).
+
+Historical records, generated artifacts, and selected technical sources are
+excluded only through an explicit classification and rationale.
+
+## 6. Practical priorities
+
+1. **Keep the current system stable**
+   - preserve deterministic domain and storage contracts;
+   - maintain green lint, typing, tests, packaging, security, and E2E checks;
+   - keep documentation pairs synchronized.
+
+2. **Complete storage evolution**
+   - reconcile vault-only and JSONL-only records;
+   - introduce and validate the SQLite adapter;
+   - prove parity with the JSONL compatibility backend;
+   - expose stale projection state explicitly;
+   - cut over gradually without creating a second authority.
+
+3. **Complete TritaLeLe product integration**
+   - connect the candidate workflow to the GUI;
+   - preserve explicit review and approval;
+   - keep provenance and failure recovery visible;
+   - avoid direct candidate promotion into canonical datasets.
+
+4. **Improve maintainability**
+   - split oversized FastAPI modules into focused routers and services;
+   - define dependency pinning or lockfile policy;
+   - keep boundaries between authoring, synchronization, projection, export,
+     and ML explicit.
+
+5. **Expand integrations when justified**
+   - editor integrations such as VS Code or Obsidian;
+   - external quiz and review consumers;
+   - richer embeddings or ranking only after measurable benefit;
+   - analytical tooling such as DuckDB only for a demonstrated workload.
+
+## 7. Nice-to-have research
+
+- alternative dense embeddings or hybrid retrieval;
+- personalized revisit-priority ranking;
+- richer explainability for similarity and duplicate detection;
+- editor-native workflows;
+- versioned external lesson contracts;
+- analytics over larger exported snapshots.
+
+These items must not weaken local-first recoverability, deterministic behavior,
+or the authority of reviewed Markdown content.
+
+## 8. Explicit non-priorities
+
+The current project does not need:
+
+- a distributed database;
+- a remote document-store service;
+- unreviewed automatic candidate approval;
+- opaque automatic translation;
+- a heavy documentation platform;
+- infrastructure that exceeds the scale of the personal local-first workload.

--- a/docs/adr/0001-storage-backend.md
+++ b/docs/adr/0001-storage-backend.md
@@ -1,319 +1,587 @@
-# ADR 0001: backend di storage per LeLe Manager
+# ADR 0001: storage backend for LeLe Manager
 
-- **Stato:** Proposto
-- **Data:** 2026-07-13
+> Language policy: ADRs are English-only canonical technical records.
+> See the [documentation policy](../documentation-policy.md).
+
+- **Status:** Proposed
+- **Date:** 2026-07-13
 - **Issue:** [#91 — Compare storage backends](https://github.com/gcomneno/lele-manager/issues/91)
 - **Epic:** [#82 — TritaLeLe Knowledge Ingestion Pipeline](https://github.com/gcomneno/lele-manager/issues/82)
 
-## Contesto
+## Context
 
-LeLe Manager è un'applicazione personale e local-first. Il repository descrive spesso il flusso come `vault Markdown -> JSONL -> ML -> API`, ma il codice attuale non ha una sola sorgente autoritativa applicata in modo uniforme:
+LeLe Manager is a personal local-first application. The repository often
+describes its flow as `Markdown vault -> JSONL -> ML -> API`, but the current
+code does not apply one authoritative source consistently:
 
-- `src/lele_manager/cli/import_from_dir.py::import_from_dir` legge i file Markdown, usa l'`id` nel frontmatter (o lo deriva dal path), normalizza metadati e body e produce record che includono anche `path`, `frontmatter` e `frontmatter_hash`;
-- `src/lele_manager/core/vault.py::write_lesson_markdown` scrive body e frontmatter nel vault, mentre `import_vault_to_jsonl` ricostruisce interamente il JSONL dal vault;
-- `src/lele_manager/api/server.py::create_vault_lesson` e `update_lesson` scrivono prima il Markdown e poi reimportano il vault. Questo rende il vault la sorgente di authoring nel flusso GUI corrente;
-- la stessa API usa però `load_lessons_df` per leggere direttamente JSONL e `append_lesson_to_jsonl` per `POST /lessons`, che non scrive nel vault;
-- le CLI storiche `src/lele_manager/cli/add_lesson.py` e `list_lessons.py` usano direttamente `src/lele_manager/core/storage.py`, basato su append e scansione completa del JSONL;
-- la CLI principale `src/lele_manager/cli/lele.py` e la GUI in `frontend/src/lib/api.ts` passano invece dall'API;
-- training e similarità ricevono `pandas.DataFrame`: `src/lele_manager/cli/train_topic_model.py` e `suggest_similar.py` leggono JSONL, mentre `src/lele_manager/api/server.py::train_topic` e `build_similarity_index` usano il DataFrame caricato dallo stesso dataset. Il modello serializzato da `src/lele_manager/ml/topic_model.py` è un artefatto derivato;
-- `scripts/lele-api-refresh.sh` rende esplicito il rebuild completo `vault -> data/lessons.jsonl -> models/topic_model.joblib`;
-- `tests/test_api_vault.py` verifica write-back Markdown e reimport, mentre `tests/test_lessons_storage.py` e `tests/test_add_lesson_cli.py` preservano il comportamento JSONL diretto;
-- i percorsi predefiniti in `src/lele_manager/core/paths.py` collocano dataset e modello nelle directory XDG. `.gitignore` esclude dati, database e modelli locali, quindi oggi Git versiona il vault dell'utente solo se questo è gestito separatamente, non `data/lessons.jsonl` nel repository.
+- `src/lele_manager/cli/import_from_dir.py::import_from_dir` reads Markdown,
+  uses the frontmatter `id` or derives it from the path, normalizes metadata
+  and body, and produces records that also include `path`, `frontmatter`, and
+  `frontmatter_hash`;
+- `src/lele_manager/core/vault.py::write_lesson_markdown` writes body and
+  frontmatter to the vault, while `import_vault_to_jsonl` rebuilds JSONL from
+  the vault;
+- `src/lele_manager/api/server.py::create_vault_lesson` and `update_lesson`
+  write Markdown first and then reimport the vault, making the vault the
+  authoring source in the current GUI flow;
+- the same API still uses `load_lessons_df` to read JSONL directly and
+  `append_lesson_to_jsonl` for `POST /lessons`, which does not write to the
+  vault;
+- the historical `add_lesson.py` and `list_lessons.py` CLIs use
+  `src/lele_manager/core/storage.py`, which appends and scans JSONL directly;
+- the main `lele` CLI and the GUI use the API instead;
+- training and similarity accept `pandas.DataFrame` values:
+  `train_topic_model.py` and `suggest_similar.py` read JSONL, while API
+  training and similarity load the same dataset into a DataFrame;
+- `models/topic_model.joblib` is a derived artifact;
+- `scripts/lele-api-refresh.sh` makes the complete rebuild explicit:
+  `vault -> data/lessons.jsonl -> models/topic_model.joblib`;
+- vault tests verify Markdown write-back and reimport, while historical storage
+  tests preserve direct JSONL behavior;
+- default dataset and model paths are XDG-based, and `.gitignore` excludes
+  local data, databases, and models from this repository.
 
-Di conseguenza, **oggi il vault è la sorgente intenzionale del flusso completo, ma JSONL è ancora uno storage operativamente mutabile e può contenere record che non esistono nel vault**. Questa ambiguità va risolta prima di aggiungere altri flussi di ingestione. L'ADR definisce lo stato obiettivo; non cambia il comportamento corrente e non implementa la successiva astrazione.
+Therefore, the vault is the intended source for the complete authoring flow,
+but JSONL is still operationally mutable and may contain records absent from
+the vault. This ambiguity must be resolved before adding more ingestion paths.
 
-### Livelli architetturali
+This ADR defines the target state. It does not itself change runtime behavior
+or implement the following abstraction and migration work.
 
-| Livello | Stato attuale | Stato deciso |
+### Architectural layers
+
+| Layer | Current state | Decided target |
 |---|---|---|
-| Vault Markdown | Authoring e write-back GUI; rebuild del dataset | Sorgente autoritativa delle lesson approvate |
-| Storage applicativo | JSONL letto o scritto direttamente da più componenti | SQLite locale, ricostruibile e interrogabile |
-| JSONL | Dataset, storage mutabile, input ML e fixture | Snapshot derivato per export, interoperabilità, fixture e ML |
-| API / CLI / GUI | Accesso misto: API o JSONL diretto | Accesso alle lesson tramite confine applicativo/storage |
-| Topic e similarità | DataFrame da JSONL più modello `joblib` | Artefatti derivati da uno snapshot identificabile dello storage |
-| Export e integrazioni | Markdown da risultati API; JSONL implicito | Operazioni esplicite, separate dal backend |
+| Markdown vault | GUI authoring and write-back; dataset rebuild | Authoritative source for approved lessons |
+| Application storage | JSONL read or written directly by several components | Local, rebuildable, queryable SQLite projection |
+| JSONL | Dataset, mutable storage, ML input, and fixtures | Derived snapshot for export, interoperability, fixtures, and ML |
+| API / CLI / GUI | Mixed access through API or direct JSONL | Access lessons through application and storage boundaries |
+| Topic and similarity | DataFrame from JSONL plus `joblib` model | Derived artifacts tied to an identifiable storage snapshot |
+| Export and integrations | Markdown from API results; implicit JSONL | Explicit operations separated from the backend |
 
-## Requisiti e criteri decisionali
+## Requirements and decision criteria
 
-La scelta deve:
+The selected architecture must:
 
-1. restare semplice da installare e gestire per un'app locale Python;
-2. conservare portabilità, inspectability e possibilità di recupero manuale;
-3. supportare upsert, cancellazioni e sostituzioni complete senza rewrite non protetti;
-4. offrire transazioni, vincoli, query, filtri e indici;
-5. sostenere letture concorrenti e scritture occasionali realistiche per FastAPI/GUI locale;
-6. avere una strategia esplicita per schema e migrazioni;
-7. consentire full-text search senza renderla un prerequisito di portabilità;
-8. funzionare bene sia con dataset piccoli sia con una crescita moderata;
-9. integrarsi con Python, Pandas e scikit-learn;
-10. consentire backup, export e test isolati;
-11. non introdurre un servizio esterno senza un requisito concreto;
-12. minimizzare il costo di migrazione dal codice e dai dati attuali;
-13. mantenere Markdown e JSONL come formati interoperabili, senza confonderli con il database applicativo;
-14. preparare i confini richiesti dalle issue [#92](https://github.com/gcomneno/lele-manager/issues/92), [#93](https://github.com/gcomneno/lele-manager/issues/93) e [#94](https://github.com/gcomneno/lele-manager/issues/94).
+1. remain simple to install and operate for a local Python application;
+2. preserve portability, inspectability, and manual recovery;
+3. support upsert, deletion, and complete replacement without unsafe rewrites;
+4. provide transactions, constraints, queries, filters, and indexes;
+5. support realistic concurrent reads and occasional writes for a local
+   FastAPI/GUI application;
+6. define an explicit schema and migration strategy;
+7. allow full-text search without making it a portability prerequisite;
+8. work for small datasets and moderate growth;
+9. integrate with Python, Pandas, and scikit-learn;
+10. support coherent backups, export, and isolated tests;
+11. avoid an external service without a concrete requirement;
+12. minimize migration cost from current code and data;
+13. preserve Markdown and JSONL as interoperable formats without confusing
+    either with the application database;
+14. prepare the boundaries required by issues
+    [#92](https://github.com/gcomneno/lele-manager/issues/92),
+    [#93](https://github.com/gcomneno/lele-manager/issues/93), and
+    [#94](https://github.com/gcomneno/lele-manager/issues/94).
 
-## Opzioni considerate
+## Options considered
 
 ### JSONL
 
-JSONL ha il costo concettuale e operativo più basso: è UTF-8, leggibile con strumenti comuni, diffabile per riga e già consumato da Pandas e dagli script del progetto. È adatto a export, fixture, scambio e snapshot di training.
+JSONL has the lowest conceptual and operational cost. It is UTF-8, readable by
+common tools, line-diffable, and already consumed by Pandas and project scripts.
+It is appropriate for export, fixtures, exchange, and training snapshots.
 
-Come storage mutabile, però, l'append non garantisce unicità dell'ID e un upsert o delete richiede leggere e riscrivere il file. Il codice corrente mostra entrambi i modelli: `core.storage.append_lesson` appende, mentre `core.vault.upsert_jsonl_lesson` e `import_vault_to_jsonl` riscrivono. Non ci sono transazioni multi-record, schema o indici; lettura e filtri richiedono scansione e materializzazione. Lock, scrittura atomica e recovery dovrebbero essere implementati dall'applicazione. La buona compatibilità teorica con Git non cambia il fatto che i dati locali sono esclusi dal Git del repository.
+As mutable storage, append does not guarantee ID uniqueness, while upsert and
+delete require reading and rewriting the file. The current code demonstrates
+both patterns: `core.storage.append_lesson` appends, while
+`core.vault.upsert_jsonl_lesson` and `import_vault_to_jsonl` rewrite. JSONL
+does not provide multi-record transactions, schema constraints, or indexes.
+Reads and filters require scanning and materialization. Locking, atomic writes,
+and recovery must be implemented by the application. Theoretical Git
+friendliness does not change the fact that local data is excluded from this
+repository.
 
-**Valutazione:** mantenere JSONL come formato derivato, non come backend applicativo primario.
+**Assessment:** retain JSONL as a derived format, not the primary mutable
+application backend.
 
 ### SQLite
 
-SQLite è embedded, serverless e memorizza normalmente il database in un singolo file. Python espone `sqlite3` nella standard library; la documentazione Python precisa però che il modulo dipende dalla libreria SQLite ed è opzionale per chi distribuisce una build CPython. Questo va verificato sulle piattaforme supportate, ma non richiede una nuova dipendenza Python nel packaging ordinario.
+SQLite is embedded and serverless, normally storing a database in one file.
+Python exposes `sqlite3` in the standard library, although the module depends
+on the SQLite library and is optional for distributors of custom CPython
+builds. Supported platforms must verify it, but ordinary packaging does not
+require another Python dependency.
 
-Fornisce transazioni, vincoli, query SQL, indici, update e delete efficienti e una storia di migrazioni tramite versione dello schema. È adatto a una singola applicazione locale con molti read e scritture occasionali. In modalità WAL lettori e writer possono procedere contemporaneamente, ma resta un solo writer alla volta e l'applicazione deve gestire timeout/`SQLITE_BUSY`; il WAL non è adatto a filesystem di rete e i file `-wal`/`-shm` fanno parte dello stato da considerare nelle copie.
+SQLite provides transactions, constraints, SQL queries, indexes, efficient
+updates and deletes, and schema-versioned migrations. It fits one local
+application with many reads and occasional writes. WAL mode permits concurrent
+readers and a writer, but only one writer at a time remains realistic. The
+application must handle timeout and `SQLITE_BUSY`. WAL is unsuitable for
+network filesystems, and `-wal` and `-shm` files are relevant when copying
+state.
 
-FTS5 offre ricerca full-text indicizzata, ma la sua disponibilità dipende da come SQLite è stato compilato. Le build e i pacchetti supportati devono provarla; la ricerca di base deve poter funzionare senza FTS5. Backup coerenti possono usare la Backup API o `VACUUM INTO`; copiare alla cieca il solo file durante una sessione WAL non è una strategia di backup.
+FTS5 provides indexed full-text search when compiled into SQLite. Supported
+builds must detect and test it; baseline search must work without FTS5.
+Coherent backups can use the Backup API or `VACUUM INTO`. Blindly copying only
+the main database file during an active WAL session is not a backup strategy.
 
-L'integrazione con Pandas può avvenire tramite query/record convertiti in DataFrame al confine ML. Il database non va versionato in Git: il vault e gli export testuali restano i formati versionabili e recuperabili.
+Pandas integration can occur by converting query results or records into a
+DataFrame at the ML boundary. The database must not be versioned in Git; the
+vault and textual exports remain the versionable and recoverable formats.
 
-**Valutazione:** miglior corrispondenza al workload locale CRUD + ricerca di LeLe Manager.
+**Assessment:** best match for LeLe Manager's local CRUD and search workload.
 
 ### DuckDB
 
-DuckDB è embedded, transazionale e ottimizzato per workload analitici colonnari e operazioni bulk. Il client Python interroga direttamente DataFrame Pandas, Arrow e altri formati, quindi è molto attraente per EDA, statistiche e preparazione di dataset.
+DuckDB is embedded, transactional, and optimized for columnar analytical
+workloads and bulk operations. Its Python client can query Pandas DataFrames,
+Arrow, and other formats directly, making it attractive for exploratory
+analysis, statistics, and dataset preparation.
 
-Non è però una dipendenza attuale di `pyproject.toml`. La documentazione DuckDB indica come modalità embedded read-write ordinaria un singolo processo, nel quale sono possibili writer concorrenti. La scrittura multi-processo è tecnicamente possibile tramite il protocollo remoto Quack, ancora beta; DuckLake con catalogo PostgreSQL è un'altra alternativa, ma introduce infrastruttura esterna. Queste modalità aggiungono costo operativo senza soddisfare meglio di SQLite il requisito locale, semplice, embedded e orientato al CRUD. Inoltre, molte piccole transazioni non sono il workload primario di DuckDB e i vantaggi colonnari sono limitati per il dataset personale attuale.
+It is not a current `pyproject.toml` dependency. Ordinary embedded read-write
+usage is centered on one process with concurrent writers inside that process.
+Multi-process writing through remote Quack remains beta, while DuckLake with a
+PostgreSQL catalog introduces external infrastructure. These modes add
+operational cost without serving the simple local CRUD requirement better than
+SQLite. Many small transactions are also not DuckDB's primary workload, and
+its columnar advantages are limited for the current personal dataset.
 
-**Valutazione:** non backend CRUD primario; candidato futuro per analisi secondaria su snapshot JSONL/Parquet o, se utile, sui dati SQLite.
+**Assessment:** not the primary CRUD backend; a future analytical layer over
+JSONL, Parquet, or SQLite remains possible when justified.
 
-### Storage document-oriented embedded o locale
+### Embedded or local document-oriented storage
 
-Questa categoria comprende librerie in-process come TinyDB e prodotti embedded analoghi, non un servizio di rete. TinyDB, per esempio, persiste documenti Python in un file JSON e offre una query API. La corrispondenza con frontmatter flessibile è naturale e il debug può restare semplice.
+This category includes in-process libraries such as TinyDB and similar
+embedded products. TinyDB persists Python documents in JSON and offers a query
+API. Flexible frontmatter maps naturally to documents, and debugging can
+remain simple.
 
-Le garanzie su transazioni, concorrenza, indici, full-text search e migrazioni variano però per prodotto. Una soluzione JSON-file ripropone parte dei problemi di rewrite e locking di JSONL; una soluzione più completa aggiunge una dipendenza e un ecosistema specifici. Le lesson hanno già campi stabili e relazioni utili (ID univoco, tag, provenance, generazione di sync): la flessibilità schemaless non compensa la perdita delle funzionalità mature disponibili in SQLite. Campi futuri possono essere gestiti con migrazioni e, se necessario, una colonna JSON per metadati non ancora promossi.
+Transactions, concurrency, indexes, full-text search, and migrations vary by
+product. A JSON-file solution repeats JSONL rewrite and locking problems. A
+more capable solution adds a product-specific dependency and ecosystem.
+Lessons already have stable, useful fields and relationships: unique ID, tags,
+provenance, and synchronization generation. Schemaless flexibility does not
+outweigh the mature consistency and query capabilities of SQLite. Future
+fields can use migrations and, when useful, a JSON column for metadata not yet
+promoted into first-class columns.
 
-**Valutazione:** respinto per il backend primario; nessun vantaggio concreto sufficiente rispetto a SQLite.
+**Assessment:** rejected for the primary backend; no concrete advantage
+outweighs SQLite.
 
-### Document store server esterno
+### External document-store server
 
-MongoDB o un equivalente offre documenti flessibili, query, indici, concorrenza e, in configurazioni appropriate, transazioni. È però un processo o servizio separato da installare, configurare, proteggere, aggiornare e sottoporre a backup. Alcune garanzie dipendono anche dalla topologia di deployment.
+MongoDB or an equivalent provides flexible documents, queries, indexes,
+concurrency, and transactions in suitable deployments. It also requires a
+separate process or service to install, configure, secure, update, and back up.
+Some guarantees depend on deployment topology.
 
-LeLe Manager è oggi personale, locale e distribuibile come applicazione Python. Non esistono requisiti di replica, sharding, accesso remoto multiutente o volume che giustifichino tale costo operativo.
+LeLe Manager is personal, local, and distributable as a Python application.
+There is no replication, sharding, remote multi-user access, or volume
+requirement that justifies this operational cost.
 
-**Valutazione:** respinto. Potrà essere riesaminato solo in presenza di requisiti distribuiti reali.
+**Assessment:** rejected. Reconsider only if real distributed requirements
+emerge.
 
-## Matrice comparativa
+## Comparison matrix
 
-Legenda: `++` molto favorevole, `+` favorevole, `0` neutro/misto, `-` sfavorevole, `--` molto sfavorevole. I punteggi sono valutazioni progettuali per LeLe Manager, non benchmark universali.
+Legend: `++` strongly favorable, `+` favorable, `0` mixed or neutral,
+`-` unfavorable, `--` strongly unfavorable. These are project-specific design
+assessments, not universal benchmarks.
 
-| Criterio | JSONL | SQLite | DuckDB | Document store embedded | Document store server |
+| Criterion | JSONL | SQLite | DuckDB | Embedded document store | Server document store |
 |---|---:|---:|---:|---:|---:|
-| Semplicità operativa local-first | ++ | ++ | + | + | -- |
-| Dipendenze Python/runtime | ++ | ++\* | - | - | -- |
-| Portabilità del dato | ++ | + | + | 0 | 0 |
-| Lettura e debug manuale | ++ | + (CLI/tool) | 0 (tool) | +/0 | 0 |
-| Transazioni e consistenza | -- | ++ | ++ | variabile | ++ |
-| Update e delete | -- | ++ | + | + | ++ |
-| Query, filtri e indici | -- | ++ | ++ | +/0 | ++ |
-| CRUD interattivo | - | ++ | 0/- | +/0 | ++ |
-| Concorrenza per app locale | -- | + | 0/- | variabile | ++ |
-| Schema, vincoli e migrazioni | -- | ++ | + | 0/- | + |
-| Full-text search | -- | +\* | -/0 | variabile | + |
-| Dataset piccoli | ++ | ++ | + | + | - |
-| Crescita moderata | - | ++ | ++ analitica | 0/+ | ++ |
+| Local-first operational simplicity | ++ | ++ | + | + | -- |
+| Python/runtime dependencies | ++ | ++* | - | - | -- |
+| Data portability | ++ | + | + | 0 | 0 |
+| Manual reading and debugging | ++ | + (CLI/tool) | 0 (tool) | +/0 | 0 |
+| Transactions and consistency | -- | ++ | ++ | variable | ++ |
+| Update and delete | -- | ++ | + | + | ++ |
+| Queries, filters, and indexes | -- | ++ | ++ | +/0 | ++ |
+| Interactive CRUD | - | ++ | 0/- | +/0 | ++ |
+| Concurrency for a local app | -- | + | 0/- | variable | ++ |
+| Schema, constraints, and migrations | -- | ++ | + | 0/- | + |
+| Full-text search | -- | +* | -/0 | variable | + |
+| Small datasets | ++ | ++ | + | + | - |
+| Moderate growth | - | ++ | ++ analytical | 0/+ | ++ |
 | Pandas / scikit-learn | ++ | + | ++ | 0/+ | + |
-| Backup coerente | 0 | ++ | + | variabile | + ma operativo |
-| Diff/versionamento Git | ++ | -- | -- | +/-- secondo formato | -- |
-| Test isolati e in-memory | + | ++ | ++ | + | -- |
-| Packaging desktop/locale | ++ | ++\* | 0/- | 0/- | -- |
-| Interoperabilità strumenti | ++ | ++ | ++ | 0/+ | + |
-| Costo migrazione attuale | ++ | + | 0/- | 0/- | -- |
+| Coherent backup | 0 | ++ | + | variable | + with operations |
+| Git diff/versioning | ++ | -- | -- | +/-- by format | -- |
+| Isolated and in-memory tests | + | ++ | ++ | + | -- |
+| Desktop/local packaging | ++ | ++* | 0/- | 0/- | -- |
+| Tool interoperability | ++ | ++ | ++ | 0/+ | + |
+| Current migration cost | ++ | + | 0/- | 0/- | -- |
 
-`\*` La disponibilità di `sqlite3` e soprattutto FTS5 deve essere verificata nelle build Python/SQLite effettivamente distribuite.
+`*` Supported Python and SQLite builds must verify `sqlite3`, and especially
+FTS5, explicitly.
 
-## Decisione
+## Decision
 
-1. **Source of truth e identità:** il vault Markdown diventa la sorgente autoritativa delle lesson approvate. Il body autoritativo vive nel corpo del file e i metadati nel frontmatter. La convenzione canonica lega identità e collocazione: `topic` corrisponde alla prima directory del path relativo e `id` al path relativo senza estensione `.md`. Di conseguenza, spostare o rinominare un file richiede di aggiornare `id`; cambiare la directory topic richiede anche di aggiornare `topic`. Con la convenzione attuale un move o rename è una migrazione d'identità e può invalidare riferimenti esterni.
-2. **Backend applicativo:** SQLite diventa lo storage locale interrogabile e indicizzato. È una proiezione ricostruibile del vault, non una seconda fonte autoritativa indipendente.
-3. **Ruolo di JSONL:** JSONL resta uno snapshot derivato per export, interoperabilità, fixture e input riproducibile di training/analisi. Durante la migrazione può restare un backend di compatibilità dietro l'astrazione della #92, ma non è il backend finale né il luogo canonico delle modifiche.
-4. **Ruolo di DuckDB:** nessun ruolo nel CRUD primario. Può essere rivalutato come strumento analitico secondario quando volume o query colonnari lo giustificheranno, lavorando su export o snapshot.
-5. **Storage document-oriented:** sia il document store embedded sia il server esterno sono respinti. Il primo non offre un vantaggio sufficiente rispetto a SQLite per consistenza e query; il secondo introduce operatività sproporzionata senza requisito distribuito.
-6. **Servizi e confine della #92:** le operazioni user-facing di create, update e delete passano da un servizio di authoring, che valida e scrive il vault. Un servizio di sincronizzazione legge il vault e aggiorna un projection store interrogabile; eventuali `upsert`, `delete` e `replace-all` sono capacità interne usate dal sync, non operazioni offerte alla business logic o agli endpoint per modificare direttamente SQLite. Servizi di export separati leggono uno snapshot della proiezione e producono JSONL o altri formati. L'astrazione della #92 rappresenta il minimo contratto della proiezione senza esporre JSONL, SQLite, SQL, Pandas o filesystem.
-7. **Stato della proiezione:** ogni proiezione registra la generazione o il fingerprint del vault da cui deriva. Un mismatch deve essere rilevabile ed esposto; API e CLI non devono dichiarare corrente una proiezione stale. La policy concreta potrà imporre il sync, restituire un errore esplicito o operare in modalità degradata segnalata, ma lo stale silenzioso è vietato.
+1. **Source of truth and identity:** the Markdown vault becomes the
+   authoritative source for approved lessons. Authoritative content lives in
+   the Markdown body and metadata in frontmatter. The canonical convention
+   binds identity to location: `topic` equals the first relative directory and
+   `id` equals the relative path without `.md`. Renaming or moving a file
+   therefore requires updating `id`; changing the topic directory also
+   requires updating `topic`. Under this convention, a move or rename is an
+   identity migration and may invalidate external references.
 
-Questa è una decisione sullo **stato obiettivo**. La #92 deve inizialmente preservare il comportamento JSONL richiesto dalla propria issue; il passaggio del default a SQLite avverrà solo dopo parità verificata e riconciliazione dei dati JSONL-only.
+2. **Application backend:** SQLite becomes the local indexed and queryable
+   storage. It is a rebuildable projection of the vault, not an independent
+   second source of truth.
 
-## Motivazione
+3. **JSONL role:** JSONL remains a derived snapshot for export,
+   interoperability, fixtures, and reproducible training or analysis input.
+   During migration it may remain a compatibility backend behind issue #92's
+   abstraction, but it is not the final backend or the canonical editing
+   surface.
 
-SQLite risolve i limiti già visibili nel codice: append duplicabili, rewrite completo per upsert, scansioni per ogni filtro e assenza di transazioni. Lo fa con un componente embedded coerente con il packaging e il workload locale, senza imporre un servizio.
+4. **DuckDB role:** DuckDB has no primary CRUD role. It may be reconsidered as
+   a secondary analytical tool when volume or columnar queries justify it,
+   operating over exports or snapshots.
 
-Mantenere Markdown come autorità conserva l'esperienza di authoring, la leggibilità, la portabilità e la storia Git del vault. Mantenere JSONL come snapshot conserva l'integrazione già funzionante con Pandas/scikit-learn e con strumenti esterni, senza chiedergli di essere anche un database mutabile.
+5. **Document-oriented storage:** both embedded and server document stores are
+   rejected. The embedded category does not provide enough advantage over
+   SQLite for consistency and queries; the server category adds
+   disproportionate operations without a distributed requirement.
 
-La separazione elimina inoltre una falsa scelta: Markdown, SQLite e JSONL non competono per lo stesso ruolo. Sono rispettivamente contenuto autoritativo, indice/storage applicativo e formato di scambio o dataset derivato.
+6. **Services and issue #92 boundary:** user-facing create, update, and delete
+   operations pass through an authoring service that validates and writes the
+   vault. A synchronization service reads the vault and updates a queryable
+   projection store. `upsert`, `delete`, and `replace-all` are internal sync
+   capabilities, not business-logic or endpoint operations that modify SQLite
+   directly. Separate export services read a projection snapshot and publish
+   JSONL or other formats. Issue #92's abstraction represents the minimum
+   projection contract without exposing JSONL, SQLite, SQL, Pandas, or the
+   filesystem.
 
-## Conseguenze positive
+7. **Projection state:** each projection records the vault generation or
+   fingerprint from which it was built. A mismatch must be detectable and
+   exposed. API and CLI consumers must not silently report a stale projection
+   as current. The concrete policy may require synchronization, return an
+   explicit error, or operate in a clearly signaled degraded mode.
 
-- ID univoci, vincoli, update, delete e rebuild possono essere atomici nello storage applicativo.
-- API, CLI e GUI possono condividere query e ordinamento senza caricare sempre l'intero dataset.
-- Indici ordinari e, dove disponibile, FTS5 preparano ricerca e filtri più efficienti.
-- SQLite è facile da creare in un file temporaneo o in memoria nei test.
-- Il vault resta leggibile, modificabile con editor comuni e versionabile indipendentemente dall'app.
-- JSONL resta semplice da esportare, ispezionare e caricare in Pandas.
-- Il database può essere ricostruito dal vault dopo corruzione o cambio schema.
-- Il confine storage rende sostituibile il backend senza esporlo ai consumer esterni.
+This is a target-state decision. Issue #92 must initially preserve the JSONL
+behavior required by its own scope. The default changes to SQLite only after
+verified parity and reconciliation of JSONL-only data.
 
-## Conseguenze negative e trade-off
+## Rationale
 
-- Esisteranno migrazioni di schema SQLite e una versione dello schema da mantenere.
-- Il file SQLite non è adatto a diff o merge Git e non deve essere trattato come backup del vault.
-- Il coordinamento tra commit filesystem e transazione SQLite non è una singola transazione ACID. Serve un protocollo di sincronizzazione esplicito.
-- WAL, timeout, checkpoint e gestione di `SQLITE_BUSY` richiedono scelte operative e test; un singolo writer resta il limite realistico.
-- FTS5 non può essere assunto disponibile ovunque: serve feature detection e fallback.
-- La conversione verso DataFrame diventa un adattatore esplicito invece di un semplice `pd.read_json`.
-- Durante la migrazione coesisteranno due backend, aumentando temporaneamente la superficie di test.
-- I record creati solo in JSONL devono essere identificati e riconciliati prima che il vault possa essere dichiarato unica autorità operativa.
+SQLite addresses limitations already visible in the code: duplicate-prone
+append, whole-file rewrites for upsert, scans for each filter, and the absence
+of transactions. It does so with an embedded component compatible with the
+local workload and packaging, without requiring a service.
 
-## Piano di adozione
+Keeping Markdown authoritative preserves the authoring experience,
+readability, portability, and independent Git history of the vault. Keeping
+JSONL as a snapshot preserves working Pandas, scikit-learn, and external-tool
+integration without forcing JSONL to act as a mutable database.
 
-Questo piano appartiene alle issue successive; la #91 non lo implementa.
+The separation also removes a false choice. Markdown, SQLite, and JSONL serve
+different roles: authoritative content, application index/storage, and
+exchange or derived dataset.
 
-1. Nella #92, introdurre il confine storage e un adapter JSONL che preservi il comportamento corrente.
-2. Introdurre il servizio di authoring come unico ingresso user-facing per create, update e delete delle lesson approvate; deve validare e scrivere il vault Markdown.
-3. Introdurre il servizio di sincronizzazione, separato dall'authoring, che pubblica snapshot della proiezione e ne registra generazione o fingerprint; rimuovere dalle regole di business la conoscenza di path JSONL, `pd.read_json` e append/rewrite senza cambiare ancora il backend predefinito.
-4. Aggiungere un adapter SQLite dietro lo stesso confine, con versione dello schema e migrazioni esplicite. Le sue capacità incrementali e transazionali restano interne al sync.
-5. Eseguire un inventario read-only di vault e JSONL. Segnalare duplicati, record JSONL-only, ID mancanti e conflitti; **non modificare automaticamente i Markdown**.
-6. Importare il vault in un database SQLite nuovo e confrontare conteggi, ID, campi, hash e risultati delle query con il backend JSONL.
-7. Solo dopo la riconciliazione, spostare in modo graduale le letture di API e CLI sul backend SQLite; GUI e CLI principale restano consumer dell'API e le scritture continuano a passare dall'authoring del vault.
-8. Separare i servizi di export e generare JSONL esplicitamente come pubblicazione atomica dello stesso snapshot, usandolo per le pipeline non ancora migrate.
-9. Spostare training e similarità verso uno snapshot/DataFrame ottenuto dal confine applicativo, registrandone fingerprint o generazione.
-10. Eliminare gli accessi diretti a JSONL soltanto dopo test di parità, stabilizzazione e una finestra di compatibilità documentata.
+## Positive consequences
 
-## Compatibilità e migrazione
+- Unique IDs, constraints, updates, deletes, and rebuilds can be atomic in the
+  application storage.
+- API, CLI, and GUI can share queries and ordering without always loading the
+  complete dataset.
+- Ordinary indexes and optional FTS5 support more efficient search and filters.
+- SQLite is easy to create in a temporary file or in memory for tests.
+- The vault remains readable, editor-friendly, and independently versionable.
+- JSONL remains easy to export, inspect, and load into Pandas.
+- The database can be rebuilt from the vault after corruption or schema change.
+- The storage boundary keeps the backend replaceable without exposing it to
+  external consumers.
 
-### Modello dei dati
+## Negative consequences and trade-offs
 
-- **Vault:** `id`, topic, source, importance, tags, date, title e provenance approvata nel frontmatter; contenuto nel body Markdown. `topic` deve coincidere con la prima directory del path relativo e `id` con l'intero path relativo senza `.md`; rename, move o cambio della directory topic richiedono l'aggiornamento coerente dei campi canonici. Metadati frontmatter sconosciuti non devono essere persi durante il round-trip.
-- **SQLite:** copia interrogabile di ID, metadati e body, più informazioni di sincronizzazione come path relativo, hash del frontmatter/contenuto e generazione. La forma esatta delle tabelle e la rappresentazione dei tag sono rinviate alla #92.
-- **JSONL:** rappresentazione completa e documentata di una generazione; non log append-only e non authority. L'ordine deve essere deterministico per diff e test riproducibili.
-- **Modelli ML:** artefatti derivati, rigenerabili, associati al fingerprint/generazione del dataset da cui provengono.
+- SQLite schema migrations and a schema version must be maintained.
+- SQLite files are not suitable for Git diff or merge and must not be treated
+  as vault backups.
+- A filesystem commit and SQLite transaction cannot form one ACID transaction;
+  synchronization needs an explicit protocol.
+- WAL, timeouts, checkpoints, and `SQLITE_BUSY` handling require operational
+  decisions and tests; one writer remains the realistic limit.
+- FTS5 cannot be assumed everywhere; feature detection and fallback are
+  required.
+- DataFrame conversion becomes an explicit adapter instead of a direct
+  `pd.read_json`.
+- Two backends coexist during migration, temporarily increasing test surface.
+- JSONL-only records must be identified and reconciled before the vault becomes
+  the sole operational authority.
 
-### Aggiornamenti, cancellazioni e consistenza
+## Adoption plan
 
-Le modifiche user-facing a lesson approvate devono passare dal servizio di authoring del vault. Il projection store non è un'interfaccia di authoring. Concettualmente:
+This plan belongs to later issues. Issue #91 does not implement it.
 
-1. validare l'intera lesson;
-2. scrivere o sostituire il Markdown in modo atomico;
-3. far rilevare la nuova generazione del vault al servizio di sincronizzazione;
-4. applicare internamente al projection store un upsert/delete opzionale o una sostituzione completa; per SQLite il sync può usare una transazione;
-5. pubblicare la nuova generazione della proiezione solo a sincronizzazione conclusa;
-6. invalidare o rigenerare JSONL, statistiche e modelli derivati.
+1. In #92, introduce the storage boundary and a JSONL adapter that preserves
+   current behavior.
+2. Introduce the authoring service as the only user-facing entry point for
+   create, update, and delete of approved lessons; it validates and writes the
+   Markdown vault.
+3. Introduce a separate synchronization service that publishes projection
+   snapshots and records their generation or fingerprint. Remove knowledge of
+   JSONL paths, `pd.read_json`, and append/rewrite behavior from business rules
+   without changing the default backend yet.
+4. Add a SQLite adapter behind the same boundary with explicit schema version
+   and migrations. Its incremental and transactional capabilities remain
+   internal to synchronization.
+5. Perform a read-only inventory of vault and JSONL. Report duplicates,
+   JSONL-only records, missing IDs, and conflicts. Do not modify Markdown
+   automatically.
+6. Import the vault into a new SQLite database and compare counts, IDs, fields,
+   hashes, and query results against JSONL.
+7. Only after reconciliation, move API and CLI reads gradually to SQLite. GUI
+   and the main CLI remain API consumers, and writes still pass through vault
+   authoring.
+8. Separate export services and publish JSONL atomically from the same
+   projection snapshot for pipelines not yet migrated.
+9. Move training and similarity to a snapshot or DataFrame obtained through
+   the application boundary, recording its fingerprint or generation.
+10. Remove direct JSONL access only after parity tests, stabilization, and a
+    documented compatibility window.
 
-Una cancellazione approvata rimuove il Markdown (la storia può restare in Git) e il successivo sync elimina la voce dalla proiezione. Se la scrittura Markdown riesce ma il sync fallisce, la proiezione precedente può restare materialmente leggibile, ma la sua generazione o fingerprint non coincide più con il vault ed è quindi stale. Il mismatch deve essere rilevato ed esposto: API e CLI non possono presentarla silenziosamente come corrente. La policy concreta — sync obbligatorio, errore esplicito o modalità degradata segnalata — è rinviata; il vault prevale, il sync è ripetibile e non si tenta un rollback distruttivo del Markdown già confermato.
+## Compatibility and migration
 
-Per un rebuild completo, tutti i Markdown vanno analizzati e validati prima di aprire la transazione che sostituisce il dataset. Errori o ID duplicati impediscono la pubblicazione della nuova generazione. JSONL va esportato tramite file temporaneo e rename, non aggiornato in-place riga per riga.
+### Data model
 
-Non è ammesso un doppio write permanente Markdown + database senza questa regola di autorità. In particolare, un endpoint applicativo non deve aggiornare SQLite e “provare poi” a scrivere il vault lasciando ambiguo quale copia vinca.
+- **Vault:** approved `id`, topic, source, importance, tags, date, title, and
+  provenance in frontmatter; content in the Markdown body. `topic` equals the
+  first relative directory and `id` equals the complete relative path without
+  `.md`. Rename, move, or topic-directory changes require coherent canonical
+  metadata updates. Unknown frontmatter metadata must survive round trips.
+- **SQLite:** queryable copies of IDs, metadata, and bodies, plus
+  synchronization information such as relative path, content/frontmatter
+  hashes, and generation. Exact tables and tag representation are deferred to
+  #92.
+- **JSONL:** complete documented representation of one generation, not an
+  append-only log and not authority. Ordering must be deterministic for
+  reproducible tests and diffs.
+- **ML models:** rebuildable derived artifacts associated with the dataset
+  fingerprint or generation used to train them.
+
+### Updates, deletions, and consistency
+
+User-facing changes to approved lessons pass through the vault authoring
+service. The projection store is not an authoring interface.
+
+Conceptually:
+
+1. validate the complete lesson;
+2. write or replace Markdown atomically;
+3. let synchronization detect the new vault generation;
+4. apply an internal upsert/delete or whole replacement to the projection
+   store; SQLite synchronization may use a transaction;
+5. publish the new projection generation only after synchronization completes;
+6. invalidate or regenerate JSONL, statistics, and derived models.
+
+An approved deletion removes the Markdown file, while Git may retain history.
+The next synchronization removes the projection entry. If Markdown writing
+succeeds but synchronization fails, the previous projection may remain
+physically readable, but its generation no longer matches the vault. That
+mismatch is stale state and must be exposed. The vault wins, synchronization is
+repeatable, and the application does not attempt a destructive rollback of
+already confirmed Markdown.
+
+For a complete rebuild, all Markdown files are parsed and validated before
+opening the transaction that replaces the dataset. Errors or duplicate IDs
+prevent publication. JSONL export uses a temporary file and atomic rename,
+never line-by-line in-place updates.
+
+Permanent dual writes to Markdown and database without this authority rule are
+not allowed. In particular, an endpoint must not update SQLite and then
+"attempt" to write the vault while leaving the winning copy ambiguous.
 
 ### Rollback
 
-- Finché SQLite non è il default, il backend JSONL resta selezionabile e i test di compatibilità garantiscono il ritorno al comportamento precedente.
-- Dopo lo switch, un rollback applicativo rigenera JSONL dal vault e può usarlo temporaneamente al posto di SQLite come proiezione. Le modifiche user-facing continuano a passare dal servizio di authoring del vault: il rollback non riabilita scritture autoritative dirette su JSONL e non promuove una copia SQLite più recente del vault ad authority.
-- Ogni migrazione SQLite opera su backup coerente o database ricostruibile e deve poter fallire senza modificare il vault.
-- Nessuna fase di migrazione riscrive automaticamente frontmatter o body. Le correzioni segnalate dall'audit richiedono revisione esplicita.
+- Until SQLite is default, JSONL remains selectable and compatibility tests
+  preserve the previous behavior.
+- After cutover, an application rollback regenerates JSONL from the vault and
+  may use it temporarily as the projection. User-facing writes still pass
+  through vault authoring; rollback does not restore authoritative direct
+  JSONL writes or promote a SQLite copy newer than the vault.
+- Each SQLite migration operates on a coherent backup or a rebuildable
+  database and may fail without modifying the vault.
+- No migration phase automatically rewrites frontmatter or body. Audit findings
+  require explicit review.
 
-### Strategia di test
+### Test strategy
 
-- suite contrattuale sul minimo comune JSONL/SQLite: lettura per ID, elenco/ricerca deterministici, lettura coerente di uno snapshot, pubblicazione o sostituzione atomica dell'intero snapshot, conteggi e generazione/fingerprint;
-- test specifici SQLite per transazioni e aggiornamenti incrementali del sync, senza estendere tali promesse al backend JSONL;
-- golden dataset con record completi, campi opzionali, Unicode, tag e ID canonici contenenti `/`, verificando che `id` sia il path relativo senza `.md` e `topic` la prima directory;
-- test di rename e move come migrazioni d'identità, incluso il possibile invalidamento di riferimenti al vecchio ID;
-- parità di filtri, ordinamento e serializzazione con gli endpoint attuali;
-- test di rollback su import invalido, duplicato, transazione interrotta e migrazione fallita;
-- test concorrenti realistici con più reader, un writer, timeout e retry limitato;
-- feature test di FTS5 nel packaging supportato e test del fallback senza FTS5;
-- confronto di fingerprint fra vault, SQLite, export JSONL e input del modello;
-- smoke API/CLI/GUI senza accessi diretti al formato del backend.
+- contract suite for common JSONL/SQLite behavior: get by ID, deterministic
+  list/search, coherent snapshot read, atomic whole-snapshot publication,
+  counts, and generation/fingerprint;
+- SQLite-specific tests for synchronization transactions and incremental
+  updates, without extending those promises to JSONL;
+- golden datasets with complete records, optional fields, Unicode, tags, and
+  canonical IDs containing `/`;
+- canonical checks that `id` equals the relative path without `.md` and
+  `topic` equals the first directory;
+- rename and move tests as identity migrations, including invalidated
+  references to old IDs;
+- filter, ordering, and serialization parity with current endpoints;
+- rollback tests for invalid import, duplicates, interrupted transactions, and
+  failed migrations;
+- realistic concurrency tests with multiple readers, one writer, timeout, and
+  limited retries;
+- FTS5 feature tests in supported packaging and fallback tests without FTS5;
+- fingerprint comparison across vault, SQLite, JSONL export, and model input;
+- API, CLI, and GUI smoke tests without direct backend-format access.
 
-## Confine concettuale per la #92
+## Conceptual boundary for issue #92
 
-Il port deve offrire capacità, senza fissare firme Python definitive:
+The port offers capabilities without fixing final Python signatures:
 
-- lettura di una lesson per ID;
-- elenco e ricerca filtrata, con ordinamento e limiti deterministici;
-- lettura coerente di uno snapshot;
-- pubblicazione o sostituzione atomica dell'intero snapshot;
-- conteggi/statistiche essenziali che evitino scansioni duplicate;
-- esposizione di una generazione o fingerprint utile a cache e derivati.
+- get one lesson by ID;
+- deterministic filtered list and search with limits;
+- read one coherent snapshot;
+- atomically publish or replace a complete snapshot;
+- obtain essential counts and statistics without duplicate scans;
+- expose a generation or fingerprint useful for cache and derivatives.
 
-L'adapter SQLite può inoltre offrire al servizio di sincronizzazione upsert, delete e transazioni come capacità interne o opzionali. Non fanno parte del minimo comune e non obbligano JSONL a simulare transazioni generali o semantiche ACID.
+The SQLite adapter may additionally provide synchronization with internal or
+optional upsert, delete, and transaction capabilities. These are not part of
+the common minimum and do not force JSONL to simulate general transactions or
+ACID semantics.
 
-Restano fuori dal port:
+The port excludes:
 
-- parsing e rendering Markdown;
-- scansione e write-back del vault;
-- operazioni user-facing di create, update e delete;
-- import/export JSONL, Markdown o altri formati;
-- costruzione di DataFrame;
-- training, serializzazione e cache dei modelli;
-- dettagli SQL, path del database e tipi specifici di Pandas.
+- Markdown parsing and rendering;
+- vault scanning and write-back;
+- user-facing create, update, and delete;
+- JSONL, Markdown, or other import/export;
+- DataFrame construction;
+- model training, serialization, and cache;
+- SQL details, database paths, and Pandas-specific types.
 
-L'authoring è un servizio applicativo distinto: valida le operazioni user-facing e scrive il vault. La sincronizzazione legge il vault già autoritativo, verifica la convenzione canonica di ID/topic e pubblica una nuova proiezione con `replace-all` o, se l'adapter lo consente, con upsert/delete incrementali; le transazioni SQLite sono un dettaglio di questa implementazione. L'export è un ulteriore servizio: legge uno snapshot tramite il port e serializza JSONL o altri formati.
+Authoring is a separate application service that validates user-facing
+operations and writes the vault. Synchronization reads the already
+authoritative vault, validates canonical ID/topic conventions, and publishes a
+new projection through `replace-all` or adapter-specific incremental
+operations. SQLite transactions are an implementation detail of that sync.
+Export is another service that reads a snapshot through the port and
+serializes JSONL or other formats.
 
-## Impatto sulle issue successive
+## Impact on later issues
 
 ### #92 — Introduce storage abstraction layer
 
-La #92 deve implementare il port minimo e l'adapter JSONL di compatibilità, preservando il comportamento esterno e le semantiche JSONL correnti, inclusi temporaneamente i flussi di scrittura legacy. Deve isolare gli accessi presenti in `core.storage`, `core.vault` e `api.server` e introdurre i confini concettuali fra authoring, sincronizzazione, projection store ed export, senza imporre nella stessa issue il passaggio definitivo delle scritture user-facing al vault. Il cutover verso l'authoring vault-only avviene in una fase successiva, dopo riconciliazione e test di parità. Nello stato obiettivo endpoint e business logic non chiamano direttamente le mutazioni del projection store; upsert/delete e transazioni SQLite appartengono al sync. Import/export non va incorporato nel repository.
+Issue #92 implements the minimum port and the JSONL compatibility adapter while
+preserving external behavior and current JSONL semantics, including temporary
+legacy write flows. It isolates access currently spread across `core.storage`,
+`core.vault`, and `api.server`, and introduces conceptual boundaries among
+authoring, synchronization, projection store, and export.
+
+It does not need to force the final cutover of user-facing writes to the vault
+in the same issue. Vault-only authoring follows after reconciliation and parity
+tests. In the target state, endpoints and business logic do not call projection
+mutations directly; SQLite upsert/delete and transactions belong to sync.
+Import/export does not belong inside the repository abstraction.
 
 ### #93 — Expose lessons for external quiz and review tools
 
-La #93 può dipendere da un contratto applicativo stabile di lesson/snapshot: get per ID, ricerca/elenco deterministici, metadati, body e generazione. La stabilità del contratto non implica però che un ID sopravviva a uno spostamento: poiché l'ID canonico deriva dal path, rename e move sono migrazioni d'identità e possono invalidare riferimenti esterni. I consumer non devono presumere la permanenza dell'ID attraverso tali operazioni. Una futura strategia di alias o una chiave esterna immutabile potrà essere valutata separatamente, senza definirne ora lo schema. Il consumer esterno non deve ricevere path SQLite, righe SQL, DataFrame o promesse sul formato JSONL interno. Un export JSONL versionato o un'API paginata possono essere trasporti dello stesso contratto. I quiz restano consumer read-only e non diventano una seconda authority.
+Issue #93 may depend on a stable application lesson/snapshot contract: get by
+ID, deterministic list/search, metadata, body, and generation.
+
+Contract stability does not mean an ID survives a move. Because canonical ID is
+derived from the path, rename and move are identity migrations and may
+invalidate external references. Consumers must not assume ID permanence across
+those operations. A future alias strategy or immutable external key may be
+considered separately.
+
+External consumers receive no SQLite paths, SQL rows, DataFrames, or promises
+about internal JSONL representation. A versioned JSONL export or paginated API
+may transport the same contract. Quiz tools remain read-only consumers and do
+not become another authority.
 
 ### #94 — TritaLeLe
 
-TritaLeLe introduce sorgenti grezze, provenance, chunking, candidati e revisione umana. I candidati **non** sono lesson approvate e non devono entrare direttamente nel vault autoritativo o nel dataset ML. Il workflow deve mantenere uno staging separato; solo l'approvazione umana produce un Markdown con ID e provenance, seguito dal sync transazionale verso SQLite e dalla rigenerazione dei derivati. Lo storage abstraction può essere esteso in futuro con un port distinto per i candidati, senza sovraccaricare il repository delle lesson.
+TritaLeLe introduces raw sources, provenance, chunking, candidates, and human
+review. Candidates are not approved lessons and must not enter the
+authoritative vault or ML dataset directly.
 
-Questa separazione rende deterministico il passaggio `source material -> candidate -> approval -> vault -> storage -> export/ML` e impedisce che testo non revisionato alteri ricerca, topic o similarità.
+The workflow keeps separate staging. Only explicit human approval produces
+Markdown with canonical ID and provenance, followed by synchronization to the
+projection and regeneration of derived artifacts. A distinct candidate port
+may be introduced without overloading the approved-lesson repository.
 
-## Alternative rinviate
+This separation makes the flow deterministic:
 
-- FTS5 come requisito obbligatorio: rinviato finché packaging e tokenizer non sono verificati; SQLite resta la scelta anche con ricerca fallback.
-- DuckDB come layer analitico o export Parquet: rinviato finché non esiste un workload analitico che ne dimostri il valore.
-- Metadati interamente normalizzati rispetto a colonna JSON per campi estesi: decisione di schema della #92, purché ID e campi interrogati abbiano vincoli/indici espliciti.
-- Change log, event sourcing o tombstone permanenti: non richiesti oggi; Git del vault e generazioni di sync coprono il recupero iniziale.
-- Database server multiutente: rinviato finché non esistono requisiti di accesso remoto, replica o writer multipli.
+```text
+source material
+  -> candidate
+  -> approval
+  -> vault
+  -> storage
+  -> export / ML
+```
 
-## Condizioni che potrebbero far riesaminare la decisione
+It prevents unreviewed text from changing search, topic, or similarity results.
 
-La decisione va riesaminata se si verifica almeno una di queste condizioni:
+## Deferred alternatives
 
-- LeLe Manager diventa multiutente o richiede writer distribuiti/remoti;
-- il vault Markdown non può più rappresentare senza perdita i contenuti o la provenance approvata;
-- volume e query analitiche rendono SQLite misurabilmente inadeguato nonostante indici e query corrette;
-- una pipeline richiede scansioni colonnari/Parquet come workload dominante, rendendo DuckDB candidato primario;
-- packaging target rilevanti non forniscono in modo affidabile `sqlite3` e non è accettabile distribuire SQLite;
-- sync filesystem/database causa problemi operativi non risolvibili con generazioni, rebuild atomico e rilevamento stale;
-- emerge un requisito concreto per documenti eterogenei con query che uno schema SQLite più campi JSON non soddisfa.
+- Mandatory FTS5: deferred until packaging and tokenizer behavior are verified;
+  SQLite remains selected with fallback search.
+- DuckDB as an analytical layer or Parquet export: deferred until a workload
+  demonstrates value.
+- Fully normalized metadata versus a JSON column for extensions: deferred to
+  #92's schema decision, provided IDs and queried fields receive explicit
+  constraints and indexes.
+- Change log, event sourcing, or permanent tombstones: not currently required;
+  vault Git history and synchronization generations cover initial recovery.
+- Multi-user database server: deferred until remote access, replication, or
+  multiple-writer requirements exist.
 
-## Rischi e domande aperte
+## Conditions for reconsidering the decision
 
-- Quali record reali esistono solo in JSONL e come verranno promossi nel vault senza perdere `created_at` o altri campi?
-- Qual è la policy UX per delete: rimozione fisica versionata in Git o tombstone esplicito?
-- Quali metadati di provenance della #94 devono diventare campi interrogabili e quali restano estensioni del frontmatter?
-- Quali build Python e sistemi operativi fanno parte della matrice di packaging per `sqlite3` e FTS5?
-- Il processo API sarà l'unico writer SQLite o devono essere coordinati anche CLI/processi separati?
-- Quale strategia di rilevamento cambiamenti del vault (refresh esplicito, watcher o scan all'avvio) soddisfa l'uso reale? Questa scelta non cambia l'autorità del vault.
-- Quale UX deve accompagnare una migrazione d'identità dovuta a rename o move, dato che l'ID canonico cambia e i riferimenti esterni possono diventare invalidi?
-- Quale policy concreta deve applicare API/CLI quando la generazione della proiezione non coincide con il fingerprint del vault: sync obbligatorio, errore esplicito o modalità degradata segnalata?
-- In futuro servono alias o una chiave esterna immutabile per riferimenti durevoli? La convenzione canonica attuale resta `id = path relativo senza .md` e questa ADR non ne definisce lo schema.
+Reconsider this ADR if at least one condition becomes true:
 
-## Riferimenti
+- LeLe Manager becomes multi-user or needs distributed or remote writers;
+- Markdown can no longer represent approved content or provenance without loss;
+- measured volume and query workloads make indexed SQLite inadequate;
+- columnar scans or Parquet become the dominant workload, making DuckDB a
+  primary candidate;
+- relevant packaging targets cannot provide `sqlite3` reliably and bundling it
+  is unacceptable;
+- filesystem/database synchronization remains operationally unreliable despite
+  generations, atomic rebuilds, and stale-state detection;
+- heterogeneous document requirements cannot be met by SQLite schema plus JSON
+  extension fields.
 
-### Repository e pianificazione
+## Risks and open questions
+
+- Which real records exist only in JSONL, and how are they promoted to the
+  vault without losing `created_at` or other fields?
+- Is deletion represented by a Git-versioned physical removal or an explicit
+  tombstone?
+- Which #94 provenance fields become queryable columns, and which remain
+  frontmatter extensions?
+- Which Python builds and operating systems belong to the `sqlite3` and FTS5
+  packaging matrix?
+- Is the API process the only SQLite writer, or must separate CLI processes be
+  coordinated?
+- Which vault change-detection strategy fits real usage: explicit refresh,
+  watcher, or startup scan?
+- What user experience accompanies an identity migration caused by rename or
+  move?
+- What concrete policy applies when projection generation differs from the
+  vault fingerprint: mandatory sync, explicit error, or signaled degraded
+  mode?
+- Will aliases or an immutable external key eventually be needed for durable
+  references? The current convention remains `id = relative path without .md`;
+  this ADR does not define an alias schema.
+
+## References
+
+### Repository and planning
 
 - [Issue #82 — Epic: TritaLeLe Knowledge Ingestion Pipeline](https://github.com/gcomneno/lele-manager/issues/82)
 - [Issue #91 — Compare storage backends](https://github.com/gcomneno/lele-manager/issues/91)
 - [Issue #92 — Introduce storage abstraction layer](https://github.com/gcomneno/lele-manager/issues/92)
 - [Issue #93 — Expose lessons for external quiz and review tools](https://github.com/gcomneno/lele-manager/issues/93)
 - [Issue #94 — Add raw knowledge ingestion workflow (TritaLeLe)](https://github.com/gcomneno/lele-manager/issues/94)
-- `README.md`, sezioni “LeLe Vault”, “ML classico”, “API” e “GUI”
-- `ROADMAP.md`, sezioni sul flusso vault/JSONL/ML/API e sullo stato attuale
+- `README.md`, sections about LeLe Vault, ML, API, and GUI
+- `ROADMAP.md`, sections about the vault/JSONL/ML/API flow and current state
 - `src/lele_manager/cli/import_from_dir.py::{LeLeRecord,import_from_dir}`
 - `src/lele_manager/core/vault.py::{write_lesson_markdown,import_vault_to_jsonl,upsert_jsonl_lesson}`
 - `src/lele_manager/core/storage.py::{append_lesson,load_lessons,iter_lessons}`
@@ -324,7 +592,7 @@ La decisione va riesaminata se si verifica almeno una di queste condizioni:
 - `scripts/{lele-api-refresh.sh,e2e-prepare.py}`
 - `tests/{test_lessons_storage.py,test_add_lesson_cli.py,test_api_vault.py,test_import_from_dir.py,test_api_basic.py,test_search_api.py,test_train_topic_model_cli.py,test_similarity_service_equivalence.py}`
 
-### Documentazione tecnica ufficiale
+### Official technical documentation
 
 - [Python `sqlite3` — DB-API 2.0 interface for SQLite databases](https://docs.python.org/3/library/sqlite3.html)
 - [SQLite — FTS5 Extension](https://www.sqlite.org/fts5.html)

--- a/docs/documentation-policy.md
+++ b/docs/documentation-policy.md
@@ -1,0 +1,103 @@
+# Documentation language policy
+
+[English](documentation-policy.md) | [Italiano](it/documentation-policy.md)
+
+## Canonical language
+
+English is the canonical and default language for maintained public documentation.
+Italian is an officially maintained translation for the document families listed
+as bilingual below.
+
+When English and Italian wording diverge, the English document is the source of
+truth. A translation must preserve requirements, examples, warnings, limitations,
+and technical meaning; it must not be a shortened summary.
+
+Commands, CLI options, HTTP endpoints, Python symbols, environment variables,
+paths, filenames, and code snippets are never translated.
+
+## Naming and navigation
+
+- Root documents use `.it.md` for their Italian mirror:
+  `README.md` / `README.it.md`, `ROADMAP.md` / `ROADMAP.it.md`, and
+  `CONTRIBUTING.md` / `CONTRIBUTING.it.md`.
+- Canonical documents under `docs/` are English.
+- Maintained Italian translations under `docs/it/` preserve the same filename
+  and relative directory structure.
+- Every maintained pair starts with visible reciprocal `English` and `Italiano`
+  links.
+- Internal links should stay in the reader's language when a mirror exists.
+  Otherwise they may point to the English canonical source.
+
+## Inventory and coverage
+
+| Path or document family | Language before #135 | Policy after #135 | Rationale |
+|---|---|---|---|
+| `README.md` | Predominantly Italian | Bilingual and maintained; English canonical | Primary user onboarding and product reference |
+| `README.it.md` | Not present | Bilingual and maintained; Italian mirror | Official Italian entry point |
+| `ROADMAP.md` | Predominantly Italian | Bilingual and maintained; English canonical | Public project direction and status |
+| `ROADMAP.it.md` | Not present | Bilingual and maintained; Italian mirror | Official Italian roadmap |
+| `CONTRIBUTING.md` | Predominantly Italian | Bilingual and maintained; English canonical | Public contributor workflow |
+| `CONTRIBUTING.it.md` | Not present | Bilingual and maintained; Italian mirror | Official Italian contributor guide |
+| `CHANGELOG.md` | Mixed Italian and English | English-only technical/release source | Historical entries remain unchanged; new entries use English |
+| `RELEASE_NOTES.md` | English | Historical/archive document, English-only | Existing historical release notes are not maintained as a bilingual manual |
+| `frontend/README.md` | English | Generated artifact | Upstream Vite/Svelte scaffold content; replace separately if project-specific guidance is needed |
+| `.github/pull_request_template.md` | Predominantly Italian | English-only contributor metadata | Repository-wide default workflow; includes bilingual-doc synchronization checks |
+| `docs/documentation-policy.md` | Not present | Bilingual and maintained; English canonical | Defines the repository language contract |
+| `docs/it/documentation-policy.md` | Not present | Bilingual and maintained; Italian mirror | Official Italian policy |
+| `docs/projection-store.md` | English | Bilingual and maintained; English canonical | Current contributor-facing storage contract |
+| `docs/it/projection-store.md` | Not present | Bilingual and maintained; Italian mirror | Official Italian storage-contract translation |
+| `docs/adr/0001-storage-backend.md` | Predominantly Italian | English-only technical source | ADRs are canonical technical records maintained in English |
+| `docs/gui-design.md` | Predominantly Italian | Historical/archive document | Completed GUI design record; retained in its original language |
+| `docs/phase-4-issue.md` | Predominantly Italian | Historical/archive document | Completed local tracking document; no ongoing translation obligation |
+
+Contributor-facing issue forms are not Markdown, but their language also affects
+the repository experience:
+
+| Path | Policy after #135 |
+|---|---|
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | English-only contributor metadata |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | English-only contributor metadata |
+
+Every exclusion is deliberate: generated scaffolds, historical records, and
+English-only technical sources do not create an Italian synchronization
+obligation.
+
+## Synchronization workflow
+
+A pull request that changes a bilingual canonical document must:
+
+1. evaluate whether the Italian mirror requires the same change;
+2. update both files in the same pull request when technical meaning changes;
+3. preserve reciprocal language links;
+4. keep technical tokens and snippets unchanged;
+5. run the documentation checks.
+
+Run the focused checks with:
+
+```bash
+pytest tests/test_documentation.py
+```
+
+The checks verify required pairs, reciprocal language selectors, same-language
+root navigation, and relative links in maintained bilingual documents. They do
+not attempt machine translation or automatic semantic comparison; semantic
+parity remains a reviewer responsibility.
+
+## ADR policy
+
+Architecture Decision Records are English-only canonical technical records.
+Existing ADR content is migrated to English without changing the recorded
+decision. New ADRs should be written in English and do not require Italian
+mirrors unless this policy is changed explicitly.
+
+## Changelog policy
+
+`CHANGELOG.md` is the canonical English release history. Existing mixed-language
+historical entries are retained to avoid rewriting release history. New entries
+must use English.
+
+## Non-goals
+
+This policy does not introduce GUI internationalization, CLI or API
+localization, runtime language selection, automatic translation, a
+documentation-site generator, or a translation-management platform.

--- a/docs/it/documentation-policy.md
+++ b/docs/it/documentation-policy.md
@@ -1,0 +1,103 @@
+# Politica linguistica della documentazione
+
+[English](../documentation-policy.md) | [Italiano](documentation-policy.md)
+
+## Lingua canonica
+
+L'inglese è la lingua canonica e predefinita della documentazione pubblica
+mantenuta. L'italiano è una traduzione ufficialmente mantenuta per le famiglie
+di documenti indicate come bilingui più avanti.
+
+Quando il testo inglese e quello italiano divergono, il documento inglese è la
+fonte autorevole. Una traduzione deve preservare requisiti, esempi, avvertenze,
+limitazioni e significato tecnico; non deve diventare un riassunto abbreviato.
+
+Comandi, opzioni CLI, endpoint HTTP, simboli Python, variabili d'ambiente,
+percorsi, nomi di file e snippet di codice non vengono mai tradotti.
+
+## Nomi e navigazione
+
+- I documenti nella root usano `.it.md` per il mirror italiano:
+  `README.md` / `README.it.md`, `ROADMAP.md` / `ROADMAP.it.md` e
+  `CONTRIBUTING.md` / `CONTRIBUTING.it.md`.
+- I documenti canonici sotto `docs/` sono in inglese.
+- Le traduzioni italiane mantenute sotto `docs/it/` preservano lo stesso nome
+  di file e la stessa struttura relativa.
+- Ogni coppia mantenuta inizia con collegamenti reciproci visibili
+  `English` e `Italiano`.
+- I link interni devono restare nella lingua del lettore quando esiste un
+  mirror. In caso contrario possono puntare alla fonte canonica inglese.
+
+## Inventario e copertura
+
+| Percorso o famiglia documentale | Lingua prima della #135 | Politica dopo la #135 | Motivazione |
+|---|---|---|---|
+| `README.md` | Prevalentemente italiano | Bilingue e mantenuto; inglese canonico | Introduzione utente e riferimento principale del prodotto |
+| `README.it.md` | Assente | Bilingue e mantenuto; mirror italiano | Punto di ingresso italiano ufficiale |
+| `ROADMAP.md` | Prevalentemente italiano | Bilingue e mantenuto; inglese canonico | Direzione e stato pubblico del progetto |
+| `ROADMAP.it.md` | Assente | Bilingue e mantenuto; mirror italiano | Roadmap italiana ufficiale |
+| `CONTRIBUTING.md` | Prevalentemente italiano | Bilingue e mantenuto; inglese canonico | Flusso pubblico per i contributor |
+| `CONTRIBUTING.it.md` | Assente | Bilingue e mantenuto; mirror italiano | Guida italiana ufficiale per i contributor |
+| `CHANGELOG.md` | Italiano e inglese mescolati | Fonte tecnica/release solo inglese | Le voci storiche restano invariate; le nuove voci usano l'inglese |
+| `RELEASE_NOTES.md` | Inglese | Documento storico/archivio solo inglese | Le note storiche non sono mantenute come manuale bilingue |
+| `frontend/README.md` | Inglese | Artefatto generato | Contenuto scaffold Vite/Svelte upstream; l'eventuale guida specifica richiede un lavoro separato |
+| `.github/pull_request_template.md` | Prevalentemente italiano | Metadato contributor solo inglese | Flusso predefinito del repository con controlli per la sincronizzazione bilingue |
+| `docs/documentation-policy.md` | Assente | Bilingue e mantenuto; inglese canonico | Definisce il contratto linguistico del repository |
+| `docs/it/documentation-policy.md` | Assente | Bilingue e mantenuto; mirror italiano | Politica italiana ufficiale |
+| `docs/projection-store.md` | Inglese | Bilingue e mantenuto; inglese canonico | Contratto storage corrente per i contributor |
+| `docs/it/projection-store.md` | Assente | Bilingue e mantenuto; mirror italiano | Traduzione italiana ufficiale del contratto storage |
+| `docs/adr/0001-storage-backend.md` | Prevalentemente italiano | Fonte tecnica solo inglese | Gli ADR sono record tecnici canonici mantenuti in inglese |
+| `docs/gui-design.md` | Prevalentemente italiano | Documento storico/archivio | Record di design GUI completato, conservato nella lingua originale |
+| `docs/phase-4-issue.md` | Prevalentemente italiano | Documento storico/archivio | Documento locale di tracking completato, senza obbligo di traduzione |
+
+Anche gli issue form rivolti ai contributor, pur non essendo Markdown,
+influenzano l'esperienza linguistica del repository:
+
+| Percorso | Politica dopo la #135 |
+|---|---|
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | Metadato contributor solo inglese |
+| `.github/ISSUE_TEMPLATE/feature_request.yml` | Metadato contributor solo inglese |
+
+Ogni esclusione è deliberata: scaffold generati, record storici e fonti
+tecniche solo inglese non creano un obbligo di sincronizzazione italiana.
+
+## Flusso di sincronizzazione
+
+Una pull request che modifica un documento canonico bilingue deve:
+
+1. valutare se il mirror italiano richiede la stessa modifica;
+2. aggiornare entrambi i file nella stessa pull request quando cambia il
+   significato tecnico;
+3. preservare i collegamenti reciproci per la selezione della lingua;
+4. mantenere invariati token tecnici e snippet;
+5. eseguire i controlli documentali.
+
+Eseguire i controlli mirati con:
+
+```bash
+pytest tests/test_documentation.py
+```
+
+I controlli verificano le coppie obbligatorie, i selettori linguistici
+reciproci, la navigazione root nella stessa lingua e i link relativi nei
+documenti bilingui mantenuti. Non tentano traduzioni automatiche né confronti
+semantici automatici; la parità semantica resta responsabilità della review.
+
+## Politica ADR
+
+Gli Architecture Decision Record sono record tecnici canonici solo inglese.
+Il contenuto dell'ADR esistente viene migrato in inglese senza cambiare la
+decisione registrata. I nuovi ADR devono essere scritti in inglese e non
+richiedono mirror italiani, salvo modifica esplicita di questa politica.
+
+## Politica changelog
+
+`CHANGELOG.md` è la cronologia release canonica in inglese. Le voci storiche
+che mescolano le lingue vengono conservate per non riscrivere la storia delle
+release. Le nuove voci devono usare l'inglese.
+
+## Non obiettivi
+
+Questa politica non introduce internazionalizzazione della GUI, localizzazione
+di CLI o API, selezione dinamica della lingua, traduzione automatica, un
+generatore di sito documentale o una piattaforma di gestione traduzioni.

--- a/docs/it/projection-store.md
+++ b/docs/it/projection-store.md
@@ -1,0 +1,62 @@
+# Projection store
+
+[English](../projection-store.md) | [Italiano](projection-store.md)
+
+LeLe Manager accede al dataset interrogabile delle lesson tramite il port
+tipizzato in `lele_manager.core.projection_store`. Il confine è
+intenzionalmente piccolo e indipendente dal backend:
+
+- apre uno snapshot coerente e immutabile;
+- recupera una lesson tramite il suo ID canonico, inclusi gli ID contenenti `/`;
+- elenca e cerca con filtri portabili, ordinamento deterministico e limiti;
+- ottiene conteggi essenziali e una generazione deterministica del contenuto
+  dallo stesso snapshot;
+- valida e pubblica atomicamente uno snapshot sostitutivo completo.
+
+I record delle lesson conservano i campi non conosciuti dall'applicazione
+corrente. Il port non espone JSONL, percorsi filesystem, oggetti Pandas, SQL o
+transazioni specifiche del backend. La conversione Pandas per ML e analytics
+resta un confine applicativo, non parte del contratto storage.
+
+## Backend di compatibilità corrente
+
+La composizione del backend avviene in
+`lele_manager.composition.projection_store`. I reader di produzione e i
+publisher di snapshot completi richiedono lì il `ProjectionStore` neutrale;
+JSONL resta l'adapter di compatibilità predefinito.
+
+`JsonlProjectionStore` è l'adapter predefinito durante la migrazione descritta
+da [ADR 0001](../adr/0001-storage-backend.md). Legge i file JSONL UTF-8
+esistenti e pubblica JSONL canonico ordinato per ID della lesson. Le chiavi
+degli oggetti sono ordinate e Unicode viene emesso direttamente. La
+pubblicazione produce byte stabili per contenuti equivalenti. In lettura,
+`LessonOrder.SNAPSHOT` espone l'ordine fisico dei record, quindi la generazione
+SHA-256 include quell'ordine: un diverso ordine osservabile dello snapshot
+produce una diversa generazione. Le righe vuote sono accettate per
+compatibilità.
+
+Una lettura valida l'intero file. JSON malformato, record che non sono oggetti,
+ID mancanti o vuoti, UTF-8 non valido e ID duplicati sono errori espliciti; non
+vengono ignorati silenziosamente. Ogni snapshot costruisce l'indice per ID e le
+statistiche essenziali nello stesso passaggio di validazione.
+
+La pubblicazione dell'intero snapshot valida tutto prima di toccare il file
+corrente, scrive ed esegue `fsync` su un file temporaneo nella directory di
+destinazione, quindi usa una sostituzione atomica. Un errore prima della
+sostituzione lascia leggibile lo snapshot precedente e rimuove il file
+temporaneo.
+
+La CLI storica `add_lesson` e l'endpoint `POST /lessons` continuano ad
+aggiungere record JSONL perché la rimozione di quel comportamento è fuori dallo
+scope della issue #92. Questo comportamento è esposto soltanto tramite
+`JsonlLegacyAppendFacade`, dal nome esplicito, e non tramite il port di
+proiezione comune. Prima della scrittura valida l'intero snapshot esistente e
+rifiuta gli ID duplicati.
+
+Si assume che i writer siano serializzati dall'applicazione locale. Non esiste
+una transazione o un locking cross-process: publisher simultanei dell'intero
+snapshot seguono la regola last-writer-wins, mentre writer simultanei del
+legacy append non sono supportati. I rebuild del vault e gli import da
+directory usano la pubblicazione atomica dell'intero snapshot. Non è avvenuto
+alcun cutover SQLite: SQLite resta un adapter futuro e qui non è né
+implementato né selezionato come predefinito.

--- a/docs/projection-store.md
+++ b/docs/projection-store.md
@@ -1,5 +1,7 @@
 # Projection store
 
+[English](projection-store.md) | [Italiano](it/projection-store.md)
+
 LeLe Manager accesses its queryable lesson dataset through the typed port in
 `lele_manager.core.projection_store`. The boundary is intentionally small and
 backend-neutral:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "pandas",
     "scikit-learn",
     "httpx",
-    "ruff",
+    "ruff==0.15.22",
     "pre-commit",
     "bandit",
     "pip-audit",

--- a/src/lele_manager/ml/features.py
+++ b/src/lele_manager/ml/features.py
@@ -102,7 +102,7 @@ class LessonFeatureExtractor(BaseEstimator, TransformerMixin):
         lengths = texts.str.len().to_numpy(dtype=float)[:, None]
 
         # Numero di parole (split su whitespace)
-        word_counts = texts.str.split().str.len().to_numpy(dtype=float)[:, None]
+        word_counts = texts.map(lambda text: len(text.split())).to_numpy(dtype=float)[:, None]
 
         # Importance se presente, altrimenti zero
         if "importance" in X.columns:

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -18,7 +18,7 @@ DOCUMENT_PAIRS = (
     (Path("docs/projection-store.md"), Path("docs/it/projection-store.md")),
 )
 
-MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+MARKDOWN_LINK = re.compile(r"(?<!!)\[[^]]+]\(([^)]+)\)")
 
 
 def _read(path: Path) -> str:
@@ -56,8 +56,10 @@ def test_language_selectors_are_reciprocal() -> None:
         english_head = "\n".join(_read(english).splitlines()[:8])
         italian_head = "\n".join(_read(italian).splitlines()[:8])
 
-        assert "English" in english_head and "Italiano" in english_head, english
-        assert "English" in italian_head and "Italiano" in italian_head, italian
+        assert "English" in english_head, english
+        assert "Italiano" in english_head, english
+        assert "English" in italian_head, italian
+        assert "Italiano" in italian_head, italian
         assert _relative_link(english, italian) in english_head, english
         assert _relative_link(italian, english) in italian_head, italian
 
@@ -67,7 +69,10 @@ def test_relative_links_in_bilingual_documents_exist() -> None:
     for pair in DOCUMENT_PAIRS:
         for path in pair:
             for target in _relative_targets(path):
-                assert target == repository_root or repository_root in target.parents
+                is_in_repository = (
+                    target == repository_root or repository_root in target.parents
+                )
+                assert is_in_repository, f"{path}: target escapes repository: {target}"
                 assert target.exists(), f"{path}: missing relative target {target}"
 
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 import re
+from pathlib import Path
 from urllib.parse import unquote
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+from urllib.parse import unquote
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DOCUMENT_PAIRS = (
+    (Path("README.md"), Path("README.it.md")),
+    (Path("ROADMAP.md"), Path("ROADMAP.it.md")),
+    (Path("CONTRIBUTING.md"), Path("CONTRIBUTING.it.md")),
+    (
+        Path("docs/documentation-policy.md"),
+        Path("docs/it/documentation-policy.md"),
+    ),
+    (Path("docs/projection-store.md"), Path("docs/it/projection-store.md")),
+)
+
+MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+
+
+def _read(path: Path) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _relative_link(from_path: Path, to_path: Path) -> str:
+    return Path(os.path.relpath(to_path, start=from_path.parent)).as_posix()
+
+
+def _relative_targets(path: Path) -> list[Path]:
+    targets: list[Path] = []
+    for raw_target in MARKDOWN_LINK.findall(_read(path)):
+        target = raw_target.strip().split(maxsplit=1)[0].strip("<>")
+        if (
+            not target
+            or target.startswith(("#", "http://", "https://", "mailto:"))
+        ):
+            continue
+        target = unquote(target.split("#", 1)[0])
+        if not target:
+            continue
+        targets.append((ROOT / path.parent / target).resolve())
+    return targets
+
+
+def test_required_bilingual_pairs_exist() -> None:
+    for english, italian in DOCUMENT_PAIRS:
+        assert (ROOT / english).is_file(), english
+        assert (ROOT / italian).is_file(), italian
+
+
+def test_language_selectors_are_reciprocal() -> None:
+    for english, italian in DOCUMENT_PAIRS:
+        english_head = "\n".join(_read(english).splitlines()[:8])
+        italian_head = "\n".join(_read(italian).splitlines()[:8])
+
+        assert "English" in english_head and "Italiano" in english_head, english
+        assert "English" in italian_head and "Italiano" in italian_head, italian
+        assert _relative_link(english, italian) in english_head, english
+        assert _relative_link(italian, english) in italian_head, italian
+
+
+def test_relative_links_in_bilingual_documents_exist() -> None:
+    repository_root = ROOT.resolve()
+    for pair in DOCUMENT_PAIRS:
+        for path in pair:
+            for target in _relative_targets(path):
+                assert target == repository_root or repository_root in target.parents
+                assert target.exists(), f"{path}: missing relative target {target}"
+
+
+def test_root_navigation_stays_in_the_same_language() -> None:
+    english_readme = _read(Path("README.md"))
+    italian_readme = _read(Path("README.it.md"))
+
+    assert "(ROADMAP.md)" in english_readme
+    assert "(CONTRIBUTING.md)" in english_readme
+    assert "(ROADMAP.it.md)" in italian_readme
+    assert "(CONTRIBUTING.it.md)" in italian_readme


### PR DESCRIPTION
## Summary

Establishes the documentation policy defined by #135:

- makes English the canonical and default language for maintained public documentation;
- adds officially maintained Italian mirrors for the primary user and contributor documents;
- introduces predictable root `.it.md` mirrors and a mirrored `docs/it/` structure;
- documents translation coverage, exclusions, synchronization rules, ADR policy, and changelog policy;
- normalizes contributor-facing GitHub templates to English;
- adds lightweight automated checks for required pairs, reciprocal language selectors, same-language navigation, and relative Markdown links.

Closes #135.

## Main changes

- Replaces the predominantly Italian `README.md`, `ROADMAP.md`, and `CONTRIBUTING.md` with canonical English versions.
- Adds `README.it.md`, `ROADMAP.it.md`, and `CONTRIBUTING.it.md` as maintained Italian mirrors.
- Adds canonical `docs/documentation-policy.md` and its Italian mirror under `docs/it/`.
- Adds an Italian mirror for the current projection-store contract while preserving English as canonical.
- Migrates `docs/adr/0001-storage-backend.md` to English without changing its architectural decision, consequences, migration plan, or references.
- Updates the pull request template with bilingual-documentation synchronization checks.
- Normalizes the bug-report and feature-request issue forms to English.
- Adds `tests/test_documentation.py`.

## Coverage decisions

The documentation policy explicitly classifies the current inventory:

- **Bilingual and maintained:** README, roadmap, contributor guide, documentation policy, and projection-store contract.
- **English-only technical source:** ADRs and future changelog entries.
- **Generated artifact:** `frontend/README.md`, which remains the upstream Vite/Svelte scaffold.
- **Historical/archive:** `docs/gui-design.md`, `docs/phase-4-issue.md`, and `RELEASE_NOTES.md` according to their current roles.
- Existing mixed-language changelog history is retained; new entries must use English.

## Validation

- `pytest tests/test_documentation.py` — 4 passed.
- Both modified GitHub issue-form YAML documents parse successfully.
- The branch is based on the current `main` commit and changes documentation, contributor metadata, and documentation tests only.
- Full repository CI is expected to run on this pull request.

## Non-goals

This pull request does not add GUI internationalization, CLI or API localization, runtime language selection, automatic translation, a documentation-site framework, or functional changes to backend, frontend, storage, API, or ML behavior.