### PR TITLE
feat(gui): integrate vault doctor

### DIFF
--- a/frontend/e2e/vault-doctor.spec.ts
+++ b/frontend/e2e/vault-doctor.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url))
+const fixtureRoot = join(repositoryRoot, '.e2e-fixture')
+const vaultDir = join(fixtureRoot, 'vault')
+const externalMarkdown = join(fixtureRoot, 'outside-vault.md')
+
+const healthyLesson = `---
+id: python/2025-01-01.e2e
+topic: python
+source: note
+importance: 3
+tags:
+  - python
+date: '2025-01-01'
+title: E2E fixture
+---
+Healthy E2E vault lesson.
+`
+
+async function resetVaultFixture() {
+  await rm(vaultDir, { recursive: true, force: true })
+  await mkdir(join(vaultDir, 'python'), { recursive: true })
+  await writeFile(join(vaultDir, 'python', '2025-01-01.e2e.md'), healthyLesson)
+  await rm(externalMarkdown, { force: true })
+}
+
+async function openDoctor(page: import('@playwright/test').Page) {
+  await page.goto('/app/#/ops')
+  await expect(page.getByRole('heading', { name: 'Vault Doctor' })).toBeVisible()
+  await page.getByRole('button', { name: 'Run Doctor' }).click()
+}
+
+test.describe('ops: vault doctor', () => {
+  test.afterEach(async () => {
+    await resetVaultFixture()
+  })
+
+  test('shows a healthy isolated vault report', async ({ page }) => {
+    await resetVaultFixture()
+
+    await openDoctor(page)
+
+    await expect(page.getByText('Vault healthy')).toBeVisible()
+    await expect(page.locator('.doctor .error')).toHaveCount(0)
+    await expect(page.locator('.doctor').getByText('1 file controllati')).toBeVisible()
+  })
+
+  test('groups malformed-frontmatter findings by diagnostic code', async ({ page }) => {
+    await resetVaultFixture()
+    await writeFile(join(vaultDir, 'python', 'a-malformed.md'), 'No frontmatter\n')
+    await writeFile(join(vaultDir, 'python', 'b-malformed.md'), 'No frontmatter\n')
+
+    await openDoctor(page)
+
+    await expect(page.getByText('Vault not healthy')).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: 'missing_frontmatter (2 findings)' }),
+    ).toBeVisible()
+    await expect(page.getByText('python/a-malformed.md')).toBeVisible()
+    await expect(page.getByText('python/b-malformed.md')).toBeVisible()
+    await expect(page.getByText('frontmatter YAML assente')).toHaveCount(2)
+    await expect(page.getByText('error', { exact: true })).toHaveCount(2)
+  })
+
+  test('surfaces an external symlink as an operational API error', async ({ page }) => {
+    await resetVaultFixture()
+    await writeFile(externalMarkdown, 'outside the vault\n')
+    try {
+      await symlink(externalMarkdown, join(vaultDir, 'python', 'escaping.md'))
+    } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error.code === 'EPERM' || error.code === 'EACCES' || error.code === 'ENOSYS')
+      ) {
+        test.skip(true, 'The platform cannot create symlinks')
+        return
+      }
+      throw error
+    }
+
+    await openDoctor(page)
+
+    await expect(
+      page.locator('.doctor').getByText('file Markdown fuori dalla radice del vault'),
+    ).toBeVisible()
+    await expect(page.getByText('Vault healthy')).toHaveCount(0)
+    await expect(page.getByText('Vault not healthy')).toHaveCount(0)
+  })
+
+  test('clears a successful report before a later operational error', async ({ page }) => {
+    await resetVaultFixture()
+
+    await openDoctor(page)
+    await expect(page.getByText('Vault healthy')).toBeVisible()
+
+    await page.route('**/vault/doctor', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'vault inspection failed for E2E' }),
+      })
+    })
+    await page.getByRole('button', { name: 'Run Doctor' }).click()
+
+    await expect(page.locator('.doctor').getByText('vault inspection failed for E2E')).toBeVisible()
+    await expect(page.getByText('Vault healthy')).toHaveCount(0)
+    await expect(page.getByText('Vault not healthy')).toHaveCount(0)
+    await expect(page.locator('.doctor').getByText('1 file controllati')).toHaveCount(0)
+  })
+})

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const e2ePort = process.env.E2E_PORT ?? '8765'
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -9,7 +11,7 @@ export default defineConfig({
   reporter: 'list',
   timeout: 60_000,
   use: {
-    baseURL: 'http://127.0.0.1:8765',
+    baseURL: `http://127.0.0.1:${e2ePort}`,
     trace: 'on-first-retry',
   },
   projects: [
@@ -20,7 +22,7 @@ export default defineConfig({
   ],
   webServer: {
     command: 'bash ../scripts/e2e-serve.sh',
-    url: 'http://127.0.0.1:8765/health',
+    url: `http://127.0.0.1:${e2ePort}/health`,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -90,6 +90,23 @@ export interface VaultImportResponse {
   topics: string[]
 }
 
+export interface VaultDoctorProblem {
+  code: string
+  message: string
+  path: string
+  field?: string | null
+  severity: 'error'
+}
+
+export interface VaultDoctorReportResponse {
+  valid: boolean
+  files_checked: number
+  checked_files: string[]
+  unique_ids: number
+  error_count: number
+  problems: VaultDoctorProblem[]
+}
+
 export interface LessonVaultWrite {
   text: string
   topic: string
@@ -223,6 +240,8 @@ export const api = {
   vaultStatus: () => request<VaultStatusResponse>('/vault/status'),
 
   vaultTree: () => request<VaultTreeResponse>('/vault/tree'),
+
+  vaultDoctor: () => request<VaultDoctorReportResponse>('/vault/doctor'),
 
   vaultImport: () =>
     request<VaultImportResponse>('/vault/import', { method: 'POST' }),

--- a/frontend/src/routes/Ops.svelte
+++ b/frontend/src/routes/Ops.svelte
@@ -1,18 +1,42 @@
 <script lang="ts">
-  import { api, type HealthResponse, type TrainResponse } from '../lib/api'
+  import {
+    api,
+    type HealthResponse,
+    type TrainResponse,
+    type VaultDoctorProblem,
+    type VaultDoctorReportResponse,
+  } from '../lib/api'
 
   let health = $state<HealthResponse | null>(null)
   let trainResult = $state<TrainResponse | null>(null)
+  let doctorReport = $state<VaultDoctorReportResponse | null>(null)
   let loadingHealth = $state(false)
   let training = $state(false)
   let importing = $state(false)
   let refreshing = $state(false)
+  let runningDoctor = $state(false)
   let error = $state('')
+  let doctorError = $state('')
   let log = $state<string[]>([])
 
   function pushLog(line: string) {
     const ts = new Date().toLocaleTimeString()
     log = [`[${ts}] ${line}`, ...log].slice(0, 20)
+  }
+
+  function groupDoctorProblems(problems: VaultDoctorProblem[]) {
+    const problemsByCode = new Map<string, VaultDoctorProblem[]>()
+    for (const problem of problems) {
+      const group = problemsByCode.get(problem.code)
+      if (group) {
+        group.push(problem)
+      } else {
+        problemsByCode.set(problem.code, [problem])
+      }
+    }
+    return [...problemsByCode.entries()]
+      .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+      .map(([code, groupedProblems]) => ({ code, problems: groupedProblems }))
   }
 
   async function refreshHealth() {
@@ -85,6 +109,26 @@
     }
   }
 
+  async function runDoctor() {
+    runningDoctor = true
+    doctorError = ''
+    doctorReport = null
+    pushLog('vault doctor avviato…')
+    try {
+      doctorReport = await api.vaultDoctor()
+      pushLog(
+        doctorReport.valid
+          ? `vault doctor ok — ${doctorReport.files_checked} file controllati`
+          : `vault doctor: ${doctorReport.error_count} errori trovati`,
+      )
+    } catch (e) {
+      doctorError = e instanceof Error ? e.message : String(e)
+      pushLog(`vault doctor errore: ${doctorError}`)
+    } finally {
+      runningDoctor = false
+    }
+  }
+
   refreshHealth()
 </script>
 
@@ -127,6 +171,54 @@
     {/if}
   </section>
 
+  <section class="card doctor" aria-live="polite">
+    <h3>Vault Doctor</h3>
+    <p class="meta">Controllo in sola lettura della struttura e dei metadati del vault.</p>
+    <div class="actions">
+      <button class="btn" onclick={runDoctor} disabled={runningDoctor}>
+        {runningDoctor ? 'Running Doctor…' : 'Run Doctor'}
+      </button>
+    </div>
+
+    {#if doctorError}
+      <p class="error">{doctorError}</p>
+    {/if}
+
+    {#if doctorReport}
+      <p class={doctorReport.valid ? 'ok' : 'error'}>
+        {doctorReport.valid ? 'Vault healthy' : 'Vault not healthy'}
+      </p>
+      <p class="meta">
+        {doctorReport.files_checked} file controllati · {doctorReport.unique_ids} ID univoci ·
+        {doctorReport.error_count} errori
+      </p>
+
+      {#if doctorReport.problems.length > 0}
+        <div class="doctor-diagnostic-groups">
+          {#each groupDoctorProblems(doctorReport.problems) as group}
+            <section class="doctor-diagnostic-group">
+              <h4>{group.code} ({group.problems.length} {group.problems.length === 1 ? 'finding' : 'findings'})</h4>
+              <ul class="doctor-diagnostics">
+                {#each group.problems as problem}
+                  <li>
+                    <div class="diagnostic-details">
+                      <code>{problem.path}</code>
+                      {#if problem.field}
+                        <span class="diagnostic-field">field: {problem.field}</span>
+                      {/if}
+                      <span class="tag severity-error">{problem.severity}</span>
+                    </div>
+                    <p>{problem.message}</p>
+                  </li>
+                {/each}
+              </ul>
+            </section>
+          {/each}
+        </div>
+      {/if}
+    {/if}
+  </section>
+
   <section class="card">
     <h3>Log operazioni</h3>
     {#if log.length === 0}
@@ -144,7 +236,7 @@
     max-width: 900px;
   }
 
-  h2, h3 {
+  h2, h3, h4 {
     margin: 0 0 8px;
   }
 
@@ -179,5 +271,56 @@
     font-size: 0.82rem;
     overflow-x: auto;
     white-space: pre-wrap;
+  }
+
+  .doctor-diagnostics {
+    list-style: none;
+    padding: 0;
+    margin: 12px 0 0;
+    display: grid;
+    gap: 8px;
+  }
+
+  .doctor-diagnostic-groups {
+    display: grid;
+    gap: 12px;
+    margin-top: 12px;
+  }
+
+  .doctor-diagnostic-group h4 {
+    margin-bottom: 6px;
+    font-size: 0.9rem;
+  }
+
+  .doctor-diagnostics li {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 10px;
+  }
+
+  .doctor-diagnostics code {
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+
+  .diagnostic-details {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .diagnostic-field {
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+
+  .doctor-diagnostics p {
+    margin: 6px 0 0;
+  }
+
+  .severity-error {
+    background: #fbe5e3;
+    color: var(--err);
   }
 </style>

--- a/scripts/e2e-prepare.py
+++ b/scripts/e2e-prepare.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Prepare JSONL + topic model for Playwright E2E smoke tests."""
+"""Prepare isolated data, model, and vault fixtures for Playwright E2E tests."""
 
 from __future__ import annotations
 
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -13,6 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_DIR = ROOT / ".e2e-fixture"
 DATA_PATH = FIXTURE_DIR / "lessons.jsonl"
 MODEL_PATH = FIXTURE_DIR / "topic_model.joblib"
+VAULT_DIR = FIXTURE_DIR / "vault"
 
 RECORDS = [
     {
@@ -51,12 +53,35 @@ RECORDS = [
 ]
 
 
+def prepare_vault() -> None:
+    """Reset only the dedicated E2E vault to a known healthy state."""
+    shutil.rmtree(VAULT_DIR, ignore_errors=True)
+    topic_dir = VAULT_DIR / "python"
+    topic_dir.mkdir(parents=True)
+    (topic_dir / "2025-01-01.e2e.md").write_text(
+        """---
+id: python/2025-01-01.e2e
+topic: python
+source: note
+importance: 3
+tags:
+  - python
+date: '2025-01-01'
+title: E2E fixture
+---
+Healthy E2E vault lesson.
+""",
+        encoding="utf-8",
+    )
+
+
 def main() -> int:
     sys.path.insert(0, str(ROOT / "src"))
     from lele_manager.ml.features import TextFeatureConfig
     from lele_manager.ml.topic_model import TopicModelConfig, save_topic_model, train_topic_model
 
     FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    prepare_vault()
     with DATA_PATH.open("w", encoding="utf-8") as f:
         for rec in RECORDS:
             f.write(json.dumps(rec, ensure_ascii=False) + "\n")
@@ -65,7 +90,9 @@ def main() -> int:
     cfg = TopicModelConfig(text_features=TextFeatureConfig(min_df=1))
     pipeline = train_topic_model(df, config=cfg)
     save_topic_model(pipeline, MODEL_PATH)
-    print(f"E2E fixture ready: {DATA_PATH} ({len(RECORDS)} lessons), {MODEL_PATH}")
+    print(
+        f"E2E fixture ready: {DATA_PATH} ({len(RECORDS)} lessons), {MODEL_PATH}, {VAULT_DIR}"
+    )
     return 0
 
 

--- a/scripts/e2e-serve.sh
+++ b/scripts/e2e-serve.sh
@@ -4,18 +4,21 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-PYTHON_BIN="python"
-if ! command -v python >/dev/null 2>&1; then
+PYTHON_BIN="$ROOT/.venv/bin/python"
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="python"
+fi
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python3"
 fi
 
-if [[ ! -f src/lele_manager/gui/static/index.html ]]; then
-  ./scripts/build-gui.sh
-fi
+# Build every time so the E2E server serves the current frontend sources.
+./scripts/build-gui.sh
 
 "$PYTHON_BIN" scripts/e2e-prepare.py
 
 export LELE_DATA_PATH="$ROOT/.e2e-fixture/lessons.jsonl"
 export LELE_MODEL_PATH="$ROOT/.e2e-fixture/topic_model.joblib"
+export LELE_VAULT_DIR="$ROOT/.e2e-fixture/vault"
 
-exec "$PYTHON_BIN" -m uvicorn lele_manager.api.server:app --host 127.0.0.1 --port 8765
+exec "$PYTHON_BIN" -m uvicorn lele_manager.api.server:app --host 127.0.0.1 --port "${E2E_PORT:-8765}"

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -24,6 +24,7 @@ from lele_manager.core.projection_store import (
     ProjectionStoreError,
 )
 from lele_manager.core.deduplication import DEFAULT_MIN_SCORE, find_duplicates
+from lele_manager.core.doctor import DoctorOperationalError, check_markdown_files
 from lele_manager.core.export import search_results_to_markdown
 from lele_manager.core.config import resolve_data_path, resolve_model_path
 from lele_manager.core.vault import (
@@ -295,6 +296,23 @@ class VaultImportResponse(BaseModel):
     n_lessons: int
     output_path: str
     topics: List[str]
+
+
+class VaultDoctorProblemResponse(BaseModel):
+    code: str
+    message: str
+    path: str
+    field: Optional[str] = None
+    severity: Literal["error"]
+
+
+class VaultDoctorReportResponse(BaseModel):
+    valid: bool
+    files_checked: int
+    checked_files: List[str]
+    unique_ids: int
+    error_count: int
+    problems: List[VaultDoctorProblemResponse]
 
 
 class LessonVaultWrite(BaseModel):
@@ -1182,6 +1200,19 @@ def vault_tree() -> VaultTreeResponse:
     vault_dir = require_vault_dir()
     tree = build_vault_tree(vault_dir)
     return VaultTreeResponse(vault_dir=str(vault_dir), tree=tree.to_dict())
+
+
+@app.get("/vault/doctor", response_model=VaultDoctorReportResponse)
+def vault_doctor() -> VaultDoctorReportResponse:
+    """Inspect the configured vault without modifying it."""
+    try:
+        vault_dir = require_vault_dir()
+        report = check_markdown_files([], vault_dir=vault_dir)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except DoctorOperationalError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return VaultDoctorReportResponse(**report.to_dict())
 
 
 @app.post("/vault/import", response_model=VaultImportResponse)

--- a/tests/test_api_vault.py
+++ b/tests/test_api_vault.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from lele_manager.api import server as server_mod
 from lele_manager.api.server import app
+from lele_manager.core.doctor import DoctorOperationalError
 from lele_manager.core.vault import (
     build_vault_tree,
     find_markdown_by_id,
@@ -135,3 +136,75 @@ def test_api_ops_refresh(vault_env: tuple[Path, Path]) -> None:
     body = resp.json()
     assert body["import_result"]["n_lessons"] >= 1
     assert data.is_file()
+
+
+def test_api_vault_doctor_returns_read_only_report(
+    vault_env: tuple[Path, Path],
+) -> None:
+    vault, _ = vault_env
+    valid = write_lesson_markdown(
+        vault,
+        lesson_id="python/2026-07-05.valid",
+        body="Valid lesson",
+        topic="python",
+        source="note",
+        importance=3,
+        tags=["python"],
+        date="2026-07-05",
+        title="Valid",
+    )
+    broken = vault / "python" / "broken.md"
+    broken.write_text("No frontmatter\n", encoding="utf-8")
+    before = {
+        path: (path.read_bytes(), path.stat().st_mtime_ns, path.stat().st_mode)
+        for path in (valid, broken)
+    }
+
+    response = TestClient(app).get("/vault/doctor")
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "valid": False,
+        "files_checked": 2,
+        "checked_files": ["python/2026-07-05.valid.md", "python/broken.md"],
+        "unique_ids": 1,
+        "error_count": 1,
+        "problems": [
+            {
+                "code": "missing_frontmatter",
+                "message": "frontmatter YAML assente",
+                "path": "python/broken.md",
+                "field": None,
+                "severity": "error",
+            }
+        ],
+    }
+    assert {
+        path: (path.read_bytes(), path.stat().st_mtime_ns, path.stat().st_mode)
+        for path in before
+    } == before
+
+
+def test_api_vault_doctor_returns_not_found_for_missing_vault(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LELE_VAULT_DIR", str(tmp_path / "missing-vault"))
+
+    response = TestClient(app).get("/vault/doctor")
+
+    assert response.status_code == 404
+    assert "Vault directory not found" in response.json()["detail"]
+
+
+def test_api_vault_doctor_returns_server_error_for_operational_failure(
+    vault_env: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail_doctor(*_args: object, **_kwargs: object) -> None:
+        raise DoctorOperationalError("vault inspection failed")
+
+    monkeypatch.setattr(server_mod, "check_markdown_files", fail_doctor)
+
+    response = TestClient(app).get("/vault/doctor")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "vault inspection failed"


### PR DESCRIPTION
## Summary

Integrates the existing read-only Vault Doctor into the daily Svelte GUI without changing Doctor validation semantics.

- adds `GET /vault/doctor`, delegating to the existing core Doctor implementation;
- maps a missing configured vault to HTTP 404 and operational inspection failures to HTTP 500;
- adds typed frontend API contracts and a Vault Doctor panel to the existing Ops page;
- groups findings deterministically by diagnostic code while preserving finding order;
- clears stale reports before reruns and presents controlled loading, success and error states;
- keeps the Doctor read-only, including file bytes, mtimes and modes;
- isolates Playwright Doctor scenarios in a dedicated `.e2e-fixture/vault`;
- makes the Playwright server port configurable through `E2E_PORT` while preserving port 8765 as the default.

## User impact

Users can run the Vault Doctor from the GUI, inspect healthy and unhealthy states, and review grouped diagnostics with paths, fields, severities and actionable messages without modifying the vault.

## Safety

- no automatic repair or vault mutation;
- no changes to Doctor rules, ordering or severity semantics;
- external symlink escapes remain operational errors;
- E2E fixtures never use the real user vault.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/mypy --python-executable .venv/bin/python`
- `.venv/bin/pytest -q` — 518 passed
- `npm run check --prefix frontend` — 0 errors; 4 pre-existing warnings
- `E2E_PORT=8891 npm run test:e2e --prefix frontend -- vault-doctor.spec.ts` — 4 passed
- `E2E_PORT=8891 npm run test:e2e --prefix frontend -- smoke.spec.ts` — 3 passed

Closes #110.