### PR TITLE
Fix release artifacts to include the compiled GUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,16 +105,13 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Build GUI
-        run: ./scripts/build-gui.sh
-
       - name: Install build tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade build
+          python -m pip install --upgrade build twine
 
       - name: Build sdist and wheel
-        run: python -m build
+        run: ./scripts/build-release-artifacts.sh
 
       - name: Install wheel in clean venv
         run: |
@@ -126,23 +123,21 @@ jobs:
         run: |
           /tmp/venv/bin/lele --help
 
-      - name: Smoke UI asset present + content check
+      - name: Smoke installed wheel
+        run: /tmp/venv/bin/python scripts/smoke-installed-package.py
+
+      - name: Rebuild and install wheel from sdist
         run: |
-          /tmp/venv/bin/python - <<'PY'
-          from pathlib import Path
-          import lele_manager.api.server as s
+          python -m pip wheel \
+            --no-deps \
+            --wheel-dir /tmp/sdist-wheel \
+            dist/*.tar.gz
+          python -m venv /tmp/sdist-venv
+          /tmp/sdist-venv/bin/pip install --upgrade pip
+          /tmp/sdist-venv/bin/pip install /tmp/sdist-wheel/*.whl
 
-          ui_path = Path(s.__file__).with_name("ui.html")
-          assert ui_path.exists(), f"ui.html missing at {ui_path}"
-
-          data = ui_path.read_text(encoding="utf-8")
-          must = ["textarea", "btnFreeSimilar"]
-          missing = [x for x in must if x not in data]
-          assert not missing, f"ui.html content check failed; missing: {missing}"
-
-          gui_index = Path(s.__file__).resolve().parent.parent / "gui" / "static" / "index.html"
-          assert gui_index.exists(), f"GUI index missing at {gui_index}"
-          gui_data = gui_index.read_text(encoding="utf-8")
-          assert "LeLe Manager" in gui_data
-          print("OK: ui.html + GUI static present")
-          PY
+      - name: Smoke sdist-rebuilt wheel
+        run: |
+          /tmp/sdist-venv/bin/lele --help
+          /tmp/sdist-venv/bin/python \
+            scripts/smoke-installed-package.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade build twine
-      - name: Build
-        run: python -m build
-      - name: Twine check
-        run: python -m twine check dist/*
+      - name: Build release artifacts
+        run: ./scripts/build-release-artifacts.sh
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -11,7 +11,8 @@ requires-python = ">=3.10"
 authors = [
   { name = "Giancarlo Cicellyn Comneno" }
 ]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 dependencies = [
   "platformdirs>=4.0.0",
   "fastapi",

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT"
+
+echo "==> Cleaning previous Python distribution outputs"
+rm -rf     "$ROOT/build"     "$ROOT/dist"     "$ROOT/src/lele_manager.egg-info"
+
+"$ROOT/scripts/build-gui.sh"
+
+echo "==> Building sdist and wheel"
+python -m build
+
+echo "==> Checking distribution metadata"
+python -m twine check "$ROOT"/dist/*
+
+echo "OK: release artifacts available in $ROOT/dist"

--- a/scripts/smoke-installed-package.py
+++ b/scripts/smoke-installed-package.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from importlib.metadata import version
+from pathlib import Path
+
+import lele_manager
+from lele_manager.api import server
+
+package_root = Path(lele_manager.__file__).resolve().parent
+static_root = package_root / "gui" / "static"
+gui_index = static_root / "index.html"
+assets = sorted(
+    path
+    for path in static_root.rglob("*")
+    if path.is_file()
+)
+frontend_assets = [
+    path
+    for path in assets
+    if path.suffix in {".css", ".js"}
+]
+
+installed_version = version("lele-manager")
+
+print(f"Versione installata: {installed_version}")
+print(f"Package root:        {package_root}")
+print(f"API module:          {Path(server.__file__).resolve()}")
+print(f"FastAPI version:     {server.app.version}")
+print(f"GUI index:           {gui_index}")
+print(f"File GUI:            {len(assets)}")
+print(f"Asset CSS/JS:        {len(frontend_assets)}")
+
+if server.app.version != installed_version:
+    raise SystemExit(
+        "ERRORE: versione FastAPI diversa dal package installato."
+    )
+
+if server.GUI_DIR != static_root:
+    raise SystemExit(
+        "ERRORE: il server non ha risolto la GUI installata."
+    )
+
+if not gui_index.is_file():
+    raise SystemExit(
+        "ERRORE: index.html della GUI assente."
+    )
+
+if not frontend_assets:
+    raise SystemExit(
+        "ERRORE: asset CSS/JS compilati assenti."
+    )
+
+index_text = gui_index.read_text(encoding="utf-8")
+if "LeLe Manager" not in index_text:
+    raise SystemExit(
+        "ERRORE: index.html non contiene il titolo atteso."
+    )
+
+print("OK: wheel installata con CLI, API e GUI compilata.")

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_COMMAND = "./scripts/build-release-artifacts.sh"
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_ci_and_release_share_artifact_build_entrypoint() -> None:
+    ci = read(".github/workflows/ci.yml")
+    release = read(".github/workflows/release.yml")
+
+    assert BUILD_COMMAND in ci
+    assert BUILD_COMMAND in release
+
+
+def test_release_workflow_prepares_node_before_build() -> None:
+    release = read(".github/workflows/release.yml")
+
+    node_position = release.index("actions/setup-node@v4")
+    build_position = release.index(BUILD_COMMAND)
+
+    assert node_position < build_position
+    assert "node-version: \"22\"" in release
+
+
+def test_artifact_script_builds_gui_before_python_distributions() -> None:
+    script = read("scripts/build-release-artifacts.sh")
+
+    gui_position = script.index("scripts/build-gui.sh")
+    package_position = script.index("python -m build")
+
+    assert gui_position < package_position
+    assert "python -m twine check" in script
+
+
+def test_packaging_smoke_rebuilds_wheel_from_sdist() -> None:
+    ci = read(".github/workflows/ci.yml")
+
+    assert "python -m pip wheel" in ci
+    assert "dist/*.tar.gz" in ci
+    assert "/tmp/sdist-venv" in ci
+    assert "scripts/smoke-installed-package.py" in ci
+
+def test_packaging_metadata_uses_current_spdx_license() -> None:
+    data = tomllib.loads(read("pyproject.toml"))
+
+    assert data["build-system"]["requires"] == [
+        "setuptools>=77.0.0"
+    ]
+    assert data["project"]["license"] == "MIT"
+    assert data["project"]["license-files"] == ["LICENSE"]


### PR DESCRIPTION
Closes #141.

## Root cause

The release workflow invoked `python -m build` without first compiling the Svelte frontend. The resulting Python artifacts installed successfully but did not contain the compiled GUI.

The ordinary CI packaging job built the GUI first, so CI and release used different artifact-production paths.

## Changes

- add one shared release-artifact build entrypoint;
- compile the GUI before building the Python distributions;
- use the same entrypoint in CI and the release workflow;
- configure Node.js in the release workflow;
- smoke-test the installed CLI, API metadata and compiled GUI;
- rebuild and test a wheel from the sdist;
- migrate the Python license metadata to the current SPDX format;
- add regression tests for the packaging contract.

Generated GUI assets remain ignored and are not committed.

## Validation

- Ruff: passed
- mypy: passed
- pytest: 527 passed
- packaging contract tests: 5 passed
- `twine check dist/*`: passed
- frontend check: 0 errors, 4 existing warnings
- frontend production build: passed
- Playwright: 19 passed, 1 skipped
- direct wheel installation: passed
- wheel rebuilt from sdist: passed
- installed GUI `/app/`: HTTP 200

## Follow-up

Issue #142 tracks the vulnerable frontend dependencies found during the release rehearsal. It remains a separate blocker for the next release.
