### PR TITLE
feat(gui): add TritaLeLe candidate review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,8 @@ Available views:
 | **Browse** | Advanced search, filters, and Markdown export |
 | **Detail** | Full lesson content and explained similarity |
 | **Editor** | Markdown authoring with live suggestions |
+| **TritaLeLe** | Controlled candidate ingestion, review, rejection, and approval |
+| **Duplicates** | Read-only review of exact and near-duplicate pairs |
 | **Timeline** | Knowledge-acquisition timeline and bucket export |
 | **Stats** | Counts, tags, topics, and averages |
 | **Vault** | Real filesystem tree and import |
@@ -492,6 +494,29 @@ Saving from the Editor writes the Markdown file into the vault and refreshes
 the JSONL projection through `PUT` or `POST /vault/lessons`.
 
 The GUI requires `LELE_VAULT_DIR`; the default is `~/LeLeVault`.
+
+### TritaLeLe workflow
+
+Open `#/tritalele` to ingest pasted text or a Markdown/plain-text file through
+the deterministic candidate workflow:
+
+1. **Preview** computes chunks and candidate identities without writing staging,
+   the canonical vault, or the JSONL projection.
+2. **Stage** persists only missing candidates. Any source change invalidates the
+   previous preview.
+3. **Review** allows explicit text and metadata revisions using optimistic
+   `expected_revision` checks. Accept moves a candidate into review; reject
+   keeps it traceable in staging with its reason and history.
+4. **Approve** requires a separate confirmation dialog showing the candidate,
+   revision, canonical lesson ID, and destination path. Those destination values
+   are calculated by the backend using the same canonicalization used during
+   publication.
+5. **Read-back** reports vault-write and projection-refresh outcomes separately,
+   including controlled partial-success cases.
+
+Preview, staging, revision, acceptance, and rejection never publish a lesson.
+Only explicit approval may write one canonical Markdown lesson and refresh the
+derived projection.
 
 The completed design record remains available in Italian at
 [`docs/gui-design.md`](docs/gui-design.md). It is classified as a historical
@@ -519,9 +544,11 @@ npx playwright install chromium
 npm run test:e2e
 ```
 
-`scripts/e2e-serve.sh` starts Uvicorn on port `8765` with data under
-`.e2e-fixture/`. CI runs the same smoke flows after building the GUI and running
-the Python tests.
+`scripts/e2e-serve.sh` rebuilds the current frontend, resets only
+`.e2e-fixture/`, and starts Uvicorn on port `8765`. The isolated runtime uses
+`.e2e-fixture/data`, `.e2e-fixture/cache`, and `.e2e-fixture/vault`, so the E2E
+suite cannot inspect or mutate personal candidate staging, datasets, caches, or
+vault files. CI runs the same flows after the Python checks.
 
 ## Versioning and releases
 

--- a/docs/gui-design.md
+++ b/docs/gui-design.md
@@ -54,6 +54,7 @@ La GUI è **client dell'API FastAPI**. CLI (`lele`) e script shell restano il pe
 | Ops | `/ops` | Import, train, refresh, log |
 | Timeline | `/timeline` | Fase 3 — #89 |
 | Stats | `/stats` | Fase 3 — #88 |
+| TritaLeLe | `/tritalele` | Ingestione e revisione umana dei candidati |
 
 ### Cosa resta solo CLI
 
@@ -435,3 +436,63 @@ lele similar <id> --explain
 lele suggest --text "..." --explain
 lele export --search "pytest" --topic python -o results.md
 ```
+
+---
+
+## 12. TritaLeLe — ingestione e review (#126)
+
+La route SPA `#/tritalele` usa il boundary versionato
+`/api/v1/tritalele`. Il candidato è un’entità di staging, non una `Lesson`:
+per questo la lista usa `CandidateCard` e non deriva il componente da
+`LessonCard`.
+
+```mermaid
+flowchart LR
+    I[File o testo incollato] --> P[Preview read-only]
+    P --> S[Stage]
+    S --> R[Revisione ottimistica]
+    R --> A[Accept: in_review]
+    R --> X[Reject tracciato]
+    A --> C[Dialog canonico]
+    C --> V[Approve: vault + refresh]
+    V --> L[Read-back lesson]
+    V --> F[Read-back vault]
+```
+
+Regole UI:
+
+- ogni modifica all’input invalida preview e possibilità di staging;
+- la lista rispetta l’ordinamento deterministico del backend, offre filtri e
+  non seleziona automaticamente alcun candidato;
+- dettaglio, provenance e history restano visibili anche per i rejected;
+- revise, accept e reject inviano sempre la revisione osservata;
+- accept non approva e non scrive nel vault;
+- il dialog di approve mostra candidato, revisione e
+  `approval_destination` (`lesson_id`, `relative_vault_path`) restituita dal
+  backend. La GUI non contiene logica di slug, digest o path;
+- una sola conferma esplicita produce una request approve; cancel non invia
+  richieste;
+- `created`, `identical`, `partial_refresh` e gli altri recuperi parziali sono
+  presentati separatamente dai read-back della proiezione e del vault;
+- le risposte asincrone diventate obsolete dopo cambio input, filtro o
+  selezione non possono sostituire lo stato corrente.
+
+Il client HTTP espone `ApiError extends Error`: i consumer esistenti che usano
+`message` continuano a funzionare, mentre TritaLeLe può leggere `status`,
+`code`, `detail` e `recovery` per gestire 409, 422 e 503 in modo controllato.
+
+I campi metadati restano locali alla route TritaLeLe. Un componente condiviso
+con Editor imporrebbe in questa fase adapter e default applicativi diversi; il
+refactor non sarebbe puramente presentazionale e aumenterebbe lo scope.
+
+### Isolamento Playwright
+
+Prima dell’avvio E2E, `scripts/e2e-prepare.py` resetta esclusivamente
+`.e2e-fixture/`. Il server riceve tre directory dedicate:
+
+- `LELE_DATA_DIR=.e2e-fixture/data` (JSONL e staging candidati);
+- `LELE_CACHE_DIR=.e2e-fixture/cache` (topic model);
+- `LELE_VAULT_DIR=.e2e-fixture/vault` (Markdown canonici).
+
+Nessun test Playwright può quindi usare fallback XDG o vault personali. Il
+percorso E2E non invoca LLM: chunking, identità e metadata sono deterministici.

--- a/frontend/e2e/duplicates.spec.ts
+++ b/frontend/e2e/duplicates.spec.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url))
-const modelPath = join(repositoryRoot, '.e2e-fixture', 'topic_model.joblib')
+const modelPath = join(repositoryRoot, '.e2e-fixture', 'cache', 'topic_model.joblib')
 
 const repeatedIdReport = {
   lessons_analyzed: 2,

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -40,4 +40,14 @@ test.describe('GUI smoke', () => {
     await expect(page.locator('.timeline .error')).toHaveCount(0, { timeout: 15_000 })
     await expect(page.locator('.bucket').first()).toBeVisible()
   })
+
+  test('Ops e Vault caricano sulla fixture isolata', async ({ page }) => {
+    await page.goto('/app/#/ops')
+    await expect(page.getByRole('heading', { name: 'Ops / Admin' })).toBeVisible()
+    await expect(page.locator('.ops .error')).toHaveCount(0, { timeout: 15_000 })
+
+    await page.getByRole('link', { name: 'Vault' }).click()
+    await expect(page.getByRole('heading', { name: 'Vault' })).toBeVisible()
+    await expect(page.locator('section.card > .error')).toHaveCount(0, { timeout: 15_000 })
+  })
 })

