### PR TITLE
feat(gui): add duplicate review workflow

### DIFF
--- a/frontend/e2e/duplicates.spec.ts
+++ b/frontend/e2e/duplicates.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from '@playwright/test'
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url))
+const modelPath = join(repositoryRoot, '.e2e-fixture', 'topic_model.joblib')
+
+const repeatedIdReport = {
+  lessons_analyzed: 2,
+  total_pairs: 1,
+  exact_pairs: 1,
+  near_pairs: 0,
+  min_score: 0.85,
+  exact_only: true,
+  pairs: [
+    {
+      left_id: 'same-id',
+      right_id: 'same-id',
+      left_position: 4,
+      right_position: 9,
+      left_path: 'first.md',
+      right_path: 'second.md',
+      kind: 'exact',
+      score: 1,
+      reasons: ['duplicate_id'],
+      shared_tags: [],
+      left_lesson: { id: 'same-id', text: 'First record with the repeated ID.', title: 'First' },
+      right_lesson: { id: 'same-id', text: 'Second record with the repeated ID.', title: 'Second' },
+    },
+  ],
+}
+
+test.describe('duplicate review', () => {
+  test('reviews an exact duplicate with both lessons visible', async ({ page }) => {
+    await page.goto('/app/#/duplicates')
+    await page.getByRole('button', { name: 'Run review' }).click()
+
+    const exactPair = page.locator('.duplicate-pair').filter({ hasText: 'exact duplicate' }).first()
+    await expect(exactPair).toBeVisible({ timeout: 15_000 })
+    await expect(exactPair.getByText('exact_text', { exact: false })).toBeVisible()
+    await expect(exactPair.getByText('git branching merge rebase strategies')).toHaveCount(2)
+    await expect(page.getByText('Total pairs before limit')).toBeVisible()
+    await expect(page.getByText('Exact pairs before limit')).toBeVisible()
+    await expect(page.getByText('Near pairs before limit')).toBeVisible()
+    await expect(page.getByText('Configured display limit')).toBeVisible()
+    await expect(page.locator('.summary').getByText('100', { exact: true })).toBeVisible()
+  })
+
+  test('reviews near duplicates from the real fixture API', async ({ page }) => {
+    await page.goto('/app/#/duplicates')
+    await page.getByLabel('Minimum score').fill('0')
+    await page.getByRole('button', { name: 'Run review' }).click()
+
+    const nearPair = page.locator('.duplicate-pair').filter({ hasText: 'near duplicate' }).first()
+    await expect(nearPair).toBeVisible({ timeout: 15_000 })
+    await expect(nearPair.getByText(/Score 0\./)).toBeVisible()
+  })
+
+  test('keeps records with a repeated ID independently inspectable by position', async ({ page }) => {
+    await page.route('**/duplicates?*', async (route) => {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify(repeatedIdReport) })
+    })
+    await page.goto('/app/#/duplicates')
+    await page.getByRole('button', { name: 'Run review' }).click()
+
+    const pair = page.locator('.duplicate-pair')
+    await expect(pair.getByText('First record with the repeated ID.')).toBeVisible()
+    await expect(pair.getByText('Second record with the repeated ID.')).toBeVisible()
+    await expect(pair.getByText('4', { exact: true })).toBeVisible()
+    await expect(pair.getByText('9', { exact: true })).toBeVisible()
+    await expect(pair.getByText('same-id', { exact: true })).toHaveCount(2)
+  })
+
+  test('runs exact-only review while the model is unavailable', async ({ page }) => {
+    const model = await readFile(modelPath)
+    await rm(modelPath)
+    try {
+      await page.goto('/app/#/duplicates')
+      await page.getByLabel('Exact only').check()
+      await page.getByRole('button', { name: 'Run review' }).click()
+
+      await expect(page.getByText('Review summary')).toBeVisible({ timeout: 15_000 })
+      await expect(page.locator('.summary').getByText('Yes', { exact: true })).toBeVisible()
+      await expect(page.locator('.error-state')).toHaveCount(0)
+    } finally {
+      await writeFile(modelPath, model)
+    }
+  })
+
+  test('shows an empty review result', async ({ page }) => {
+    await page.route('**/duplicates?*', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          lessons_analyzed: 3,
+          total_pairs: 0,
+          exact_pairs: 0,
+          near_pairs: 0,
+          min_score: 0.85,
+          exact_only: false,
+          pairs: [],
+        }),
+      })
+    })
+    await page.goto('/app/#/duplicates')
+    await page.getByRole('button', { name: 'Run review' }).click()
+
+    await expect(page.getByRole('heading', { name: 'No duplicate pairs found' })).toBeVisible()
+    await expect(page.getByText('Displayed pairs')).toBeVisible()
+  })
+
+  test('rejects an invalid minimum score without requesting duplicates or keeping a stale report', async ({ page }) => {
+    let duplicateRequests = 0
+    await page.route('**/duplicates?*', async (route) => {
+      duplicateRequests += 1
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify(repeatedIdReport) })
+    })
+    await page.goto('/app/#/duplicates')
+    await page.getByRole('button', { name: 'Run review' }).click()
+    await expect(page.getByText('Review summary')).toBeVisible()
+
+    await page.getByLabel('Minimum score').fill('1.1')
+    await page.getByRole('button', { name: 'Refresh review' }).click()
+
+    await expect(page.getByText('Minimum score must be a finite number between 0 and 1.')).toBeVisible()
+    await expect(page.getByText('Review summary')).toHaveCount(0)
+    await expect(page.getByText('Configured display limit')).toHaveCount(0)
+    expect(duplicateRequests).toBe(1)
+  })
+
+  test('presents a model-unavailable error for a near-duplicate review', async ({ page }) => {
+    const model = await readFile(modelPath)
+    await rm(modelPath)
+    try {
+      await page.goto('/app/#/duplicates')
+      await page.getByRole('button', { name: 'Run review' }).click()
+
+      await expect(page.getByRole('heading', { name: 'Similarity model unavailable' })).toBeVisible({ timeout: 15_000 })
+      await expect(page.getByText('Run an exact-only review', { exact: false })).toBeVisible()
+    } finally {
+      await writeFile(modelPath, model)
+    }
+  })
+})

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -6,6 +6,7 @@
   import Editor from './routes/Editor.svelte'
   import Vault from './routes/Vault.svelte'
   import Ops from './routes/Ops.svelte'
