### PR TITLE
Release LeLe Manager 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,62 @@ The format is based on **Keep a Changelog**.
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-04
+
+### Added
+- **TritaLeLe:** flusso controllato per acquisire fonti Markdown, testo,
+  standard input e contenuti in memoria, con normalizzazione deterministica,
+  fingerprint SHA-256, chunking, staging, review, rifiuto e approvazione
+  esplicita dei candidati.
+- CLI, API e GUI complete per anteprima, ingestione, revisione e approvazione
+  TritaLeLe.
+- **Projection store:** contratto backend-neutral, adapter JSONL atomico,
+  adapter per il vault Markdown canonico e facade di compatibilità con i
+  consumer legacy.
+- **Vault Doctor:** diagnostica read-only disponibile tramite CLI, API e
+  pannello Ops.
+- Rilevamento e revisione read-only di duplicati esatti e near-duplicate,
+  inclusa una vista GUI dedicata.
+- Piano di importazione tipizzato e anteprima `--dry-run` deterministica.
+- Feed API versionato per l'esposizione di lesson verso consumer esterni.
+
+### Changed
+- API, import, vault e componenti ML passano attraverso il composition
+  boundary e il projection-store contract, mantenendo la compatibilità con
+  la proiezione JSONL esistente.
+- La GUI locale include i workflow TritaLeLe, Duplicates e Vault Doctor e
+  dispone di copertura Playwright isolata.
+- Il processo di release compila il frontend e incorpora la GUI sia nella
+  wheel sia nella sdist.
+- CI e release usano lo stesso entrypoint di build e verificano installazione,
+  CLI, API e GUI dalla wheel diretta e dalla wheel ricostruita dalla sdist.
+- La documentazione inglese è canonica e dispone di mirror italiani
+  mantenuti.
+
+### Fixed
+- L'import non riscrive frontmatter già valido.
+- L'anteprima dry-run usa i candidati effettivamente risolti e traduce
+  correttamente gli errori di input.
+- Gli artefatti Python di release includono ora la GUI Svelte compilata.
+
+### Security
+- Aggiornati DOMPurify a 3.4.13, PostCSS a 8.5.25 e Nanoid a 3.3.17.
+- `npm audit` completo e `npm audit --omit=dev` non riportano vulnerabilità.
+
+### Documentation
+- Aggiunti guida utente GUI, ADR sul projection store e ADR sulla strategia
+  di packaging locale FastAPI/Svelte.
+- Aggiunti screenshot GUI deterministici e relativo workflow Playwright.
+- Aggiornati README, roadmap, guida contributori e policy documentale in
+  inglese e italiano.
+
+### Compatibility
+- Non sono introdotte incompatibilità intenzionali nelle API o nella CLI
+  pubblica.
+- `LELE_DATA_PATH` e `LELE_MODEL_PATH` restano temporaneamente supportate;
+  per nuove configurazioni usare `LELE_DATA_DIR` e `LELE_CACHE_DIR`.
+
+
 ## [1.9.0] - 2026-07-05
 
 ### Added
@@ -184,7 +240,8 @@ _See [1.2.0] — same commit tag point; version marker for milestone tracking._
 - Date parsing (YAML → JSON).
 - NaN/NaT handling in the API layer.
 
-[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/gcomneno/lele-manager/compare/v1.9.0...v2.0.0
 [1.9.0]: https://github.com/gcomneno/lele-manager/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/gcomneno/lele-manager/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/gcomneno/lele-manager/compare/v1.6.0...v1.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lele-manager"
-version = "1.9.0"
+version = "2.0.0"
 description = "Lesson Learned Manager: archivio intelligente di lesson learned testuali."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release

Prepare LeLe Manager 2.0.0.

This release completes the v2.0 product milestone with the projection-store
boundary, Vault Doctor, duplicate review, the complete TritaLeLe workflow,
maintained GUI documentation and installable GUI artifacts.

## Changes

- bump the Python package version from 1.9.0 to 2.0.0;
- publish the complete 2.0.0 changelog;
- update changelog comparison links for v2.0.0.

No tag or GitHub Release is created by this pull request.

## Validation

- Ruff: passed
- mypy: passed
- pytest: passed
- `npm audit`: 0 vulnerabilities
- `npm audit --omit=dev`: 0 vulnerabilities
- Svelte/TypeScript check: passed
- release wheel and sdist: built
- `twine check`: passed
- installed wheel version: 2.0.0
- installed CLI/API/compiled-GUI smoke: passed

## Operational rehearsal

The pre-release rehearsal ran both the direct wheel and a wheel rebuilt from
the sdist against isolated copies of the real runtime.

- GUI, API and read-only CLI workflows passed;
- both installed artifacts produced equivalent results;
- copied vault/data/cache remained byte-for-byte unchanged;
- original runtime data was never used as a write target;
- Vault Doctor reported 9 existing content diagnostics and no
  operational error;
- real cached model available: false;
- no tag or release was created.