--- a/frontend/e2e/tritalele.spec.ts
+++ b/frontend/e2e/tritalele.spec.ts
@@ -1,0 +1,255 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test'
+
+const API = '/api/v1/tritalele'
+
+async function countVaultFiles(page: Page): Promise<number> {
+  const response = await page.request.get('/vault/tree')
+  expect(response.ok()).toBeTruthy()
+  const body = (await response.json()) as {
+    tree: { type: 'dir' | 'file'; children?: unknown[] }
+  }
+  const count = (node: unknown): number => {
+    if (typeof node !== 'object' || node === null) return 0
+    const item = node as { type?: string; children?: unknown[] }
+    if (item.type === 'file') return 1
+    return (item.children ?? []).reduce<number>((total, child) => total + count(child), 0)
+  }
+  return count(body.tree)
+}
+
+async function stageAccepted(
+  request: APIRequestContext,
+  logicalName: string,
+): Promise<{ candidateId: string; revision: number; lessonId: string; path: string }> {
+  const staged = await request.post(`${API}/ingestion/stage`, {
+    data: {
+      content: `Candidate for controlled partial refresh: ${logicalName}`,
+      source_kind: 'plain_text',
+      logical_name: logicalName,
+      max_characters: 2000,
+    },
+  })
+  expect(staged.ok()).toBeTruthy()
+  const candidateId = (await staged.json()).candidate_ids[0] as string
+  const revised = await request.patch(`${API}/candidates/${encodeURIComponent(candidateId)}`, {
+    data: {
+      expected_revision: 0,
+      proposed_metadata: {
+        topic: 'e2e',
+        source: 'playwright',
+        importance: 4,
+        tags: ['e2e', 'partial'],
+        date: '2026-07-22',
+        title: 'Controlled partial refresh',
+      },
+    },
+  })
+  expect(revised.ok()).toBeTruthy()
+  const revisedBody = await revised.json()
+  const accepted = await request.post(
+    `${API}/candidates/${encodeURIComponent(candidateId)}/accept`,
+    { data: { expected_revision: revisedBody.revision, reason: 'ready for controlled E2E' } },
+  )
+  expect(accepted.ok()).toBeTruthy()
+  const acceptedBody = await accepted.json()
+  return {
+    candidateId,
+    revision: acceptedBody.revision,
+    lessonId: acceptedBody.approval_destination.lesson_id,
+    path: acceptedBody.approval_destination.relative_vault_path,
+  }
+}
+
+test.describe.serial('TritaLeLe GUI', () => {
+  test('plain text: preview, stage, revise, accept and one explicit approval', async ({ page }) => {
+    await page.goto('/app/#/tritalele')
+    await expect(page.getByRole('heading', { name: 'TritaLeLe' })).toBeVisible()
+    await expect(page.getByText('Nessuna selezione.')).toBeVisible()
+
+    const initialVaultFiles = await countVaultFiles(page)
+
+    await page.getByLabel('Nome logico').fill('pasted-happy-path.txt')
+    const source = page.getByLabel('Testo sorgente')
+    await source.fill('Plain text incollato per il workflow TritaLeLe deterministico.')
+    await page.getByRole('button', { name: 'Genera anteprima' }).click()
+    await expect(page.getByTestId('ingestion-preview')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Crea staging' })).toBeEnabled()
+
+    await source.fill('Plain text incollato modificato: la preview precedente non è più valida.')
+    await expect(page.getByTestId('ingestion-preview')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Crea staging' })).toBeDisabled()
+
+    await page.getByRole('button', { name: 'Genera anteprima' }).click()
+    await page.getByRole('button', { name: 'Crea staging' }).click()
+    await expect(page.getByText(/Staging completato: 1 created/)).toBeVisible()
+    expect(await countVaultFiles(page)).toBe(initialVaultFiles)
+
+    await page.locator('.candidate-card').filter({ hasText: 'pasted-happy-path.txt' }).click()
+    await expect(page.getByRole('heading', { name: 'Dettaglio candidato' })).toBeVisible()
+    await page.getByLabel('Testo proposto').fill(
+      'Testo rivisto in Markdown con **contenuto canonico** e provenienza intatta.',
+    )
+    await page.getByLabel('Topic', { exact: true }).fill('e2e')
+    await page.getByLabel('Source', { exact: true }).fill('playwright')
+    await page.getByLabel('Importance', { exact: true }).fill('4')
+    await page.getByLabel('Date', { exact: true }).fill('2026-07-22')
+    await page.getByLabel('Tags', { exact: true }).fill('e2e, tritalele')
+    await page.getByLabel('Title', { exact: true }).fill('TritaLeLe approval')
+    await page.getByLabel('Motivo revisione (opzionale)').fill('editorial pass')
+    await page.getByRole('button', { name: 'Salva revisione' }).click()
+    await expect(page.getByText(/Revisione 1 salvata/)).toBeVisible()
+    await expect(page.getByTestId('approval-destination')).toContainText('e2e/')
+    expect(await countVaultFiles(page)).toBe(initialVaultFiles)
+
+    await page.getByLabel(/Motivo transizione/).fill('ready')
+    await page.getByRole('button', { name: 'Accetta per revisione' }).click()
+    await expect(page.getByText(/non è ancora pubblicato/)).toBeVisible()
+    expect(await countVaultFiles(page)).toBe(initialVaultFiles)
+
+    let approvalRequests = 0
+    page.on('request', (request) => {
+      if (request.method() === 'POST' && request.url().endsWith('/approve')) {
+        approvalRequests += 1
+      }
+    })
+    await page.getByRole('button', { name: 'Approva nel vault' }).click()
+    const dialog = page.getByRole('dialog', { name: 'Conferma approvazione canonica' })
+    await expect(dialog).toContainText('Candidato')
+    await expect(dialog).toContainText('Revisione')
+    await expect(dialog).toContainText('Lesson ID')
+    await expect(dialog).toContainText('Path canonico')
+    await dialog.getByRole('button', { name: 'Annulla' }).click()
+    await expect(dialog).toHaveCount(0)
+    expect(approvalRequests).toBe(0)
+
+    await page.getByRole('button', { name: 'Approva nel vault' }).click()
+    await page.getByRole('button', { name: 'Conferma approvazione' }).click()
+    await expect(page.getByTestId('approval-result')).toContainText('created')
+    await expect(page.getByText(/Lesson riletta:/)).toBeVisible()
+    await expect(page.getByText(/File vault riletto:/)).toBeVisible()
+    expect(approvalRequests).toBe(1)
+    expect(await countVaultFiles(page)).toBe(initialVaultFiles + 1)
+
+    const lessons = await page.request.get('/lessons?limit=50')
+    expect(lessons.ok()).toBeTruthy()
+    expect(((await lessons.json()) as unknown[]).length).toBe(initialVaultFiles + 1)
+  })
+
+  test('Markdown file can be staged and a rejected candidate remains visible', async ({ page }) => {
+    await page.goto('/app/#/tritalele')
+    const initialVaultFiles = await countVaultFiles(page)
+
+    await page.getByLabel('File Markdown o testo').setInputFiles({
+      name: 'file-input.md',
+      mimeType: 'text/markdown',
+      buffer: Buffer.from('# File input\n\nCandidate rejected but retained.'),
+    })
+    await expect(page.getByLabel('Tipo sorgente')).toHaveValue('markdown')
+    await expect(page.getByLabel('Nome logico')).toHaveValue('file-input.md')
+    await page.getByRole('button', { name: 'Genera anteprima' }).click()
+    await expect(page.getByTestId('ingestion-preview')).toBeVisible()
+    await page.getByRole('button', { name: 'Crea staging' }).click()
+    await expect(page.getByText(/Staging completato: 1 created/)).toBeVisible()
+
+    await page.locator('.candidate-card').filter({ hasText: 'file-input.md' }).click()
+    await page.getByLabel(/Motivo transizione/).fill('not useful for the vault')
+    await page.getByRole('button', { name: 'Rifiuta candidato' }).click()
+    await expect(page.getByText(/resta nello staging/)).toBeVisible()
+    await expect(page.locator('.candidate-card').filter({ hasText: 'file-input.md' })).toBeVisible()
+    await expect(page.getByText('rejected → rejected')).toHaveCount(0)
+    await expect(page.getByText('staged → rejected')).toBeVisible()
+    await expect(page.getByText('not useful for the vault')).toBeVisible()
+    expect(await countVaultFiles(page)).toBe(initialVaultFiles)
+  })
+
+  test('409, 422, 503 and obsolete preview responses are controlled', async ({ page }) => {
+    await page.goto('/app/#/tritalele')
+    await page.getByLabel('Nome logico').fill('controlled-errors.txt')
+    await page.getByLabel('Testo sorgente').fill('Valid input used to exercise controlled HTTP errors.')
+
+    const previewUrl = '**/api/v1/tritalele/ingestion/preview'
+    await page.route(previewUrl, (route) =>
+      route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: { code: 'ingestion_conflict', message: 'Conflict.' } }),
+      }),
+    )
+    await page.getByRole('button', { name: 'Genera anteprima' }).click()
+    await expect(page.getByText(/Conflitto \(409 · ingestion_conflict\)/)).toBeVisible()
+    await page.unroute(previewUrl)
+
+    await page.route(previewUrl, (route) =>
+      route.fulfill({
+        status: 422,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: [{ loc: ['body'], msg: 'invalid', type: 'value_error' }] }),
+      }),
+    )
+    await page.getByRole('button', { name: 'Genera anteprima' }).click()
+    await expect(page.getByText(/Dati non validi \(422\)/)).toBeVisible()
+    await page.unroute(previewUrl)
+
+    await page.route(previewUrl, (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          detail: { code: 'candidate_storage_unavailable', message: 'Unavailable.' },
+        }),
+      }),
+    )
+    await page.getByRole('button', { name: 'Genera anteprima' }).click()
+    await expect(page.getByText(/Errore operativo \(503 · candidate_storage_unavailable\)/)).toBeVisible()
+    await page.unroute(previewUrl)
+
+    await page.route(previewUrl, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      await route.continue()
+    })
+    await page.getByRole('button', { name: 'Genera anteprima' }).click()
+    await page.getByLabel('Testo sorgente').fill('Changed while the preview request is still running.')
+    await page.waitForTimeout(500)
+    await expect(page.getByTestId('ingestion-preview')).toHaveCount(0)
+    await expect(page.getByRole('button', { name: 'Crea staging' })).toBeDisabled()
+    await page.unroute(previewUrl)
+  })
+
+  test('partial_refresh is reported as persisted with separate read-backs', async ({ page }) => {
+    const staged = await stageAccepted(page.request, 'partial-refresh.txt')
+    await page.route(`**/candidates/${encodeURIComponent(staged.candidateId)}/approve`, (route) =>
+      route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          detail: {
+            code: 'partial_refresh',
+            message: 'Projection refresh failed.',
+            recovery: {
+              partial_approval_result: {
+                candidate_id: staged.candidateId,
+                candidate_revision: staged.revision + 1,
+                lesson_id: staged.lessonId,
+                relative_vault_path: staged.path,
+                vault_write_outcome: 'created',
+                candidate_state_changed: true,
+                refresh_outcome: { refreshed: false },
+              },
+              canonical_lesson_persisted: true,
+              candidate_approval_persisted: true,
+              projection_refreshed: false,
+            },
+          },
+        }),
+      }),
+    )
+
+    await page.goto('/app/#/tritalele')
+    await page.locator('.candidate-card').filter({ hasText: 'partial-refresh.txt' }).click()
+    await page.getByRole('button', { name: 'Approva nel vault' }).click()
+    await page.getByRole('button', { name: 'Conferma approvazione' }).click()
+    await expect(page.getByText(/partial_refresh/).first()).toBeVisible()
+    await expect(page.getByText('Dettagli di recupero')).toBeVisible()
+    await expect(page.getByLabel('Read-back approvazione')).toBeVisible()
+  })
+})

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
   import Duplicates from './routes/Duplicates.svelte'
   import Stats from './routes/Stats.svelte'
   import Timeline from './routes/Timeline.svelte'
+  import TritaLeLe from './routes/TritaLeLe.svelte'
   import { parseRoute, type Route } from './lib/router'
 
   let route = $state<Route>({ view: 'browse' })
@@ -40,5 +41,7 @@
     <Stats />
   {:else if route.view === 'timeline'}
     <Timeline />
+  {:else if route.view === 'tritalele'}
+    <TritaLeLe />
   {/if}
 </Shell>