+  import Duplicates from './routes/Duplicates.svelte'
   import Stats from './routes/Stats.svelte'
   import Timeline from './routes/Timeline.svelte'
   import { parseRoute, type Route } from './lib/router'
@@ -33,6 +34,8 @@
     <Vault />
   {:else if route.view === 'ops'}
     <Ops />
+  {:else if route.view === 'duplicates'}
+    <Duplicates />
   {:else if route.view === 'stats'}
     <Stats />
   {:else if route.view === 'timeline'}

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -15,6 +15,7 @@
     { view: 'stats' as const, label: 'Stats', hash: '#/stats' },
     { view: 'editor' as const, label: 'Editor', hash: '#/editor' },
     { view: 'vault' as const, label: 'Vault', hash: '#/vault' },
+    { view: 'duplicates' as const, label: 'Duplicates', hash: '#/duplicates' },
     { view: 'ops' as const, label: 'Ops', hash: '#/ops' },
   ]
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -157,6 +157,43 @@ export interface TimelineResponse {
   buckets: TimelineBucket[]
 }
 
+export type DuplicateKind = 'exact' | 'near'
+
+export interface DuplicateLessonSnapshot extends Lesson {
+  path?: string | null
+}
+
+export interface DuplicatePair {
+  left_id: string
+  right_id: string
+  left_position: number
+  right_position: number
+  left_path?: string | null
+  right_path?: string | null
+  kind: DuplicateKind
+  score: number
+  reasons: string[]
+  shared_tags: string[]
+  left_lesson: DuplicateLessonSnapshot
+  right_lesson: DuplicateLessonSnapshot
+}
+
+export interface DuplicateReportResponse {
+  lessons_analyzed: number
+  total_pairs: number
+  exact_pairs: number
+  near_pairs: number
+  min_score: number
+  exact_only: boolean
+  pairs: DuplicatePair[]
+}
+
+export interface DuplicateQuery {
+  min_score: number
+  exact_only: boolean
+  limit?: number | null
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const resp = await fetch(path, init)
   const data = await resp.json().catch(() => ({}))
@@ -175,6 +212,15 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
 export const api = {
   health: () => request<HealthResponse>('/health'),
+
+  duplicates: ({ min_score, exact_only, limit }: DuplicateQuery) => {
+    const params = new URLSearchParams({
+      min_score: String(min_score),
+      exact_only: String(exact_only),
+    })
+    if (limit != null) params.set('limit', String(limit))
+    return request<DuplicateReportResponse>(`/duplicates?${params.toString()}`)
+  },
 
   listLessons: (limit = 50) =>
     request<Lesson[]>(`/lessons?limit=${encodeURIComponent(limit)}`),

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -4,6 +4,7 @@ export type Route =
   | { view: 'editor'; id?: string }
   | { view: 'vault' }
   | { view: 'ops' }
+  | { view: 'duplicates' }
   | { view: 'stats' }
   | { view: 'timeline' }
 
@@ -12,6 +13,7 @@ export function parseRoute(hash = location.hash): Route {
 
   if (path === '/' || path === '/browse') return { view: 'browse' }
   if (path === '/ops') return { view: 'ops' }
+  if (path === '/duplicates') return { view: 'duplicates' }
   if (path === '/vault') return { view: 'vault' }
   if (path === '/stats') return { view: 'stats' }
   if (path === '/timeline') return { view: 'timeline' }
@@ -32,6 +34,8 @@ export function routeToHash(route: Route): string {
       return '#/'
     case 'ops':
       return '#/ops'
+    case 'duplicates':
+      return '#/duplicates'
     case 'vault':
       return '#/vault'
     case 'stats':

--- a/frontend/src/routes/Duplicates.svelte
+++ b/frontend/src/routes/Duplicates.svelte
@@ -1,0 +1,263 @@
+<script lang="ts">
+  import { api, type DuplicateLessonSnapshot, type DuplicatePair, type DuplicateReportResponse } from '../lib/api'
+
+  const reasonLabels: Record<string, string> = {
+    duplicate_id: 'Same lesson ID',
+    exact_text: 'Exact normalized text',
+    equivalent_metadata: 'Equivalent metadata',
+    same_title: 'Same title',
+    same_topic: 'Same topic',
+    same_source: 'Same source',
+    same_date: 'Same date',
+    shared_tags: 'Shared tags',
+  }
+
+  interface LessonSide {
+    heading: string
+    position: number
+    id: string
+    lesson: DuplicateLessonSnapshot
+    path: string
+  }
+
+  interface AppliedDuplicateQuery {
+    minScore: number
+    exactOnly: boolean
+    limit: number
+  }
+
+  let minScore = $state(0.85)
+  let exactOnly = $state(false)
+  let limit = $state('100')
+  let report = $state<DuplicateReportResponse | null>(null)
+  let appliedQuery = $state<AppliedDuplicateQuery | null>(null)
+  let loading = $state(false)
+  let error = $state('')
+
+  function requestLimit(): number | null {
+    const parsed = Number(limit)
+    return Number.isInteger(parsed) && parsed >= 1 ? parsed : null
+  }
+
+  function requestMinScore(): number | null {
+    const parsed = Number(minScore)
+    return Number.isFinite(parsed) && parsed >= 0 && parsed <= 1 ? parsed : null
+  }
+
+  function describeReason(reason: string): string {
+    return reasonLabels[reason] ?? 'Reported duplicate signal'
+  }
+
+  function isModelError(message: string): boolean {
+    return /model|modello/i.test(message)
+  }
+
+  function displayPath(pair: DuplicatePair, side: 'left' | 'right'): string {
+    const direct = side === 'left' ? pair.left_path : pair.right_path
+    const snapshot = side === 'left' ? pair.left_lesson : pair.right_lesson
+    return direct ?? snapshot.path ?? '—'
+  }
+
+  function metadata(lesson: DuplicateLessonSnapshot): Array<[string, string | number]> {
+    return [
+      ['Title', lesson.title ?? '—'],
+      ['Topic', lesson.topic ?? '—'],
+      ['Source', lesson.source ?? '—'],
+      ['Importance', lesson.importance ?? '—'],
+      ['Date', lesson.date ?? '—'],
+      ['Created', lesson.created_at ?? '—'],
+    ]
+  }
+
+  function lessonSides(pair: DuplicatePair): LessonSide[] {
+    return [
+      {
+        heading: 'Left lesson',
+        position: pair.left_position,
+        id: pair.left_id,
+        lesson: pair.left_lesson,
+        path: displayPath(pair, 'left'),
+      },
+      {
+        heading: 'Right lesson',
+        position: pair.right_position,
+        id: pair.right_id,
+        lesson: pair.right_lesson,
+        path: displayPath(pair, 'right'),
+      },
+    ]
+  }
+
+  async function runReview() {
+    report = null
+    appliedQuery = null
+    error = ''
+
+    const parsedLimit = requestLimit()
+    if (parsedLimit == null) {
+      error = 'Limit must be a whole number of at least 1.'
+      return
+    }
+    const parsedMinScore = requestMinScore()
+    if (parsedMinScore == null) {
+      error = 'Minimum score must be a finite number between 0 and 1.'
+      return
+    }
+    const requestedExactOnly = exactOnly
+    loading = true
+    try {
+      const response = await api.duplicates({
+        min_score: parsedMinScore,
+        exact_only: requestedExactOnly,
+        limit: parsedLimit,
+      })
+      report = response
+      appliedQuery = { minScore: parsedMinScore, exactOnly: requestedExactOnly, limit: parsedLimit }
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e)
+    } finally {
+      loading = false
+    }
+  }
+</script>
+
+<section class="duplicates">
+  <section class="card controls">
+    <h2>Duplicate review</h2>
+    <p class="meta">Read-only review of exact and near duplicate candidates. No records are changed.</p>
+    <div class="control-grid">
+      <label>
+        Minimum score
+        <input aria-label="Minimum score" type="number" min="0" max="1" step="0.01" bind:value={minScore} />
+      </label>
+      <label class="checkbox-label">
+        <input aria-label="Exact only" type="checkbox" bind:checked={exactOnly} />
+        Exact only (does not require the similarity model)
+      </label>
+      <label>
+        Display limit
+        <input aria-label="Display limit" type="number" min="1" step="1" bind:value={limit} />
+      </label>
+    </div>
+    <div class="actions">
+      <button class="btn btn-primary" onclick={runReview} disabled={loading}>
+        {loading ? 'Running…' : report ? 'Refresh review' : 'Run review'}
+      </button>
+    </div>
+  </section>
+
+  {#if loading}
+    <p class="meta" role="status">Running duplicate review…</p>
+  {:else if error}
+    <section class="card error-state" role="alert">
+      <h3>{isModelError(error) ? 'Similarity model unavailable' : 'Duplicate review failed'}</h3>
+      <p class="error">{error}</p>
+      {#if isModelError(error)}
+        <p class="meta">Run an exact-only review, or train and make the topic model available before reviewing near duplicates.</p>
+      {/if}
+    </section>
+  {:else if report && appliedQuery}
+    <section class="card summary" aria-label="Duplicate review summary">
+      <h3>Review summary</h3>
+      <dl>
+        <div><dt>Lessons analyzed</dt><dd>{report.lessons_analyzed}</dd></div>
+        <div><dt>Total pairs before limit</dt><dd>{report.total_pairs}</dd></div>
+        <div><dt>Exact pairs before limit</dt><dd>{report.exact_pairs}</dd></div>
+        <div><dt>Near pairs before limit</dt><dd>{report.near_pairs}</dd></div>
+        <div><dt>Configured minimum score</dt><dd>{appliedQuery.minScore}</dd></div>
+        <div><dt>Configured display limit</dt><dd>{appliedQuery.limit}</dd></div>
+        <div><dt>Exact only</dt><dd>{appliedQuery.exactOnly ? 'Yes' : 'No'}</dd></div>
+        <div><dt>Displayed pairs</dt><dd>{report.pairs.length}</dd></div>
+      </dl>
+    </section>
+
+    {#if report.pairs.length === 0}
+      <section class="card empty-state">
+        <h3>No duplicate pairs found</h3>
+        <p class="meta">Try a lower minimum score or review a dataset with more lessons.</p>
+      </section>
+    {:else}
+      <section class="pair-list" aria-label="Duplicate pairs">
+        {#each report.pairs as pair, index (`${pair.left_position}-${pair.right_position}-${index}`)}
+          <article class="card duplicate-pair">
+            <header class="pair-header">
+              <h3>Pair {index + 1}</h3>
+              <div class="signals">
+                <span class:exact={pair.kind === 'exact'} class:near={pair.kind === 'near'} class="kind">{pair.kind} duplicate</span>
+                <span class="score">Score {pair.score.toFixed(3)}</span>
+              </div>
+            </header>
+            <div class="reasons" aria-label="Duplicate signals">
+              {#if pair.reasons.length}
+                {#each pair.reasons as reason}
+                  <span class="reason" title={reason}>{describeReason(reason)} <code>{reason}</code></span>
+                {/each}
+              {:else}
+                <span class="meta">Reasons: —</span>
+              {/if}
+              <span class="meta">Shared tags: {pair.shared_tags.length ? pair.shared_tags.join(', ') : '—'}</span>
+            </div>
+
+            <div class="lessons">
+              {#each lessonSides(pair) as item}
+                <section class="lesson" aria-label={item.heading}>
+                  <h4>{item.heading}</h4>
+                  <dl class="identity">
+                    <div><dt>Position (zero-based)</dt><dd>{item.position}</dd></div>
+                    <div><dt>ID</dt><dd>{item.id || '—'}</dd></div>
+                    <div><dt>Path</dt><dd>{item.path}</dd></div>
+                  </dl>
+                  <h5>Text</h5>
+                  <pre>{item.lesson.text}</pre>
+                  <h5>Metadata</h5>
+                  <dl class="metadata">
+                    {#each metadata(item.lesson) as field}
+                      <div><dt>{field[0]}</dt><dd>{field[1]}</dd></div>
+                    {/each}
+                    <div>
+                      <dt>Tags</dt>
+                      <dd>{item.lesson.tags?.length ? item.lesson.tags.join(', ') : '—'}</dd>
+                    </div>
+                  </dl>
+                </section>
+              {/each}
+            </div>
+          </article>
+        {/each}
+      </section>
+    {/if}
+  {:else}
+    <p class="meta">Choose the review settings and run the read-only check.</p>
+  {/if}
+</section>
+
+<style>
+  .duplicates, .pair-list { display: grid; gap: 16px; }
+  h2, h3, h4, h5 { margin: 0; }
+  .controls > .meta { margin: 8px 0 16px; }
+  .control-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; }
+  label { display: grid; gap: 5px; color: var(--muted); font-size: .85rem; }
+  input[type='number'] { padding: 8px 10px; border: 1px solid var(--border); border-radius: 8px; background: white; color: var(--text); }
+  .checkbox-label { display: flex; align-items: center; gap: 8px; padding-top: 25px; }
+  .actions { margin-top: 14px; }
+  .summary h3 { margin-bottom: 12px; }
+  .summary dl { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 10px; margin: 0; }
+  .summary dl div, .identity div, .metadata div { border: 1px solid var(--border); border-radius: 7px; padding: 8px; }
+  dt { color: var(--muted); font-size: .76rem; }
+  dd { margin: 3px 0 0; overflow-wrap: anywhere; }
+  .pair-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+  .signals, .reasons { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; }
+  .kind, .score, .reason { border-radius: 999px; padding: 3px 8px; font-size: .78rem; }
+  .kind.exact { background: #dff4e5; color: #146c3b; }
+  .kind.near { background: #fff0d9; color: #955600; }
+  .score, .reason { background: #f3efe8; }
+  .reason code { color: var(--muted); font-size: .75rem; }
+  .reasons { margin: 12px 0; }
+  .lessons { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+  .lesson { min-width: 0; border: 1px solid var(--border); border-radius: 8px; padding: 12px; }
+  .lesson h4 { margin-bottom: 10px; }
+  .lesson h5 { margin: 14px 0 6px; font-size: .83rem; color: var(--muted); }
+  .identity, .metadata { display: grid; grid-template-columns: repeat(auto-fit, minmax(115px, 1fr)); gap: 7px; margin: 0; }
+  pre { margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere; background: #f7f4ee; border-radius: 6px; font: .85rem/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
+  @media (max-width: 850px) { .lessons { grid-template-columns: 1fr; } }
+</style>

--- a/scripts/e2e-prepare.py
+++ b/scripts/e2e-prepare.py
@@ -40,6 +40,17 @@ RECORDS = [
         "created_at": "2025-02-01T10:00:00+00:00",
     },
     {
+        "id": "e2e/git-lesson-copy",
+        "text": "git branching merge rebase strategies",
+        "topic": "git",
+        "source": "note",
+        "importance": 3,
+        "tags": ["git"],
+        "date": "2025-02-01",
+        "title": "Git branching copy",
+        "created_at": "2025-02-02T10:00:00+00:00",
+    },
+    {
         "id": "e2e/linux-lesson",
         "text": "linux networking iptables basics",
         "topic": "linux",

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -246,6 +246,12 @@ class SimilarBatchResponse(BaseModel):
     items: List[SimilarResponse]
 
 
+class DuplicateLessonSnapshot(Lesson):
+    """Read-only lesson data captured from the same snapshot as a duplicate pair."""
+
+    path: Optional[str] = None
+
+
 class DuplicatePairResponse(BaseModel):
     left_id: str
     right_id: str
@@ -257,6 +263,8 @@ class DuplicatePairResponse(BaseModel):
     score: float
     reasons: List[str]
     shared_tags: List[str]
+    left_lesson: DuplicateLessonSnapshot
+    right_lesson: DuplicateLessonSnapshot
 
 
 class DuplicateReportResponse(BaseModel):
@@ -651,6 +659,16 @@ def _row_to_search_result(row: dict) -> LessonSearchResult:
     )
 
 
+def _row_to_duplicate_snapshot(row: dict) -> DuplicateLessonSnapshot:
+    """Return display data for a duplicate pair without using its (non-unique) ID."""
+    lesson = _row_to_search_result(row)
+    return DuplicateLessonSnapshot(
+        **lesson.model_dump(exclude={"created_at"}),
+        created_at=_to_optional_str(row.get("created_at")),
+        path=_to_optional_str(row.get("path")),
+    )
+
+
 # -----------------------------------------------------------------------------
 # Endpoint
 # -----------------------------------------------------------------------------
@@ -753,7 +771,16 @@ def duplicates(
         exact_only=exact_only,
         limit=limit,
     )
-    return DuplicateReportResponse(**report.to_dict())
+    payload = report.to_dict()
+    payload["pairs"] = [
+        {
+            **pair.to_dict(),
+            "left_lesson": _row_to_duplicate_snapshot(df.iloc[pair.left_position].to_dict()).model_dump(),
+            "right_lesson": _row_to_duplicate_snapshot(df.iloc[pair.right_position].to_dict()).model_dump(),
+        }
+        for pair in report.pairs
+    ]
+    return DuplicateReportResponse(**payload)
 
 
 @app.get("/lessons", response_model=List[LessonSearchResult])

--- a/tests/test_api_duplicates.py
+++ b/tests/test_api_duplicates.py
@@ -94,3 +94,49 @@ def test_empty_dataset_is_valid_without_model(monkeypatch) -> None:
     assert response.status_code == 200
     assert response.json()["lessons_analyzed"] == 0
     assert response.json()["pairs"] == []
+
+
+def test_duplicate_pairs_include_independent_read_only_lesson_snapshots(monkeypatch) -> None:
+    monkeypatch.setattr(
+        server,
+        "load_lessons_df",
+        lambda: pd.DataFrame(
+            [
+                {
+                    "id": "repeated-id",
+                    "text": "first independently inspectable lesson",
+                    "title": "First",
+                    "tags": ["one"],
+                    "path": "first.md",
+                },
+                {
+                    "id": "repeated-id",
+                    "text": "second independently inspectable lesson",
+                    "title": "Second",
+                    "tags": ["two"],
+                    "path": "second.md",
+                },
+            ]
+        ),
+    )
+    response = TestClient(server.app).get("/duplicates", params={"exact_only": "true"})
+
+    assert response.status_code == 200
+    pair = response.json()["pairs"][0]
+    assert pair["left_position"] == 0
+    assert pair["right_position"] == 1
+    assert pair["left_lesson"] == {
+        "id": "repeated-id",
+        "text": "first independently inspectable lesson",
+        "topic": None,
+        "source": None,
+        "importance": None,
+        "tags": ["one"],
+        "date": None,
+        "title": "First",
+        "created_at": None,
+        "path": "first.md",
+    }
+    assert pair["right_lesson"]["text"] == "second independently inspectable lesson"
+    assert pair["right_lesson"]["title"] == "Second"
+    assert pair["right_lesson"]["path"] == "second.md"


### PR DESCRIPTION
## Summary

- add a dedicated read-only `#/duplicates` GUI workflow;
- expose minimum score, exact-only mode and display limit controls;
- show deterministic duplicate candidates with reasons, scores, shared tags and zero-based positions;
- render both lessons side by side, including independently inspectable records with repeated IDs;
- add read-only lesson snapshots to the existing duplicate API response;
- add deterministic API and Playwright coverage for exact, near, repeated-ID, empty and model-unavailable scenarios.

## API compatibility

The `/duplicates` response remains backward compatible. Existing fields are unchanged; `left_lesson` and `right_lesson` are additive read-only snapshots sourced from the exact analyzed DataFrame positions.

No duplicate detection, CLI, ordering or mutation semantics were changed.

## Safety

The workflow is review-only. It provides no merge, delete, rewrite, approval, winner-selection or automatic-resolution actions.

## Validation

- `ruff check .`
- `mypy --python-executable .venv/bin/python`
- `pytest -q` — 519 passed
- `npm run check --prefix frontend` — 0 errors
- `npm run test:e2e --prefix frontend -- duplicates.spec.ts` — 7 passed
- `npm run test:e2e --prefix frontend -- smoke.spec.ts` — 3 passed
- `npm run test:e2e --prefix frontend -- vault-doctor.spec.ts` — 4 passed

Closes #111