--- a/frontend/src/components/CandidateCard.svelte
+++ b/frontend/src/components/CandidateCard.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import type { Candidate } from '../lib/api'
+
+  interface Props {
+    candidate: Candidate
+    selected?: boolean
+    onclick?: () => void
+  }
+
+  let { candidate, selected = false, onclick }: Props = $props()
+
+  function shortId(id: string): string {
+    return id.startsWith('sha256:') ? id.slice(7, 19) : id.slice(0, 12)
+  }
+</script>
+
+<button
+  class="candidate-card"
+  class:selected
+  type="button"
+  aria-label={`Apri candidato ${shortId(candidate.candidate_id)}`}
+  {onclick}
+>
+  <span class={`state state-${candidate.state}`}>{candidate.state}</span>
+  <strong>{candidate.provenance.source_logical_name}</strong>
+  <span class="meta identity">{shortId(candidate.candidate_id)} · rev {candidate.revision}</span>
+  <span class="meta">
+    {candidate.provenance.source_kind}
+    {#if candidate.provenance.chunk_index !== null}
+      · chunk {candidate.provenance.chunk_index}
+    {/if}
+  </span>
+  <span class="preview">
+    {candidate.effective_text.slice(0, 150)}{candidate.effective_text.length > 150 ? '…' : ''}
+  </span>
+</button>
+
+<style>
+  .candidate-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 5px 9px;
+    width: 100%;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 11px;
+    text-align: left;
+    color: var(--text);
+    background: var(--surface);
+  }
+
+  .candidate-card:hover,
+  .candidate-card.selected {
+    border-color: var(--accent);
+    background: #fffaf5;
+  }
+
+  strong,
+  .preview {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .identity,
+  .preview {
+    grid-column: 1 / -1;
+  }
+
+  .preview {
+    line-height: 1.35;
+    font-size: 0.9rem;
+  }
+
+  .state {
+    align-self: start;
+    border-radius: 999px;
+    padding: 2px 7px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: white;
+    background: var(--muted);
+  }
+
+  .state-in_review { background: var(--warn); }
+  .state-approved { background: var(--ok); }
+  .state-rejected { background: var(--err); }
+</style>

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -14,6 +14,7 @@
     { view: 'timeline' as const, label: 'Timeline', hash: '#/timeline' },
     { view: 'stats' as const, label: 'Stats', hash: '#/stats' },
     { view: 'editor' as const, label: 'Editor', hash: '#/editor' },
+    { view: 'tritalele' as const, label: 'TritaLeLe', hash: '#/tritalele' },
     { view: 'vault' as const, label: 'Vault', hash: '#/vault' },
     { view: 'duplicates' as const, label: 'Duplicates', hash: '#/duplicates' },
     { view: 'ops' as const, label: 'Ops', hash: '#/ops' },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -194,21 +194,153 @@ export interface DuplicateQuery {
   limit?: number | null
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
-  const resp = await fetch(path, init)
-  const data = await resp.json().catch(() => ({}))
-  if (!resp.ok) {
-    const detail = (data as { detail?: unknown }).detail
-    const msg =
+export type CandidateState = 'staged' | 'in_review' | 'rejected' | 'approved'
+export type SourceKind = 'markdown' | 'plain_text' | 'stdin' | 'in_memory'
+
+export interface ApprovalDestination {
+  lesson_id: string
+  relative_vault_path: string
+}
+
+export interface CandidateProvenance {
+  source_kind: SourceKind
+  source_logical_name: string
+  source_fingerprint: string
+  ingested_at: string
+  chunk_index: number | null
+  source_span: { start: number; end: number } | null
+  run_metadata: Record<string, unknown>
+  transformations: Record<string, unknown>[]
+}
+
+export interface CandidateReviewEvent {
+  revision: number
+  action: 'revised' | 'accepted' | 'rejected' | 'approved'
+  occurred_at: string
+  previous_state: CandidateState
+  resulting_state: CandidateState
+  reason: string | null
+}
+
+export interface CanonicalMetadata {
+  topic: string
+  source: string
+  importance: number
+  tags: string[]
+  date: string
+  title: string
+}
+
+export interface Candidate {
+  candidate_id: string
+  state: CandidateState
+  revision: number
+  original_text: string
+  proposed_text: string | null
+  effective_text: string
+  proposed_metadata: CanonicalMetadata | null
+  approval_destination: ApprovalDestination | null
+  provenance: CandidateProvenance
+  review_history: CandidateReviewEvent[]
+}
+
+export interface RawSourceInput {
+  content: string
+  source_kind: SourceKind
+  logical_name: string
+  max_characters: number
+}
+
+export interface IngestionResult {
+  preview: boolean
+  source: { kind: SourceKind; logical_name: string; fingerprint: string }
+  chunking: { max_characters: number }
+  candidate_ids: string[]
+  created_candidate_ids: string[]
+  skipped_candidate_ids: string[]
+  pending_candidate_ids: string[]
+  counts: { planned: number; created: number; skipped: number; pending: number }
+  candidates: Candidate[]
+}
+
+export interface CandidateFilters {
+  state?: CandidateState | ''
+  source_kind?: SourceKind | ''
+  source_fingerprint?: string
+  source_logical_name?: string
+  chunk_index?: number | null
+}
+
+export interface CandidateListResponse {
+  count: number
+  candidates: Candidate[]
+}
+
+export interface CandidateRevisionInput {
+  expected_revision: number
+  proposed_text?: string
+  proposed_metadata?: CanonicalMetadata
+  reason?: string
+}
+
+export interface ApprovalResult {
+  candidate_id: string
+  candidate_revision: number
+  lesson_id: string
+  relative_vault_path: string
+  vault_write_outcome: 'created' | 'identical'
+  candidate_state_changed: boolean
+  refresh_outcome: { refreshed: boolean }
+}
+
+export interface ApiErrorDetail {
+  code: string
+  message: string
+  recovery?: Record<string, unknown> | null
+}
+
+function isApiErrorDetail(value: unknown): value is ApiErrorDetail {
+  if (typeof value !== 'object' || value === null) return false
+  const candidate = value as Record<string, unknown>
+  return typeof candidate.code === 'string' && typeof candidate.message === 'string'
+}
+
+export class ApiError extends Error {
+  readonly status: number
+  readonly detail: unknown
+  readonly code: string | null
+  readonly recovery: Record<string, unknown> | null
+
+  constructor(status: number, detail: unknown) {
+    const message =
       typeof detail === 'string'
         ? detail
         : detail != null
           ? JSON.stringify(detail)
-          : `HTTP ${resp.status}`
-    throw new Error(msg)
+          : `HTTP ${status}`
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.detail = detail
+    this.code = isApiErrorDetail(detail) ? detail.code : null
+    this.recovery = isApiErrorDetail(detail) ? (detail.recovery ?? null) : null
+  }
+}
+
+async function responseError(resp: Response): Promise<ApiError> {
+  const data = (await resp.json().catch(() => ({}))) as { detail?: unknown }
+  return new ApiError(resp.status, data.detail)
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const resp = await fetch(path, init)
+  const data = await resp.json().catch(() => ({}))
+  if (!resp.ok) {
+    throw new ApiError(resp.status, (data as { detail?: unknown }).detail)
   }
   return data as T
 }
+
 
 export const api = {
   health: () => request<HealthResponse>('/health'),
@@ -242,15 +374,7 @@ export const api = {
       body: JSON.stringify(body),
     })
     if (!resp.ok) {
-      const data = await resp.json().catch(() => ({}))
-      const detail = (data as { detail?: unknown }).detail
-      const msg =
-        typeof detail === 'string'
-          ? detail
-          : detail != null
-            ? JSON.stringify(detail)
-            : `HTTP ${resp.status}`
-      throw new Error(msg)
+      throw await responseError(resp)
     }
     if (format === 'json') {
       return (await resp.json()) as ExportSearchResponse
@@ -315,4 +439,79 @@ export const api = {
 
   statsTimeline: (groupBy: 'year' | 'month' | 'topic' = 'month') =>
     request<TimelineResponse>(`/stats/timeline?group_by=${encodeURIComponent(groupBy)}`),
+
+  previewIngestion: (body: RawSourceInput) =>
+    request<IngestionResult>('/api/v1/tritalele/ingestion/preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+
+  stageIngestion: (body: RawSourceInput) =>
+    request<IngestionResult>('/api/v1/tritalele/ingestion/stage', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+
+  listCandidates: (filters: CandidateFilters = {}) => {
+    const query = new URLSearchParams()
+    if (filters.state) query.set('state', filters.state)
+    if (filters.source_kind) query.set('source_kind', filters.source_kind)
+    if (filters.source_fingerprint?.trim()) {
+      query.set('source_fingerprint', filters.source_fingerprint.trim())
+    }
+    if (filters.source_logical_name?.trim()) {
+      query.set('source_logical_name', filters.source_logical_name.trim())
+    }
+    if (filters.chunk_index != null) query.set('chunk_index', String(filters.chunk_index))
+    const suffix = query.size ? `?${query.toString()}` : ''
+    return request<CandidateListResponse>(`/api/v1/tritalele/candidates${suffix}`)
+  },
+
+  getCandidate: (candidateId: string) =>
+    request<Candidate>(`/api/v1/tritalele/candidates/${encodeURIComponent(candidateId)}`),
+
+  reviseCandidate: (candidateId: string, body: CandidateRevisionInput) =>
+    request<Candidate>(`/api/v1/tritalele/candidates/${encodeURIComponent(candidateId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+
+  acceptCandidate: (candidateId: string, expectedRevision: number, reason?: string) =>
+    request<Candidate>(
+      `/api/v1/tritalele/candidates/${encodeURIComponent(candidateId)}/accept`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          expected_revision: expectedRevision,
+          ...(reason?.trim() ? { reason: reason.trim() } : {}),
+        }),
+      },
+    ),
+
+  rejectCandidate: (candidateId: string, expectedRevision: number, reason?: string) =>
+    request<Candidate>(
+      `/api/v1/tritalele/candidates/${encodeURIComponent(candidateId)}/reject`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          expected_revision: expectedRevision,
+          ...(reason?.trim() ? { reason: reason.trim() } : {}),
+        }),
+      },
+    ),
+
+  approveCandidate: (candidateId: string, expectedRevision: number) =>
+    request<ApprovalResult>(
+      `/api/v1/tritalele/candidates/${encodeURIComponent(candidateId)}/approve`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ expected_revision: expectedRevision }),
+      },
+    ),
 }

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -7,6 +7,7 @@ export type Route =
   | { view: 'duplicates' }
   | { view: 'stats' }
   | { view: 'timeline' }
+  | { view: 'tritalele' }
 
 export function parseRoute(hash = location.hash): Route {
   const path = hash.replace(/^#/, '') || '/'
@@ -17,6 +18,7 @@ export function parseRoute(hash = location.hash): Route {
   if (path === '/vault') return { view: 'vault' }
   if (path === '/stats') return { view: 'stats' }
   if (path === '/timeline') return { view: 'timeline' }
+  if (path === '/tritalele') return { view: 'tritalele' }
   if (path === '/editor') return { view: 'editor' }
 
   const editorMatch = path.match(/^\/editor\/(.+)$/)
@@ -42,6 +44,8 @@ export function routeToHash(route: Route): string {
       return '#/stats'
     case 'timeline':
       return '#/timeline'
+    case 'tritalele':
+      return '#/tritalele'
     case 'editor':
       return route.id ? `#/editor/${encodeURIComponent(route.id)}` : '#/editor'
     case 'detail':

--- a/frontend/src/routes/TritaLeLe.svelte
+++ b/frontend/src/routes/TritaLeLe.svelte
@@ -1,0 +1,1126 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import {
+    ApiError,
+    api,
+    type ApprovalResult,
+    type Candidate,
+    type CandidateFilters,
+    type CandidateState,
+    type CanonicalMetadata,
+    type IngestionResult,
+    type RawSourceInput,
+    type SourceKind,
+    type VaultTreeNode,
+  } from '../lib/api'
+  import { renderMarkdown } from '../lib/markdown'
+  import CandidateCard from '../components/CandidateCard.svelte'
+
+  type ReadBackState = 'idle' | 'loading' | 'ok' | 'error'
+
+  let sourceContent = $state('')
+  let sourceKind = $state<SourceKind>('plain_text')
+  let logicalName = $state('pasted-note.txt')
+  let maxCharacters = $state(2000)
+  let loadedFileName = $state('')
+  let inputVersion = $state(0)
+  let fileRequest = 0
+  let previewRequest = 0
+  let stageRequest = 0
+
+  let preview = $state<IngestionResult | null>(null)
+  let previewVersion = $state(-1)
+  let previewLoading = $state(false)
+  let staging = $state(false)
+  let ingestionError = $state('')
+  let stageResult = $state<IngestionResult | null>(null)
+
+  let stateFilter = $state<CandidateState | ''>('')
+  let kindFilter = $state<SourceKind | ''>('')
+  let nameFilter = $state('')
+  let fingerprintFilter = $state('')
+  let chunkFilter = $state('')
+  let candidates = $state<Candidate[]>([])
+  let candidatesLoading = $state(true)
+  let candidatesError = $state('')
+  let listRequest = 0
+
+  let selectedId = $state<string | null>(null)
+  let candidate = $state<Candidate | null>(null)
+  let detailLoading = $state(false)
+  let detailError = $state('')
+  let detailRequest = 0
+  let actionRequest = 0
+  let mutating = $state(false)
+  let actionMessage = $state('')
+  let actionError = $state('')
+  let transitionReason = $state('')
+
+  let proposedText = $state('')
+  let metadataTopic = $state('')
+  let metadataSource = $state('note')
+  let metadataImportance = $state(3)
+  let metadataTags = $state('')
+  let metadataDate = $state(new Date().toISOString().slice(0, 10))
+  let metadataTitle = $state('')
+  let revisionReason = $state('')
+
+  let approvalDialog = $state(false)
+  let approving = $state(false)
+  let approvalResult = $state<ApprovalResult | null>(null)
+  let approvalWarning = $state('')
+  let recoveryDetails = $state<Record<string, unknown> | null>(null)
+  let readBackRequest = 0
+  let lessonReadBack = $state<ReadBackState>('idle')
+  let lessonReadBackMessage = $state('')
+  let vaultReadBack = $state<ReadBackState>('idle')
+  let vaultReadBackMessage = $state('')
+
+  function sourcePayload(): RawSourceInput {
+    return {
+      content: sourceContent,
+      source_kind: sourceKind,
+      logical_name: logicalName.trim(),
+      max_characters: Number(maxCharacters),
+    }
+  }
+
+  function invalidatePreview() {
+    inputVersion += 1
+    previewRequest += 1
+    stageRequest += 1
+    preview = null
+    previewVersion = -1
+    previewLoading = false
+    staging = false
+    stageResult = null
+    ingestionError = ''
+  }
+
+  function sourceChanged() {
+    fileRequest += 1
+    loadedFileName = ''
+    invalidatePreview()
+  }
+
+  function sourceSettingsChanged() {
+    fileRequest += 1
+    invalidatePreview()
+  }
+
+  async function loadFile(event: Event) {
+    const input = event.currentTarget as HTMLInputElement
+    const file = input.files?.[0]
+    const request = ++fileRequest
+    invalidatePreview()
+    if (!file) {
+      loadedFileName = ''
+      return
+    }
+    ingestionError = ''
+    try {
+      const content = await file.text()
+      if (request !== fileRequest) return
+      sourceContent = content
+      logicalName = file.name
+      sourceKind = /\.(md|markdown)$/i.test(file.name) ? 'markdown' : 'plain_text'
+      loadedFileName = file.name
+      invalidatePreview()
+    } catch {
+      if (request !== fileRequest) return
+      ingestionError = 'Impossibile leggere il file selezionato.'
+    }
+  }
+
+  function displayError(error: unknown, context: string): string {
+    if (!(error instanceof ApiError)) {
+      return `${context}: ${error instanceof Error ? error.message : String(error)}`
+    }
+    if (error.status === 409) {
+      return `Conflitto (409${error.code ? ` · ${error.code}` : ''}). Ricarica il candidato e riprova.`
+    }
+    if (error.status === 422) {
+      return 'Dati non validi (422). Controlla i campi della richiesta.'
+    }
+    if (error.status === 503) {
+      return `Errore operativo (503${error.code ? ` · ${error.code}` : ''}). I dati già persistiti non vengono nascosti.`
+    }
+    if (error.status === 400) {
+      return `Richiesta non valida${error.code ? ` (${error.code})` : ''}.`
+    }
+    return `${context}: ${error.message}`
+  }
+
+  async function runPreview() {
+    if (!sourceContent.trim() || !logicalName.trim()) {
+      ingestionError = 'Testo sorgente e nome logico sono obbligatori.'
+      return
+    }
+    const request = ++previewRequest
+    const version = inputVersion
+    previewLoading = true
+    ingestionError = ''
+    stageResult = null
+    try {
+      const result = await api.previewIngestion(sourcePayload())
+      if (request !== previewRequest || version !== inputVersion) return
+      preview = result
+      previewVersion = version
+    } catch (error) {
+      if (request !== previewRequest || version !== inputVersion) return
+      preview = null
+      previewVersion = -1
+      ingestionError = displayError(error, 'Anteprima non riuscita')
+    } finally {
+      if (request === previewRequest && version === inputVersion) previewLoading = false
+    }
+  }
+
+  async function runStage() {
+    if (!preview || previewVersion !== inputVersion) {
+      ingestionError = 'Genera una nuova anteprima prima di creare lo staging.'
+      return
+    }
+    const request = ++stageRequest
+    const version = inputVersion
+    staging = true
+    ingestionError = ''
+    try {
+      const result = await api.stageIngestion(sourcePayload())
+      if (request !== stageRequest || version !== inputVersion) return
+      stageResult = result
+      await loadCandidates()
+    } catch (error) {
+      if (request !== stageRequest || version !== inputVersion) return
+      ingestionError = displayError(error, 'Staging non riuscito')
+      if (error instanceof ApiError) recoveryDetails = error.recovery
+    } finally {
+      if (request === stageRequest && version === inputVersion) staging = false
+    }
+  }
+
+  function filters(): CandidateFilters {
+    const parsedChunk = chunkFilter.trim() === '' ? null : Number(chunkFilter)
+    return {
+      state: stateFilter,
+      source_kind: kindFilter,
+      source_logical_name: nameFilter,
+      source_fingerprint: fingerprintFilter,
+      chunk_index:
+        parsedChunk !== null && Number.isInteger(parsedChunk) && parsedChunk >= 0
+          ? parsedChunk
+          : null,
+    }
+  }
+
+  async function loadCandidates(showLoading = true) {
+    const request = ++listRequest
+    if (showLoading) candidatesLoading = true
+    candidatesError = ''
+    try {
+      const result = await api.listCandidates(filters())
+      if (request !== listRequest) return
+      candidates = result.candidates
+    } catch (error) {
+      if (request !== listRequest) return
+      candidates = []
+      candidatesError = displayError(error, 'Lista candidati non disponibile')
+    } finally {
+      if (request === listRequest) candidatesLoading = false
+    }
+  }
+
+  function resetFilters() {
+    stateFilter = ''
+    kindFilter = ''
+    nameFilter = ''
+    fingerprintFilter = ''
+    chunkFilter = ''
+    loadCandidates()
+  }
+
+  function populateReviewForm(item: Candidate) {
+    proposedText = item.effective_text
+    const metadata = item.proposed_metadata
+    metadataTopic = metadata?.topic ?? ''
+    metadataSource = metadata?.source ?? 'note'
+    metadataImportance = metadata?.importance ?? 3
+    metadataTags = metadata?.tags.join(', ') ?? ''
+    metadataDate = metadata?.date ?? new Date().toISOString().slice(0, 10)
+    metadataTitle = metadata?.title ?? ''
+    revisionReason = ''
+    transitionReason = ''
+  }
+
+  function resetApprovalState() {
+    approvalDialog = false
+    approving = false
+    approvalResult = null
+    approvalWarning = ''
+    recoveryDetails = null
+    readBackRequest += 1
+    lessonReadBack = 'idle'
+    lessonReadBackMessage = ''
+    vaultReadBack = 'idle'
+    vaultReadBackMessage = ''
+  }
+
+  async function selectCandidate(item: Candidate) {
+    selectedId = item.candidate_id
+    candidate = null
+    detailLoading = true
+    detailError = ''
+    actionMessage = ''
+    actionError = ''
+    resetApprovalState()
+    const request = ++detailRequest
+    try {
+      const result = await api.getCandidate(item.candidate_id)
+      if (request !== detailRequest || selectedId !== item.candidate_id) return
+      candidate = result
+      populateReviewForm(result)
+    } catch (error) {
+      if (request !== detailRequest || selectedId !== item.candidate_id) return
+      detailError = displayError(error, 'Dettaglio non disponibile')
+    } finally {
+      if (request === detailRequest && selectedId === item.candidate_id) detailLoading = false
+    }
+  }
+
+  async function reloadSelected() {
+    const listItem = candidates.find((item) => item.candidate_id === selectedId)
+    if (listItem) {
+      await selectCandidate(listItem)
+      return
+    }
+    if (!selectedId) return
+    const placeholder = candidate
+    if (placeholder) await selectCandidate(placeholder)
+  }
+
+  function replaceCandidate(updated: Candidate) {
+    candidate = updated
+    candidates = candidates.map((item) =>
+      item.candidate_id === updated.candidate_id ? updated : item,
+    )
+    populateReviewForm(updated)
+  }
+
+  function reviewMetadata(): CanonicalMetadata | null {
+    const tags = metadataTags
+      .split(',')
+      .map((tag) => tag.trim())
+      .filter(Boolean)
+    if (
+      !metadataTopic.trim() ||
+      !metadataSource.trim() ||
+      !metadataTitle.trim() ||
+      !metadataDate.trim() ||
+      tags.length === 0 ||
+      !Number.isInteger(Number(metadataImportance)) ||
+      Number(metadataImportance) < 1 ||
+      Number(metadataImportance) > 5
+    ) {
+      return null
+    }
+    return {
+      topic: metadataTopic,
+      source: metadataSource,
+      importance: Number(metadataImportance),
+      tags,
+      date: metadataDate,
+      title: metadataTitle,
+    }
+  }
+
+  async function saveRevision() {
+    if (!candidate || candidate.state !== 'staged') return
+    const metadata = reviewMetadata()
+    if (!proposedText.trim() || !metadata) {
+      actionError = 'Testo e metadati completi sono obbligatori; inserisci almeno un tag.'
+      return
+    }
+    const textChanged = proposedText !== candidate.effective_text
+    const metadataChanged = JSON.stringify(metadata) !== JSON.stringify(candidate.proposed_metadata)
+    if (!textChanged && !metadataChanged) {
+      actionError = 'Nessuna modifica da salvare.'
+      return
+    }
+    const captured = candidate
+    const request = ++actionRequest
+    mutating = true
+    actionError = ''
+    actionMessage = ''
+    try {
+      const updated = await api.reviseCandidate(captured.candidate_id, {
+        expected_revision: captured.revision,
+        ...(textChanged ? { proposed_text: proposedText } : {}),
+        ...(metadataChanged ? { proposed_metadata: metadata } : {}),
+        ...(revisionReason.trim() ? { reason: revisionReason.trim() } : {}),
+      })
+      if (request !== actionRequest || selectedId !== captured.candidate_id) return
+      replaceCandidate(updated)
+      actionMessage = `Revisione ${updated.revision} salvata.`
+    } catch (error) {
+      if (request !== actionRequest || selectedId !== captured.candidate_id) return
+      actionError = displayError(error, 'Revisione non riuscita')
+      if (error instanceof ApiError) recoveryDetails = error.recovery
+    } finally {
+      if (request === actionRequest) mutating = false
+    }
+  }
+
+  async function acceptCandidate() {
+    if (!candidate || candidate.state !== 'staged') return
+    if (!candidate.approval_destination) {
+      actionError = 'Completa e salva i metadati canonici prima di accettare.'
+      return
+    }
+    const captured = candidate
+    const request = ++actionRequest
+    mutating = true
+    actionError = ''
+    actionMessage = ''
+    try {
+      const updated = await api.acceptCandidate(
+        captured.candidate_id,
+        captured.revision,
+        transitionReason,
+      )
+      if (request !== actionRequest || selectedId !== captured.candidate_id) return
+      replaceCandidate(updated)
+      actionMessage = `Candidato accettato per la revisione ${updated.revision}; non è ancora pubblicato.`
+    } catch (error) {
+      if (request !== actionRequest || selectedId !== captured.candidate_id) return
+      actionError = displayError(error, 'Accettazione non riuscita')
+      if (error instanceof ApiError) recoveryDetails = error.recovery
+    } finally {
+      if (request === actionRequest) mutating = false
+    }
+  }
+
+  async function rejectCandidate() {
+    if (!candidate || !['staged', 'in_review'].includes(candidate.state)) return
+    if (!transitionReason.trim()) {
+      actionError = 'Inserisci un motivo per rendere il rifiuto tracciabile.'
+      return
+    }
+    const captured = candidate
+    const request = ++actionRequest
+    mutating = true
+    actionError = ''
+    actionMessage = ''
+    try {
+      const updated = await api.rejectCandidate(
+        captured.candidate_id,
+        captured.revision,
+        transitionReason,
+      )
+      if (request !== actionRequest || selectedId !== captured.candidate_id) return
+      replaceCandidate(updated)
+      actionMessage = `Candidato rifiutato alla revisione ${updated.revision}; resta nello staging.`
+    } catch (error) {
+      if (request !== actionRequest || selectedId !== captured.candidate_id) return
+      actionError = displayError(error, 'Rifiuto non riuscito')
+      if (error instanceof ApiError) recoveryDetails = error.recovery
+    } finally {
+      if (request === actionRequest) mutating = false
+    }
+  }
+
+  function treeContainsPath(node: VaultTreeNode, relativePath: string): boolean {
+    if (node.type === 'file') return node.path === relativePath
+    return node.children?.some((child) => treeContainsPath(child, relativePath)) ?? false
+  }
+
+  async function runReadBacks(lessonId: string, relativePath: string) {
+    const request = ++readBackRequest
+    lessonReadBack = 'loading'
+    lessonReadBackMessage = 'Lettura proiezione in corso…'
+    vaultReadBack = 'loading'
+    vaultReadBackMessage = 'Lettura vault in corso…'
+
+    void api.getLesson(lessonId).then(
+      (lesson) => {
+        if (request !== readBackRequest) return
+        lessonReadBack = 'ok'
+        lessonReadBackMessage = `Lesson riletta: ${lesson.id}`
+      },
+      (error) => {
+        if (request !== readBackRequest) return
+        lessonReadBack = 'error'
+        lessonReadBackMessage = displayError(error, 'Read-back lesson fallito')
+      },
+    )
+
+    void api.vaultTree().then(
+      (tree) => {
+        if (request !== readBackRequest) return
+        if (treeContainsPath(tree.tree, relativePath)) {
+          vaultReadBack = 'ok'
+          vaultReadBackMessage = `File vault riletto: ${relativePath}`
+        } else {
+          vaultReadBack = 'error'
+          vaultReadBackMessage = `File non trovato nel read-back vault: ${relativePath}`
+        }
+      },
+      (error) => {
+        if (request !== readBackRequest) return
+        vaultReadBack = 'error'
+        vaultReadBackMessage = displayError(error, 'Read-back vault fallito')
+      },
+    )
+  }
+
+  function recoveredApproval(error: ApiError): ApprovalResult | null {
+    const raw = error.recovery?.partial_approval_result
+    if (typeof raw !== 'object' || raw === null) return null
+    const value = raw as Record<string, unknown>
+    if (
+      typeof value.candidate_id !== 'string' ||
+      typeof value.candidate_revision !== 'number' ||
+      typeof value.lesson_id !== 'string' ||
+      typeof value.relative_vault_path !== 'string' ||
+      (value.vault_write_outcome !== 'created' && value.vault_write_outcome !== 'identical')
+    ) {
+      return null
+    }
+    return value as unknown as ApprovalResult
+  }
+
+  async function refreshApprovedCandidate(candidateId: string, request: number) {
+    try {
+      const updated = await api.getCandidate(candidateId)
+      if (request !== actionRequest || selectedId !== candidateId) return
+      replaceCandidate(updated)
+    } catch {
+      // The publication outcome and the two explicit read-backs remain independently visible.
+    }
+  }
+
+  async function confirmApproval() {
+    if (approving || !candidate || candidate.state !== 'in_review') return
+    const destination = candidate.approval_destination
+    if (!destination) return
+    const captured = candidate
+    const request = ++actionRequest
+    approving = true
+    mutating = true
+    actionError = ''
+    actionMessage = ''
+    approvalWarning = ''
+    recoveryDetails = null
+    try {
+      const result = await api.approveCandidate(captured.candidate_id, captured.revision)
+      if (request !== actionRequest || selectedId !== captured.candidate_id) return
+      approvalResult = result
+      approvalDialog = false
+      actionMessage =
+        result.vault_write_outcome === 'created'
+          ? `Approvazione completata: creato ${result.relative_vault_path}.`
+          : `Approvazione verificata: file canonico identico ${result.relative_vault_path}.`
+      await refreshApprovedCandidate(captured.candidate_id, request)
+      void runReadBacks(result.lesson_id, result.relative_vault_path)
+    } catch (error) {
+      if (request !== actionRequest || selectedId !== captured.candidate_id) return
+      if (error instanceof ApiError && error.code === 'partial_refresh') {
+        const recovered = recoveredApproval(error)
+        approvalDialog = false
+        approvalResult = recovered
+        approvalWarning =
+          'Approvazione persistita, ma refresh della proiezione fallito (partial_refresh). Verifica i read-back separati.'
+        recoveryDetails = error.recovery
+        await refreshApprovedCandidate(captured.candidate_id, request)
+        if (recovered) void runReadBacks(recovered.lesson_id, recovered.relative_vault_path)
+      } else {
+        actionError = displayError(error, 'Approvazione non riuscita')
+        if (error instanceof ApiError) recoveryDetails = error.recovery
+      }
+    } finally {
+      if (request === actionRequest) {
+        approving = false
+        mutating = false
+      }
+    }
+  }
+
+  onMount(() => {
+    loadCandidates()
+  })
+</script>
+
+<div class="tritalele">
+  <section class="card ingestion" aria-labelledby="ingestion-title">
+    <div class="section-head">
+      <div>
+        <h2 id="ingestion-title">TritaLeLe</h2>
+        <p class="meta">Prepara candidati deterministici da Markdown o testo; la preview non scrive nello staging.</p>
+      </div>
+      {#if loadedFileName}<span class="tag">file: {loadedFileName}</span>{/if}
+    </div>
+
+    <div class="source-grid">
+      <label>
+        File Markdown o testo
+        <input type="file" accept=".md,.markdown,.txt,text/markdown,text/plain" onchange={loadFile} />
+      </label>
+      <label>
+        Tipo sorgente
+        <select bind:value={sourceKind} onchange={sourceSettingsChanged}>
+          <option value="plain_text">plain_text</option>
+          <option value="markdown">markdown</option>
+        </select>
+      </label>
+      <label>
+        Nome logico
+        <input bind:value={logicalName} oninput={sourceSettingsChanged} />
+      </label>
+      <label>
+        Caratteri massimi per chunk
+        <input type="number" min="1" bind:value={maxCharacters} oninput={sourceSettingsChanged} />
+      </label>
+    </div>
+    <label class="source-text">
+      Testo sorgente
+      <textarea
+        rows="8"
+        bind:value={sourceContent}
+        oninput={sourceChanged}
+        placeholder="Incolla qui testo plain text o Markdown…"
+      ></textarea>
+    </label>
+    <div class="actions">
+      <button class="btn" onclick={runPreview} disabled={previewLoading || staging}>
+        {previewLoading ? 'Anteprima…' : 'Genera anteprima'}
+      </button>
+      <button
+        class="btn btn-primary"
+        onclick={runStage}
+        disabled={!preview || previewVersion !== inputVersion || previewLoading || staging}
+      >
+        {staging ? 'Creazione staging…' : 'Crea staging'}
+      </button>
+    </div>
+    {#if ingestionError}<p class="error" role="alert">{ingestionError}</p>{/if}
+
+    {#if preview}
+      <div class="preview-block" data-testid="ingestion-preview">
+        <h3>Anteprima (nessuna scrittura)</h3>
+        <p class="meta">
+          {preview.counts.planned} pianificati · {preview.counts.pending} nuovi · {preview.counts.skipped} già presenti
+        </p>
+        <ol>
+          {#each preview.candidates as item}
+            <li>
+              <code>{item.candidate_id.slice(7, 19)}</code>
+              <span>{item.effective_text.slice(0, 180)}</span>
+            </li>
+          {/each}
+        </ol>
+      </div>
+    {/if}
+
+    {#if stageResult}
+      <div class="stage-result ok" role="status">
+        Staging completato: {stageResult.counts.created} created, {stageResult.counts.skipped} identical/skipped.
+      </div>
+    {/if}
+  </section>
+
+  <section class="review-layout">
+    <div class="candidate-column">
+      <section class="card filters" aria-labelledby="candidate-list-title">
+        <div class="section-head">
+          <h2 id="candidate-list-title">Candidati in staging</h2>
+          <button class="btn" onclick={() => loadCandidates()} disabled={candidatesLoading}>Aggiorna</button>
+        </div>
+        <div class="filter-grid">
+          <label>
+            Stato
+            <select bind:value={stateFilter}>
+              <option value="">tutti</option>
+              <option value="staged">staged</option>
+              <option value="in_review">in_review</option>
+              <option value="rejected">rejected</option>
+              <option value="approved">approved</option>
+            </select>
+          </label>
+          <label>
+            Tipo
+            <select bind:value={kindFilter}>
+              <option value="">tutti</option>
+              <option value="markdown">markdown</option>
+              <option value="plain_text">plain_text</option>
+              <option value="stdin">stdin</option>
+              <option value="in_memory">in_memory</option>
+            </select>
+          </label>
+          <label>Nome sorgente <input bind:value={nameFilter} /></label>
+          <label>Chunk <input type="number" min="0" bind:value={chunkFilter} /></label>
+          <label class="wide-filter">Fingerprint <input bind:value={fingerprintFilter} /></label>
+        </div>
+        <div class="actions compact">
+          <button class="btn btn-primary" onclick={() => loadCandidates()}>Applica filtri</button>
+          <button class="btn" onclick={resetFilters}>Reset filtri</button>
+        </div>
+        {#if candidatesError}<p class="error" role="alert">{candidatesError}</p>{/if}
+      </section>
+
+      <div class="candidate-list" aria-live="polite">
+        {#if candidatesLoading}
+          <p class="meta">Caricamento candidati…</p>
+        {:else if candidates.length === 0}
+          <p class="card meta empty">Nessun candidato corrisponde ai filtri.</p>
+        {:else}
+          {#each candidates as item (item.candidate_id)}
+            <CandidateCard
+              candidate={item}
+              selected={selectedId === item.candidate_id}
+              onclick={() => selectCandidate(item)}
+            />
+          {/each}
+        {/if}
+      </div>
+    </div>
+
+    <div class="detail-column">
+      {#if !selectedId}
+        <section class="card empty detail-empty">
+          <h2>Dettaglio candidato</h2>
+          <p class="meta">Nessuna selezione. Scegli esplicitamente un candidato dalla lista.</p>
+        </section>
+      {:else if detailLoading}
+        <section class="card"><p class="meta">Caricamento dettaglio…</p></section>
+      {:else if detailError}
+        <section class="card">
+          <p class="error" role="alert">{detailError}</p>
+          <button class="btn" onclick={reloadSelected}>Riprova</button>
+        </section>
+      {:else if candidate}
+        <section class="card candidate-detail" aria-labelledby="candidate-detail-title">
+          <div class="section-head">
+            <div>
+              <h2 id="candidate-detail-title">Dettaglio candidato</h2>
+              <code>{candidate.candidate_id}</code>
+            </div>
+            <span class={`state state-${candidate.state}`}>{candidate.state} · rev {candidate.revision}</span>
+          </div>
+
+          <details open>
+            <summary>Provenienza</summary>
+            <dl>
+              <dt>Sorgente</dt><dd>{candidate.provenance.source_logical_name}</dd>
+              <dt>Tipo</dt><dd>{candidate.provenance.source_kind}</dd>
+              <dt>Fingerprint</dt><dd><code>{candidate.provenance.source_fingerprint}</code></dd>
+              <dt>Chunk</dt><dd>{candidate.provenance.chunk_index ?? '—'}</dd>
+              <dt>Span</dt><dd>{candidate.provenance.source_span ? `${candidate.provenance.source_span.start}–${candidate.provenance.source_span.end}` : '—'}</dd>
+              <dt>Ingested at</dt><dd>{candidate.provenance.ingested_at}</dd>
+            </dl>
+            {#if Object.keys(candidate.provenance.run_metadata).length || candidate.provenance.transformations.length}
+              <pre>{JSON.stringify({ run_metadata: candidate.provenance.run_metadata, transformations: candidate.provenance.transformations }, null, 2)}</pre>
+            {/if}
+          </details>
+
+          <div class="review-form">
+            <label>
+              Testo proposto
+              <textarea rows="11" bind:value={proposedText} disabled={candidate.state !== 'staged'}></textarea>
+            </label>
+            <div class="metadata-grid">
+              <label>Topic <input bind:value={metadataTopic} disabled={candidate.state !== 'staged'} /></label>
+              <label>Source <input bind:value={metadataSource} disabled={candidate.state !== 'staged'} /></label>
+              <label>Importance <input type="number" min="1" max="5" bind:value={metadataImportance} disabled={candidate.state !== 'staged'} /></label>
+              <label>Date <input type="date" bind:value={metadataDate} disabled={candidate.state !== 'staged'} /></label>
+              <label class="wide">Tags <input bind:value={metadataTags} placeholder="python, pytest" disabled={candidate.state !== 'staged'} /></label>
+              <label class="wide">Title <input bind:value={metadataTitle} disabled={candidate.state !== 'staged'} /></label>
+            </div>
+            {#if candidate.state === 'staged'}
+              <label>Motivo revisione (opzionale) <input bind:value={revisionReason} /></label>
+              <button class="btn" onclick={saveRevision} disabled={mutating}>Salva revisione</button>
+            {/if}
+          </div>
+
+          <div class="markdown-preview">
+            <h3>Preview testo effettivo</h3>
+            <article class="markdown-body">{@html renderMarkdown(proposedText)}</article>
+          </div>
+
+          {#if candidate.approval_destination}
+            <div class="destination" data-testid="approval-destination">
+              <strong>Destinazione canonica calcolata dal backend</strong>
+              <code>{candidate.approval_destination.lesson_id}</code>
+              <code>{candidate.approval_destination.relative_vault_path}</code>
+            </div>
+          {:else}
+            <p class="meta">Destinazione non calcolabile: completa e salva i metadati.</p>
+          {/if}
+
+          {#if candidate.state === 'staged' || candidate.state === 'in_review'}
+            <label>
+              Motivo transizione {candidate.state === 'staged' ? '(obbligatorio per rifiutare)' : '(obbligatorio per rifiutare)'}
+              <input bind:value={transitionReason} />
+            </label>
+            <div class="actions">
+              {#if candidate.state === 'staged'}
+                <button
+                  class="btn btn-primary"
+                  onclick={acceptCandidate}
+                  disabled={mutating || !candidate.approval_destination}
+                >
+                  Accetta per revisione
+                </button>
+              {/if}
+              <button class="btn danger" onclick={rejectCandidate} disabled={mutating || !transitionReason.trim()}>
+                Rifiuta candidato
+              </button>
+              {#if candidate.state === 'in_review'}
+                <button
+                  class="btn btn-primary"
+                  onclick={() => (approvalDialog = true)}
+                  disabled={mutating || !candidate.approval_destination}
+                >
+                  Approva nel vault
+                </button>
+              {/if}
+            </div>
+          {/if}
+
+          {#if actionMessage}<p class="ok" role="status">{actionMessage}</p>{/if}
+          {#if actionError}
+            <div class="action-error" role="alert">
+              <p class="error">{actionError}</p>
+              {#if actionError.includes('409')}
+                <button class="btn" onclick={reloadSelected}>Ricarica candidato</button>
+              {/if}
+            </div>
+          {/if}
+          {#if approvalWarning}<p class="warning" role="status">{approvalWarning}</p>{/if}
+          {#if recoveryDetails}
+            <details class="recovery">
+              <summary>Dettagli di recupero</summary>
+              <pre>{JSON.stringify(recoveryDetails, null, 2)}</pre>
+            </details>
+          {/if}
+          {#if approvalResult}
+            <div class="approval-result" data-testid="approval-result">
+              <h3>Esito approvazione: {approvalResult.vault_write_outcome}</h3>
+              <p><code>{approvalResult.lesson_id}</code></p>
+              <p><code>{approvalResult.relative_vault_path}</code></p>
+            </div>
+          {/if}
+          {#if lessonReadBack !== 'idle' || vaultReadBack !== 'idle'}
+            <div class="readbacks" aria-label="Read-back approvazione">
+              <p class:ok={lessonReadBack === 'ok'} class:error={lessonReadBack === 'error'}>{lessonReadBackMessage}</p>
+              <p class:ok={vaultReadBack === 'ok'} class:error={vaultReadBack === 'error'}>{vaultReadBackMessage}</p>
+            </div>
+          {/if}
+
+          <details class="history" open>
+            <summary>History ({candidate.review_history.length})</summary>
+            {#if candidate.review_history.length === 0}
+              <p class="meta">Nessuna revisione registrata.</p>
+            {:else}
+              <ol>
+                {#each candidate.review_history as event}
+                  <li>
+                    <strong>rev {event.revision} · {event.action}</strong>
+                    <span>{event.previous_state} → {event.resulting_state}</span>
+                    <time>{event.occurred_at}</time>
+                    {#if event.reason}<q>{event.reason}</q>{/if}
+                  </li>
+                {/each}
+              </ol>
+            {/if}
+          </details>
+        </section>
+      {/if}
+    </div>
+  </section>
+</div>
+
+{#if approvalDialog && candidate?.approval_destination}
+  <div class="dialog-backdrop" role="presentation">
+    <div class="approval-dialog card" role="dialog" aria-modal="true" aria-labelledby="approval-title">
+      <h2 id="approval-title">Conferma approvazione canonica</h2>
+      <p>Questa è l’unica azione che pubblica nel vault.</p>
+      <dl>
+        <dt>Candidato</dt><dd><code>{candidate.candidate_id}</code></dd>
+        <dt>Revisione</dt><dd>{candidate.revision}</dd>
+        <dt>Lesson ID</dt><dd><code>{candidate.approval_destination.lesson_id}</code></dd>
+        <dt>Path canonico</dt><dd><code>{candidate.approval_destination.relative_vault_path}</code></dd>
+      </dl>
+      {#if actionError}<p class="error" role="alert">{actionError}</p>{/if}
+      {#if recoveryDetails}
+        <details class="recovery">
+          <summary>Dettagli di recupero</summary>
+          <pre>{JSON.stringify(recoveryDetails, null, 2)}</pre>
+        </details>
+      {/if}
+      <div class="actions">
+        <button class="btn" onclick={() => (approvalDialog = false)} disabled={approving}>Annulla</button>
+        <button class="btn btn-primary" onclick={confirmApproval} disabled={approving}>
+          {approving ? 'Approvazione…' : 'Conferma approvazione'}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .tritalele,
+  .candidate-column,
+  .detail-column,
+  .candidate-list {
+    display: grid;
+    gap: 14px;
+  }
+
+  .section-head,
+  .actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  h2,
+  h3,
+  p {
+    margin-top: 0;
+  }
+
+  .source-grid,
+  .filter-grid,
+  .metadata-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .source-text,
+  .review-form,
+  .review-form > label,
+  .candidate-detail > label {
+    margin-top: 12px;
+  }
+
+  label {
+    display: grid;
+    gap: 5px;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+
+  input,
+  select,
+  textarea {
+    width: 100%;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    color: var(--text);
+    background: white;
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  input:disabled,
+  textarea:disabled {
+    background: #f3efe8;
+  }
+
+  .ingestion > .actions,
+  .compact {
+    justify-content: flex-start;
+    margin-top: 12px;
+  }
+
+  .preview-block,
+  .destination,
+  .approval-result,
+  .readbacks {
+    margin-top: 14px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: #fffdf9;
+  }
+
+  .preview-block ol,
+  .history ol {
+    display: grid;
+    gap: 8px;
+    margin-bottom: 0;
+    padding-left: 22px;
+  }
+
+  .preview-block li,
+  .history li,
+  .destination {
+    display: grid;
+    gap: 4px;
+  }
+
+  .stage-result {
+    margin-top: 12px;
+  }
+
+  .review-layout {
+    display: grid;
+    grid-template-columns: minmax(280px, 0.75fr) minmax(420px, 1.25fr);
+    gap: 16px;
+    align-items: start;
+  }
+
+  .candidate-column,
+  .detail-column {
+    min-width: 0;
+  }
+
+  .candidate-list {
+    max-height: 76vh;
+    overflow-y: auto;
+  }
+
+  .empty {
+    text-align: center;
+  }
+
+  .detail-empty {
+    min-height: 180px;
+    align-content: center;
+  }
+
+  code,
+  dd {
+    overflow-wrap: anywhere;
+  }
+
+  .state {
+    border-radius: 999px;
+    padding: 4px 9px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: white;
+    background: var(--muted);
+  }
+
+  .state-in_review { background: var(--warn); }
+  .state-approved { background: var(--ok); }
+  .state-rejected { background: var(--err); }
+
+  details {
+    margin-top: 14px;
+  }
+
+  summary {
+    cursor: pointer;
+    font-weight: 700;
+    margin-bottom: 9px;
+  }
+
+  dl {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 6px 12px;
+    margin: 10px 0;
+  }
+
+  dt {
+    color: var(--muted);
+    font-size: 0.82rem;
+  }
+
+  dd {
+    margin: 0;
+  }
+
+  pre {
+    overflow-x: auto;
+    padding: 10px;
+    border-radius: 8px;
+    background: #f3efe8;
+    white-space: pre-wrap;
+  }
+
+  .review-form,
+  .markdown-preview {
+    margin-top: 16px;
+    padding-top: 14px;
+    border-top: 1px solid var(--border);
+  }
+
+  .review-form > .btn {
+    margin-top: 10px;
+  }
+
+  .wide,
+  .wide-filter {
+    grid-column: 1 / -1;
+  }
+
+  .danger {
+    border-color: var(--err);
+    color: var(--err);
+  }
+
+  .warning {
+    color: var(--warn);
+    font-weight: 600;
+  }
+
+  .history li span,
+  .history li time,
+  .history li q {
+    display: block;
+    font-size: 0.82rem;
+    color: var(--muted);
+  }
+
+  .dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+    display: grid;
+    place-items: center;
+    padding: 20px;
+    background: rgba(31, 27, 22, 0.55);
+  }
+
+  .approval-dialog {
+    width: min(680px, 100%);
+    max-height: 90vh;
+    overflow-y: auto;
+  }
+
+  .approval-dialog .actions {
+    justify-content: flex-end;
+    margin-top: 18px;
+  }
+
+  @media (max-width: 1000px) {
+    .review-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .candidate-list {
+      max-height: none;
+    }
+  }
+
+  @media (max-width: 650px) {
+    .source-grid,
+    .filter-grid,
+    .metadata-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .wide,
+    .wide-filter {
+      grid-column: auto;
+    }
+  }
+</style>

--- a/scripts/e2e-prepare.py
+++ b/scripts/e2e-prepare.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prepare isolated data, model, and vault fixtures for Playwright E2E tests."""
+"""Prepare isolated data, model, staging, and vault fixtures for Playwright."""
 
 from __future__ import annotations
 
@@ -12,9 +12,11 @@ import pandas as pd
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_DIR = ROOT / ".e2e-fixture"
-DATA_PATH = FIXTURE_DIR / "lessons.jsonl"
-MODEL_PATH = FIXTURE_DIR / "topic_model.joblib"
+DATA_DIR = FIXTURE_DIR / "data"
+CACHE_DIR = FIXTURE_DIR / "cache"
 VAULT_DIR = FIXTURE_DIR / "vault"
+DATA_PATH = DATA_DIR / "lessons.jsonl"
+MODEL_PATH = CACHE_DIR / "topic_model.joblib"
 
 RECORDS = [
     {
@@ -64,9 +66,20 @@ RECORDS = [
 ]
 
 
+def reset_fixture() -> None:
+    """Reset only the dedicated E2E root, never personal runtime paths."""
+    if FIXTURE_DIR.is_symlink() or FIXTURE_DIR.is_file():
+        FIXTURE_DIR.unlink()
+    else:
+        shutil.rmtree(FIXTURE_DIR, ignore_errors=True)
+
+    DATA_DIR.mkdir(parents=True)
+    CACHE_DIR.mkdir(parents=True)
+    VAULT_DIR.mkdir(parents=True)
+
+
 def prepare_vault() -> None:
-    """Reset only the dedicated E2E vault to a known healthy state."""
-    shutil.rmtree(VAULT_DIR, ignore_errors=True)
+    """Create one healthy canonical lesson in the isolated E2E vault."""
     topic_dir = VAULT_DIR / "python"
     topic_dir.mkdir(parents=True)
     (topic_dir / "2025-01-01.e2e.md").write_text(
@@ -88,21 +101,30 @@ Healthy E2E vault lesson.
 
 def main() -> int:
     sys.path.insert(0, str(ROOT / "src"))
+
     from lele_manager.ml.features import TextFeatureConfig
-    from lele_manager.ml.topic_model import TopicModelConfig, save_topic_model, train_topic_model
+    from lele_manager.ml.topic_model import (
+        TopicModelConfig,
+        save_topic_model,
+        train_topic_model,
+    )
 
-    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+    reset_fixture()
     prepare_vault()
-    with DATA_PATH.open("w", encoding="utf-8") as f:
-        for rec in RECORDS:
-            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
 
-    df = pd.read_json(DATA_PATH, lines=True)
-    cfg = TopicModelConfig(text_features=TextFeatureConfig(min_df=1))
-    pipeline = train_topic_model(df, config=cfg)
+    with DATA_PATH.open("w", encoding="utf-8") as stream:
+        for record in RECORDS:
+            stream.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    dataframe = pd.read_json(DATA_PATH, lines=True)
+    config = TopicModelConfig(text_features=TextFeatureConfig(min_df=1))
+    pipeline = train_topic_model(dataframe, config=config)
     save_topic_model(pipeline, MODEL_PATH)
+
     print(
-        f"E2E fixture ready: {DATA_PATH} ({len(RECORDS)} lessons), {MODEL_PATH}, {VAULT_DIR}"
+        "E2E fixture ready: "
+        f"data={DATA_DIR}, cache={CACHE_DIR}, vault={VAULT_DIR} "
+        f"({len(RECORDS)} lessons)"
     )
     return 0
 

--- a/scripts/e2e-serve.sh
+++ b/scripts/e2e-serve.sh
@@ -12,13 +12,18 @@ if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python3"
 fi
 
-# Build every time so the E2E server serves the current frontend sources.
+# Build every time so the server exposes the current frontend sources.
 ./scripts/build-gui.sh
 
 "$PYTHON_BIN" scripts/e2e-prepare.py
 
-export LELE_DATA_PATH="$ROOT/.e2e-fixture/lessons.jsonl"
-export LELE_MODEL_PATH="$ROOT/.e2e-fixture/topic_model.joblib"
+export LELE_DATA_DIR="$ROOT/.e2e-fixture/data"
+export LELE_CACHE_DIR="$ROOT/.e2e-fixture/cache"
 export LELE_VAULT_DIR="$ROOT/.e2e-fixture/vault"
 
-exec "$PYTHON_BIN" -m uvicorn lele_manager.api.server:app --host 127.0.0.1 --port "${E2E_PORT:-8765}"
+unset LELE_DATA_PATH
+unset LELE_MODEL_PATH
+
+exec "$PYTHON_BIN" -m uvicorn lele_manager.api.server:app \
+  --host 127.0.0.1 \
+  --port "${E2E_PORT:-8765}"

--- a/src/lele_manager/api/tritalele.py
+++ b/src/lele_manager/api/tritalele.py
@@ -32,6 +32,7 @@ from lele_manager.application.candidate_approval import (
     PartialApprovalError,
     PartialRefreshError,
     StaleApprovalRevisionError,
+    canonical_lesson_for,
 )
 from lele_manager.application.candidate_review import (
     CandidateReviewConflictError,
@@ -137,6 +138,11 @@ class CandidateReviewEventResponse(BaseModel):
     reason: str | None
 
 
+class ApprovalDestinationResponse(BaseModel):
+    lesson_id: str
+    relative_vault_path: str
+
+
 class CandidateResponse(BaseModel):
     candidate_id: str
     state: str
@@ -145,6 +151,7 @@ class CandidateResponse(BaseModel):
     proposed_text: str | None
     effective_text: str
     proposed_metadata: dict[str, Any] | None
+    approval_destination: ApprovalDestinationResponse | None
     provenance: CandidateProvenanceResponse
     review_history: list[CandidateReviewEventResponse]
 
@@ -312,6 +319,15 @@ def _candidate_response(candidate: LessonCandidate) -> CandidateResponse:
     assert proposed_metadata is None or isinstance(proposed_metadata, dict)
     assert isinstance(run_metadata, dict)
     assert isinstance(transformations, list)
+    try:
+        canonical = canonical_lesson_for(candidate)
+    except InvalidApprovalMetadataError:
+        approval_destination = None
+    else:
+        approval_destination = ApprovalDestinationResponse(
+            lesson_id=canonical.lesson_id,
+            relative_vault_path=canonical.relative_path,
+        )
     return CandidateResponse(
         candidate_id=candidate.candidate_id,
         state=candidate.state.value,
@@ -320,6 +336,7 @@ def _candidate_response(candidate: LessonCandidate) -> CandidateResponse:
         proposed_text=candidate.proposed_text,
         effective_text=candidate.effective_text,
         proposed_metadata=proposed_metadata,
+        approval_destination=approval_destination,
         provenance=CandidateProvenanceResponse(
             source_kind=provenance.source_kind.value,
             source_logical_name=provenance.source_logical_name,

--- a/tests/test_api_tritalele.py
+++ b/tests/test_api_tritalele.py
@@ -159,6 +159,7 @@ def test_openapi_exposes_exact_versioned_surface_and_schemas() -> None:
         "RawSourceRequest",
         "CanonicalMetadataRequest",
         "CandidateRevisionRequest",
+        "ApprovalDestinationResponse",
         "CandidateResponse",
         "CandidateListResponse",
         "IngestionResultResponse",
@@ -317,6 +318,46 @@ def test_stage_creates_only_candidates_and_replay_is_idempotent(
     assert not (tmp_path / "data" / "lessons.jsonl").exists()
 
 
+def test_preview_stage_revise_and_accept_never_publish(
+    client: TestClient, tmp_path: Path
+) -> None:
+    payload = raw_payload(
+        "A candidate must remain outside the canonical vault until approval.",
+        logical_name="not-published.txt",
+        max_characters=2_000,
+    )
+    vault = tmp_path / "vault"
+    projection = tmp_path / "data" / "lessons.jsonl"
+
+    preview = client.post(f"{API}/ingestion/preview", json=payload)
+    stage = client.post(f"{API}/ingestion/stage", json=payload)
+    item_id = candidate_id(stage.json())
+    revised = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={
+            "expected_revision": 0,
+            "proposed_text": "A reviewed candidate still must not be published.",
+            "proposed_metadata": metadata(title="Not published yet"),
+            "reason": "complete review",
+        },
+    )
+    accepted = client.post(
+        f"{API}/candidates/{item_id}/accept",
+        json={"expected_revision": 1, "reason": "ready for approval"},
+    )
+
+    assert preview.status_code == stage.status_code == 200
+    assert revised.status_code == accepted.status_code == 200
+    assert accepted.json()["state"] == "in_review"
+    assert accepted.json()["approval_destination"] is not None
+    assert not vault.exists()
+    assert not projection.exists()
+
+    listed = client.get(f"{API}/candidates").json()["candidates"]
+    assert [item["candidate_id"] for item in listed] == [item_id]
+    assert listed[0]["state"] == "in_review"
+
+
 def test_missing_candidate_staging_lists_as_empty(client: TestClient) -> None:
     response = client.get(f"{API}/candidates")
 
@@ -410,10 +451,12 @@ def test_candidate_retrieval_has_stable_transport_only_representation(
         "proposed_text",
         "effective_text",
         "proposed_metadata",
+        "approval_destination",
         "provenance",
         "review_history",
     }
     assert body["candidate_id"] == item_id
+    assert body["approval_destination"] is None
     assert body["original_text"] == body["effective_text"]
     assert body["provenance"]["ingested_at"].endswith("+00:00")
     assert set(body["provenance"]) == {
@@ -429,6 +472,41 @@ def test_candidate_retrieval_has_stable_transport_only_representation(
     assert str(tmp_path) not in response.text
     assert "JsonCandidateRepository" not in response.text
     assert "MappingProxyType" not in response.text
+
+
+def test_approval_destination_is_backend_computed_and_additive(
+    client: TestClient,
+) -> None:
+    item_id = candidate_id(stage_one(client, logical_name="destination.txt"))
+
+    revised = client.patch(
+        f"{API}/candidates/{item_id}",
+        json={
+            "expected_revision": 0,
+            "proposed_metadata": metadata(
+                topic="python", title="Déstination canonica"
+            ),
+        },
+    )
+
+    assert revised.status_code == 200, revised.text
+    body = revised.json()
+    authoritative = canonical_lesson_for(
+        tritalele.get_candidate_repository().get(item_id)
+    )
+    assert body["approval_destination"] == {
+        "lesson_id": authoritative.lesson_id,
+        "relative_vault_path": authoritative.relative_path,
+    }
+    assert body["approval_destination"]["lesson_id"].startswith("python/")
+    assert body["approval_destination"]["relative_vault_path"].endswith(".md")
+
+    schema = app.openapi()["components"]["schemas"]["CandidateResponse"]
+    assert "approval_destination" in schema["properties"]
+    destination_schema = schema["properties"]["approval_destination"]
+    assert {item.get("$ref") for item in destination_schema["anyOf"]} >= {
+        "#/components/schemas/ApprovalDestinationResponse"
+    }
 
 
 def test_missing_candidate_returns_structured_404(client: TestClient) -> None:
@@ -578,6 +656,11 @@ def test_accept_and_reject_enforce_lifecycle_and_expected_revision(
     assert repeated_accept.json()["detail"]["code"] == "invalid_candidate_transition"
     assert stale.status_code == 409
     assert stale.json()["detail"]["code"] == "stale_candidate_revision"
+    visible = client.get(f"{API}/candidates").json()["candidates"]
+    assert any(
+        item["candidate_id"] == rejected_id and item["state"] == "rejected"
+        for item in visible
+    )
 
 
 def test_approval_is_ordered_and_idempotent(client: TestClient, tmp_path: Path) -> None:

--- a/tests/test_e2e_isolation.py
+++ b/tests/test_e2e_isolation.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_playwright_server_uses_only_targeted_fixture_directories() -> None:
+    root = Path(__file__).parents[1]
+    prepare = (root / "scripts/e2e-prepare.py").read_text(encoding="utf-8")
+    serve = (root / "scripts/e2e-serve.sh").read_text(encoding="utf-8")
+
+    assert 'FIXTURE_DIR = ROOT / ".e2e-fixture"' in prepare
+    assert "shutil.rmtree(FIXTURE_DIR, ignore_errors=True)" in prepare
+    assert "FIXTURE_DIR.is_symlink()" in prepare
+    assert "FIXTURE_DIR.unlink()" in prepare
+    assert "shutil.rmtree(ROOT" not in prepare
+    assert 'DATA_DIR = FIXTURE_DIR / "data"' in prepare
+    assert 'CACHE_DIR = FIXTURE_DIR / "cache"' in prepare
+    assert 'VAULT_DIR = FIXTURE_DIR / "vault"' in prepare
+
+    for variable, child in (
+        ("LELE_DATA_DIR", "data"),
+        ("LELE_CACHE_DIR", "cache"),
+        ("LELE_VAULT_DIR", "vault"),
+    ):
+        assert f'export {variable}="$ROOT/.e2e-fixture/{child}"' in serve
+    assert "unset LELE_DATA_PATH" in serve
+    assert "unset LELE_MODEL_PATH" in serve


### PR DESCRIPTION
## Summary

Adds the TritaLeLe candidate review and approval workflow to the Svelte GUI.

The new `#/tritalele` view supports deterministic preview and staging, candidate filtering and detail inspection, editable text and canonical metadata, optimistic revision checks, accept/reject transitions, explicit approval confirmation, provenance and review history, and separate read-back reporting for vault and projection outcomes.

## Integration details

- preserves the English-canonical README introduced by the bilingual documentation foundation;
- integrates TritaLeLe API types and structured `ApiError` handling with the existing Vault Doctor and Duplicate Review clients;
- keeps preview, staging, revision, acceptance, and rejection non-publishing;
- uses backend-calculated canonical lesson IDs and vault destinations during approval;
- reports controlled `409`, `422`, `503`, obsolete-response, and partial-refresh cases;
- isolates E2E data, cache, candidate staging, and vault state under `.e2e-fixture/`;
- updates Duplicate Review tests to use the isolated model cache path;
- makes TritaLeLe E2E assertions relative to the shared canonical vault fixture.

## User impact

Users can now complete the TritaLeLe workflow from source ingestion through explicit canonical approval without using the CLI. Rejected candidates remain inspectable, provenance and history remain visible, and no canonical write occurs before the dedicated approval confirmation.

## Validation

- `ruff check .`
- `mypy src/lele_manager`
- `pytest -q` — 522 passed
- `npm run check --prefix frontend` — 0 errors, 4 existing warnings
- Playwright GUI smoke — 4 passed
- Playwright Vault Doctor — 4 passed
- Playwright Duplicate Review — 7 passed
- Playwright TritaLeLe — 4 passed
- combined Duplicate Review + TritaLeLe run — 11 passed

Closes #126