### PR TITLE
feat: add PKPS package consumer boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on **Keep a Changelog**.
 ## [Unreleased]
 
 ### Added
-- **Personal Knowledge Publishing System (PKPS):** local v1 GYTE lesson-package
+- **LeLe Manager PKPS consumer boundary:** local v1 GYTE lesson-package
   import through the existing TritaLeLe candidate staging boundary. Directory
   and single-root ZIP packages are strictly validated, retain immutable
   provenance, are idempotent by package ID/content hash, and never write the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on **Keep a Changelog**.
 
 ## [Unreleased]
 
+### Added
+- **Personal Knowledge Publishing System (PKPS):** local v1 GYTE lesson-package
+  import through the existing TritaLeLe candidate staging boundary. Directory
+  and single-root ZIP packages are strictly validated, retain immutable
+  provenance, are idempotent by package ID/content hash, and never write the
+  vault or derived artifacts before explicit approval.
+
 ## [1.10.0] - 2026-08-04
 
 ### Added

--- a/README.it.md
+++ b/README.it.md
@@ -46,6 +46,8 @@ pytest tests/test_documentation.py
 - Contratto projection store:
   [docs/it/projection-store.md](docs/it/projection-store.md)
 
+- Contratto package PKPS: [docs/it/pkps-package.md](docs/it/pkps-package.md)
+
 - Manuale della GUI: [docs/it/gui-user-guide.md](docs/it/gui-user-guide.md)
 
 ## Obiettivi principali
@@ -507,6 +509,24 @@ Il salvataggio dall'Editor scrive il file Markdown nel vault e aggiorna la
 proiezione JSONL tramite `PUT` o `POST /vault/lessons`.
 
 La GUI richiede `LELE_VAULT_DIR`; il default è `~/LeLeVault`.
+
+### Personal Knowledge Publishing System (PKPS)
+
+GYTE Study Tools può consegnare una lesson revisionata all'esistente confine
+TritaLeLe senza esporre il proprio workspace:
+
+```bash
+lele pkps import PACKAGE_PATH
+lele pkps import PACKAGE_PATH --json
+```
+
+L'import v1 accetta una directory package o uno ZIP con root singola, valida
+manifest, confinamento dei path, lesson UTF-8, conteggio byte e SHA-256, poi
+mette in staging un candidato. Reimportare `package_id` e hash invariati è
+idempotente; un package ID riutilizzato con hash differente viene rifiutato.
+Nessuna scrittura nel vault, nelle proiezioni o nel ML avviene prima
+dell'esistente approvazione esplicita. Consultare il [contratto package
+PKPS](docs/it/pkps-package.md).
 
 Il record di design completato resta disponibile in italiano in
 [`docs/gui-design.md`](docs/gui-design.md). È classificato come documento

--- a/README.it.md
+++ b/README.it.md
@@ -46,7 +46,8 @@ pytest tests/test_documentation.py
 - Contratto projection store:
   [docs/it/projection-store.md](docs/it/projection-store.md)
 
-- Contratto package PKPS: [docs/it/pkps-package.md](docs/it/pkps-package.md)
+- Contratto consumer PKPS di LeLe Manager:
+  [docs/it/pkps-package.md](docs/it/pkps-package.md)
 
 - Manuale della GUI: [docs/it/gui-user-guide.md](docs/it/gui-user-guide.md)
 
@@ -510,10 +511,11 @@ proiezione JSONL tramite `PUT` o `POST /vault/lessons`.
 
 La GUI richiede `LELE_VAULT_DIR`; il default è `~/LeLeVault`.
 
-### Personal Knowledge Publishing System (PKPS)
+### Consumer package PKPS di LeLe Manager
 
-GYTE Study Tools può consegnare una lesson revisionata all'esistente confine
-TritaLeLe senza esporre il proprio workspace:
+LeLe Manager implementa esclusivamente il lato consumer locale del protocollo
+PKPS. GYTE Study Tools può consegnare una lesson revisionata all'esistente
+confine TritaLeLe senza esporre il proprio workspace:
 
 ```bash
 lele pkps import PACKAGE_PATH
@@ -525,8 +527,9 @@ manifest, confinamento dei path, lesson UTF-8, conteggio byte e SHA-256, poi
 mette in staging un candidato. Reimportare `package_id` e hash invariati è
 idempotente; un package ID riutilizzato con hash differente viene rifiutato.
 Nessuna scrittura nel vault, nelle proiezioni o nel ML avviene prima
-dell'esistente approvazione esplicita. Consultare il [contratto package
-PKPS](docs/it/pkps-package.md).
+dell'esistente approvazione esplicita. Questo confine non costituisce il
+progetto PKPS completo né un orchestratore cross-repository. Consultare il
+[contratto consumer PKPS](docs/it/pkps-package.md).
 
 Il record di design completato resta disponibile in italiano in
 [`docs/gui-design.md`](docs/gui-design.md). È classificato come documento

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ pytest tests/test_documentation.py
 - GUI user guide: [docs/gui-user-guide.md](docs/gui-user-guide.md)
 - Projection-store contract:
   [docs/projection-store.md](docs/projection-store.md)
+- PKPS package contract: [docs/pkps-package.md](docs/pkps-package.md)
 
 ## Main goals
 
@@ -521,6 +522,23 @@ the deterministic candidate workflow:
 Preview, staging, revision, acceptance, and rejection never publish a lesson.
 Only explicit approval may write one canonical Markdown lesson and refresh the
 derived projection.
+
+### Personal Knowledge Publishing System (PKPS)
+
+GYTE Study Tools can hand a reviewed lesson to the existing TritaLeLe boundary
+without exposing its workspace:
+
+```bash
+lele pkps import PACKAGE_PATH
+lele pkps import PACKAGE_PATH --json
+```
+
+The v1 import accepts a package directory or a single-root ZIP, validates its
+manifest, path confinement, UTF-8 lesson, byte count, and SHA-256, then stages
+one candidate. Re-importing an unchanged `package_id` and hash is idempotent;
+a reused package ID with another hash is rejected. No vault, projection, or ML
+write happens before the existing explicit approval. See the full
+[PKPS package contract](docs/pkps-package.md).
 
 The completed design record remains available in Italian at
 [`docs/gui-design.md`](docs/gui-design.md). It is classified as a historical

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ pytest tests/test_documentation.py
 - GUI user guide: [docs/gui-user-guide.md](docs/gui-user-guide.md)
 - Projection-store contract:
   [docs/projection-store.md](docs/projection-store.md)
-- PKPS package contract: [docs/pkps-package.md](docs/pkps-package.md)
+- LeLe Manager PKPS consumer contract:
+  [docs/pkps-package.md](docs/pkps-package.md)
 
 ## Main goals
 
@@ -523,8 +524,9 @@ Preview, staging, revision, acceptance, and rejection never publish a lesson.
 Only explicit approval may write one canonical Markdown lesson and refresh the
 derived projection.
 
-### Personal Knowledge Publishing System (PKPS)
+### LeLe Manager PKPS package consumer
 
+LeLe Manager implements only the local consumer side of the PKPS protocol.
 GYTE Study Tools can hand a reviewed lesson to the existing TritaLeLe boundary
 without exposing its workspace:
 
@@ -537,8 +539,9 @@ The v1 import accepts a package directory or a single-root ZIP, validates its
 manifest, path confinement, UTF-8 lesson, byte count, and SHA-256, then stages
 one candidate. Re-importing an unchanged `package_id` and hash is idempotent;
 a reused package ID with another hash is rejected. No vault, projection, or ML
-write happens before the existing explicit approval. See the full
-[PKPS package contract](docs/pkps-package.md).
+write happens before the existing explicit approval. This boundary is
+not the complete PKPS project or a cross-repository orchestrator. See the
+[PKPS consumer contract](docs/pkps-package.md).
 
 The completed design record remains available in Italian at
 [`docs/gui-design.md`](docs/gui-design.md). It is classified as a historical

--- a/ROADMAP.it.md
+++ b/ROADMAP.it.md
@@ -111,6 +111,8 @@ LeLe Manager fornisce oggi:
 - una GUI Svelte;
 - flussi TritaLeLe per ingestione fonti grezze, revisione candidati e
   approvazione;
+- validazione package PKPS v1 e staging tramite il confine candidati TritaLeLe,
+  senza scritture di vault o proiezioni prima dell'approvazione;
 - test deterministici sui confini domain, storage, API, CLI e GUI.
 
 Il progetto è utilizzabile come strumento personale in produzione, mentre la
@@ -149,6 +151,7 @@ La copertura comprende:
 - `lele duplicates`;
 - `lele doctor`;
 - comandi candidati TritaLeLe;
+- `lele pkps import PACKAGE_PATH` per package lesson GYTE versionati;
 - configurazione `LELE_API_URL` dove applicabile.
 
 ### 4.4 Documentazione e igiene release
@@ -200,7 +203,15 @@ source material
 I candidati non sono lesson approvate. Restano isolati dal vault canonico e
 dal dataset ML fino al completamento di un'approvazione esplicita.
 
-### 5.3 Documentazione
+### 5.3 Personal Knowledge Publishing System (PKPS)
+
+PKPS v1 è un confine locale package completato: GYTE esporta un package lesson
+versionato, mentre LeLe lo valida e mette in staging un ordinario candidato
+TritaLeLe. La provenienza del package è immutabile e fluisce nell'approvazione;
+identità canonica, gestione duplicati e pubblicazione restano decisioni di
+LeLe. Consultare il [contratto package PKPS](docs/it/pkps-package.md).
+
+### 5.4 Documentazione
 
 L'inglese è canonico e predefinito. L'italiano è ufficialmente mantenuto per le
 coppie elencate nella

--- a/ROADMAP.it.md
+++ b/ROADMAP.it.md
@@ -111,8 +111,8 @@ LeLe Manager fornisce oggi:
 - una GUI Svelte;
 - flussi TritaLeLe per ingestione fonti grezze, revisione candidati e
   approvazione;
-- validazione package PKPS v1 e staging tramite il confine candidati TritaLeLe,
-  senza scritture di vault o proiezioni prima dell'approvazione;
+- confine consumer locale per package PKPS v1 e staging tramite i candidati
+  TritaLeLe, senza scritture di vault o proiezioni prima dell'approvazione;
 - test deterministici sui confini domain, storage, API, CLI e GUI.
 
 Il progetto è utilizzabile come strumento personale in produzione, mentre la
@@ -203,13 +203,17 @@ source material
 I candidati non sono lesson approvate. Restano isolati dal vault canonico e
 dal dataset ML fino al completamento di un'approvazione esplicita.
 
-### 5.3 Personal Knowledge Publishing System (PKPS)
+### 5.3 Consumer locale PKPS di LeLe Manager
 
-PKPS v1 è un confine locale package completato: GYTE esporta un package lesson
-versionato, mentre LeLe lo valida e mette in staging un ordinario candidato
-TritaLeLe. La provenienza del package è immutabile e fluisce nell'approvazione;
-identità canonica, gestione duplicati e pubblicazione restano decisioni di
-LeLe. Consultare il [contratto package PKPS](docs/it/pkps-package.md).
+LeLe Manager completa il proprio confine consumer locale per package PKPS v1:
+GYTE esporta un package lesson versionato, mentre LeLe lo valida e mette in
+staging un ordinario candidato TritaLeLe. La provenienza del package è
+immutabile e fluisce nell'approvazione; identità canonica, gestione duplicati e
+pubblicazione restano decisioni di LeLe.
+
+Questo verticale non costituisce il progetto PKPS autonomo, la sua
+orchestrazione cross-repository o il contratto canonico futuro. Consultare il
+[contratto consumer PKPS](docs/it/pkps-package.md).
 
 ### 5.4 Documentazione
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,6 +108,8 @@ LeLe Manager currently provides:
 - an API-oriented `lele` CLI client;
 - a Svelte GUI;
 - TritaLeLe raw-source ingestion, candidate review, and approval workflows;
+- PKPS v1 package validation and staging through the TritaLeLe candidate
+  boundary, without pre-approval vault or projection writes;
 - deterministic tests across domain, storage, API, CLI, and GUI boundaries.
 
 The project is usable as a personal production tool, while storage migration
@@ -146,6 +148,7 @@ Coverage includes:
 - `lele duplicates`;
 - `lele doctor`;
 - TritaLeLe candidate commands;
+- `lele pkps import PACKAGE_PATH` for versioned GYTE lesson packages;
 - `LELE_API_URL` configuration where applicable.
 
 ### 4.4 Documentation and release hygiene
@@ -195,7 +198,15 @@ source material
 Candidates are not approved lessons. They remain isolated from the canonical
 vault and ML dataset until explicit approval succeeds.
 
-### 5.3 Documentation
+### 5.3 Personal Knowledge Publishing System (PKPS)
+
+PKPS v1 is a completed local package boundary: GYTE exports a versioned lesson
+package, while LeLe validates it and stages an ordinary TritaLeLe candidate.
+Package provenance is immutable and flows into approval; canonical identity,
+duplicate handling, and publication remain LeLe decisions. See the
+[PKPS package contract](docs/pkps-package.md).
+
+### 5.4 Documentation
 
 English is canonical and default. Italian is officially maintained for the
 document pairs listed in

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,8 +108,8 @@ LeLe Manager currently provides:
 - an API-oriented `lele` CLI client;
 - a Svelte GUI;
 - TritaLeLe raw-source ingestion, candidate review, and approval workflows;
-- PKPS v1 package validation and staging through the TritaLeLe candidate
-  boundary, without pre-approval vault or projection writes;
+- a local PKPS v1 package consumer boundary and staging through TritaLeLe
+  candidates, without pre-approval vault or projection writes;
 - deterministic tests across domain, storage, API, CLI, and GUI boundaries.
 
 The project is usable as a personal production tool, while storage migration
@@ -198,13 +198,17 @@ source material
 Candidates are not approved lessons. They remain isolated from the canonical
 vault and ML dataset until explicit approval succeeds.
 
-### 5.3 Personal Knowledge Publishing System (PKPS)
+### 5.3 LeLe Manager local PKPS consumer
 
-PKPS v1 is a completed local package boundary: GYTE exports a versioned lesson
-package, while LeLe validates it and stages an ordinary TritaLeLe candidate.
-Package provenance is immutable and flows into approval; canonical identity,
-duplicate handling, and publication remain LeLe decisions. See the
-[PKPS package contract](docs/pkps-package.md).
+LeLe Manager completes its local consumer boundary for PKPS v1 packages: GYTE
+exports a versioned lesson package, while LeLe validates it and stages an
+ordinary TritaLeLe candidate. Package provenance is immutable and flows into
+approval; canonical identity, duplicate handling, and publication remain LeLe
+decisions.
+
+This vertical slice is not the independent PKPS project, its cross-repository
+orchestration, or the future canonical protocol. See the
+[PKPS consumer contract](docs/pkps-package.md).
 
 ### 5.4 Documentation
 

--- a/docs/it/pkps-package.md
+++ b/docs/it/pkps-package.md
@@ -1,0 +1,82 @@
+# Contratto package PKPS v1
+
+[English](../pkps-package.md) | [Italiano](pkps-package.md)
+
+Il **Personal Knowledge Publishing System (PKPS)** definisce un piccolo confine
+di consegna tra GYTE Study Tools e LeLe Manager. GYTE possiede il proprio
+workspace privato e i materiali sorgente; LeLe Manager possiede revisione dei
+candidati, approvazione esplicita, Markdown canonico e dati derivati.
+
+## Package
+
+LeLe accetta una directory package la cui root contiene `pkps-manifest.json` e
+la lesson dichiarata, oppure uno ZIP con esattamente una directory root che
+contiene gli stessi file. Il manifest v1 richiede:
+
+```json
+{
+  "schema_version": 1,
+  "package_id": "stable-producer-identifier",
+  "producer": {"name": "gyte-study-tools", "version": "0.1.0"},
+  "created_at": "2026-08-06T09:00:00Z",
+  "lesson": {"path": "lesson.md", "sha256": "…", "bytes": 123},
+  "source": {"type": "youtube", "url": "https://example.invalid/watch"}
+}
+```
+
+`schema_version` è esattamente `1`; `package_id` e `producer.version` sono
+stringhe non vuote; `created_at` è un timestamp UTC; `source.type` è `youtube`
+o `article`; e `source.url` è un URL HTTP/HTTPS assoluto. `source.title` e
+altri identificatori sorgente sono opzionali e conservati come provenienza. Lo
+SHA-256 della lesson è esadecimale minuscolo e il conteggio byte è positivo.
+
+Il path della lesson è un path POSIX relativo normalizzato. Path assoluti, `..`,
+symlink, file mancanti, non-file ed escape dalla root del package vengono
+rifiutati. Lo ZIP rifiuta inoltre traversal, path assoluti o non normalizzati,
+entry duplicate, symlink e root ambigue/multiple.
+
+## Importazione e ciclo di vita
+
+```bash
+lele pkps import PACKAGE_PATH
+lele pkps import PACKAGE_PATH --json
+```
+
+L'importazione valida il package prima di mettere in staging esattamente un
+ordinario candidato TritaLeLe. Non scrive nel vault canonico, nella proiezione
+JSONL o negli artefatti ML e non aggiorna le proiezioni. Il normale flusso di
+review, accept e approvazione esplicita di TritaLeLe rimane l'unica strada verso
+il Markdown canonico.
+
+L'identità del package è `package_id`; l'identità del contenuto è
+`lesson.sha256`. Una reimportazione con entrambi invariati riusa il candidato
+esistente. Riutilizzare lo stesso package ID con un content hash diverso è un
+conflitto controllato. Package ID differenti con lo stesso contenuto restano
+candidati di revisione separati; l'esistente workflow duplicati di LeLe decide
+come procedere.
+
+La provenienza del candidato conserva il manifest normalizzato originale,
+l'identità di package e producer, timestamp del package, dati sorgente, digest
+e lunghezza del contenuto e timestamp locale di importazione. Tale provenienza
+immutabile è mostrata dall'esistente workflow candidati e copiata nella traccia
+di approvazione canonica.
+
+Riferimenti di pubblicazione come metadati PDF, EPUB e Kindle possono essere
+conservati nel manifest, ma v1 non importa quegli artefatti né trasferisce a
+LeLe l'autorità su di essi.
+
+## Limiti di risorse e path
+
+PKPS v1 considera il package un input locale non fidato. Il path del package,
+il manifest, la lesson dichiarata e ogni directory intermedia rilevante non
+devono essere collegamenti simbolici.
+
+L'importatore applica questi limiti prima di leggere il contenuto completo:
+
+- manifest: 256 KiB;
+- lesson Markdown: 16 MiB;
+- entry ZIP: 128;
+- contenuto ZIP totale non compresso: 32 MiB.
+
+Il contenuto ZIP viene ispezionato senza estrazione. I package che superano
+questi limiti falliscono con errori di dominio PKPS controllati.

--- a/docs/it/pkps-package.md
+++ b/docs/it/pkps-package.md
@@ -1,11 +1,15 @@
-# Contratto package PKPS v1
+# Contratto consumer locale PKPS v1 di LeLe Manager
 
 [English](../pkps-package.md) | [Italiano](pkps-package.md)
 
-Il **Personal Knowledge Publishing System (PKPS)** definisce un piccolo confine
-di consegna tra GYTE Study Tools e LeLe Manager. GYTE possiede il proprio
-workspace privato e i materiali sorgente; LeLe Manager possiede revisione dei
-candidati, approvazione esplicita, Markdown canonico e dati derivati.
+Questo documento descrive esclusivamente il **consumer locale PKPS
+implementato da LeLe Manager**. Non descrive il progetto PKPS completo, la sua
+orchestrazione cross-repository o il futuro contratto canonico del protocollo.
+
+Il confine consente la consegna tra GYTE Study Tools e LeLe Manager. GYTE
+possiede il proprio workspace privato e i materiali sorgente; LeLe Manager
+possiede revisione dei candidati, approvazione esplicita, Markdown canonico e
+dati derivati.
 
 ## Package
 

--- a/docs/pkps-package.md
+++ b/docs/pkps-package.md
@@ -1,0 +1,80 @@
+# PKPS package contract v1
+
+[English](pkps-package.md) | [Italiano](it/pkps-package.md)
+
+**Personal Knowledge Publishing System (PKPS)** defines a small hand-off
+boundary between GYTE Study Tools and LeLe Manager. GYTE owns its private
+workspace and source materials; LeLe Manager owns candidate review, explicit
+approval, canonical Markdown, and derived data.
+
+## Package
+
+LeLe accepts a package directory whose root contains `pkps-manifest.json` and
+the declared lesson, or a ZIP with exactly one root directory containing those
+same files. The v1 manifest requires:
+
+```json
+{
+  "schema_version": 1,
+  "package_id": "stable-producer-identifier",
+  "producer": {"name": "gyte-study-tools", "version": "0.1.0"},
+  "created_at": "2026-08-06T09:00:00Z",
+  "lesson": {"path": "lesson.md", "sha256": "…", "bytes": 123},
+  "source": {"type": "youtube", "url": "https://example.invalid/watch"}
+}
+```
+
+`schema_version` is exactly `1`; `package_id` and `producer.version` are
+non-empty strings; `created_at` is a UTC timestamp; `source.type` is `youtube`
+or `article`; and `source.url` is an absolute HTTP/HTTPS URL. `source.title`
+and other source identifiers are optional and retained as provenance. The
+lesson SHA-256 is lowercase hexadecimal and its byte count is positive.
+
+The lesson path is a normalized relative POSIX path. Absolute paths, `..`,
+symlinks, missing files, non-files, and escapes from the package root are
+rejected. ZIP input also rejects traversal, absolute or non-normalized paths,
+duplicate entries, symlinks, and ambiguous/multiple roots.
+
+## Import and lifecycle
+
+```bash
+lele pkps import PACKAGE_PATH
+lele pkps import PACKAGE_PATH --json
+```
+
+Import validates the package before it stages exactly one ordinary TritaLeLe
+candidate. It does not write the canonical vault, JSONL projection, or ML
+artifacts, and it does not refresh projections. The usual TritaLeLe review,
+accept, and explicit approval flow remains the only route to canonical
+Markdown.
+
+Package identity is `package_id`; content identity is `lesson.sha256`. A
+repeat import with both values unchanged reuses the existing candidate. Reusing
+the same package ID with another content hash is a controlled conflict.
+Different package IDs with the same content remain separate review candidates;
+LeLe's existing duplicate workflow decides what to do with them.
+
+Candidate provenance stores the original normalized manifest, package and
+producer identity, package timestamp, source data, content digest and length,
+and the local import timestamp. That immutable provenance is shown by the
+existing candidate workflow and is copied into the canonical approval trace.
+
+Publication references such as PDF, EPUB, and Kindle metadata may be retained
+in the manifest, but v1 neither imports those artifacts nor transfers authority
+over them to LeLe.
+
+## Resource and path limits
+
+PKPS v1 treats package input as untrusted local data. The package path itself,
+the manifest, the declared lesson, and every relevant intermediate directory
+must not be symbolic links.
+
+The importer enforces these limits before reading complete content:
+
+- manifest: 256 KiB;
+- Markdown lesson: 16 MiB;
+- ZIP entries: 128;
+- total uncompressed ZIP content: 32 MiB.
+
+ZIP content is inspected in place and is never extracted. Packages exceeding
+these limits fail with controlled PKPS domain errors.

--- a/docs/pkps-package.md
+++ b/docs/pkps-package.md
@@ -1,11 +1,14 @@
-# PKPS package contract v1
+# LeLe Manager local PKPS consumer contract v1
 
 [English](pkps-package.md) | [Italiano](it/pkps-package.md)
 
-**Personal Knowledge Publishing System (PKPS)** defines a small hand-off
-boundary between GYTE Study Tools and LeLe Manager. GYTE owns its private
-workspace and source materials; LeLe Manager owns candidate review, explicit
-approval, canonical Markdown, and derived data.
+This document describes only the **local PKPS consumer implemented by
+LeLe Manager**. It does not describe the complete PKPS project, its
+cross-repository orchestration, or the future canonical protocol contract.
+
+The boundary supports hand-off between GYTE Study Tools and LeLe Manager. GYTE
+owns its private workspace and source materials; LeLe Manager owns candidate
+review, explicit approval, canonical Markdown, and derived data.
 
 ## Package
 

--- a/src/lele_manager/application/pkps_import.py
+++ b/src/lele_manager/application/pkps_import.py
@@ -1,0 +1,554 @@
+"""Import the versioned Personal Knowledge Publishing System package v1.
+
+This boundary deliberately creates ordinary TritaLeLe candidates only.  It
+does not know the vault, projection store, or any ML component.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import stat
+from typing import Callable, Mapping
+from urllib.parse import urlparse
+import zipfile
+
+from lele_manager.application.lesson_candidate import (
+    CandidateProvenance,
+    CandidateRepository,
+    CandidateRepositoryError,
+    LessonCandidate,
+)
+from lele_manager.application.raw_source import SourceKind
+from lele_manager.core.json_compat import canonical_json
+
+
+class PkpsImportError(Exception):
+    """Base class for controlled PKPS import failures."""
+
+
+class PkpsPackageError(PkpsImportError):
+    """The supplied package cannot safely be read."""
+
+
+class PkpsValidationError(PkpsImportError):
+    """The package does not satisfy the PKPS v1 contract."""
+
+
+class PkpsConflictError(PkpsImportError):
+    """A package ID has already been imported with other content."""
+
+
+class PkpsPersistenceError(PkpsImportError):
+    """Candidate persistence failed while staging a valid package."""
+
+
+MAX_MANIFEST_BYTES = 256 * 1024
+MAX_LESSON_BYTES = 16 * 1024 * 1024
+MAX_ZIP_ENTRIES = 128
+MAX_ZIP_UNCOMPRESSED_BYTES = 32 * 1024 * 1024
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON object key")
+        result[key] = value
+    return result
+
+
+def _reject_constant(value: str) -> object:
+    raise ValueError(f"non-finite JSON number {value}")
+
+
+def _object(value: object, field: str) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise PkpsValidationError(f"{field} must be an object")
+    return value
+
+
+def _non_empty_string(value: object, field: str) -> str:
+    if type(value) is not str or not value.strip():
+        raise PkpsValidationError(f"{field} must be a non-empty string")
+    return value
+
+
+def _valid_json_strings(value: object) -> None:
+    """Reject JSON strings that candidate persistence cannot safely preserve."""
+    if isinstance(value, str):
+        if any("\ud800" <= character <= "\udfff" for character in value):
+            raise PkpsValidationError("manifest contains invalid Unicode")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _valid_json_strings(key)
+            _valid_json_strings(item)
+    elif isinstance(value, list):
+        for item in value:
+            _valid_json_strings(item)
+
+
+def _relative_path(value: object) -> str:
+    path = _non_empty_string(value, "lesson.path")
+    if "\\" in path:
+        raise PkpsValidationError(
+            "lesson.path must be a normalized relative POSIX path"
+        )
+    candidate = PurePosixPath(path)
+    if candidate.is_absolute() or any(part in (".", "..") for part in candidate.parts):
+        raise PkpsValidationError("lesson.path must be a normalized relative path")
+    if candidate.as_posix() != path or path.startswith("/"):
+        raise PkpsValidationError("lesson.path must be a normalized relative path")
+    return path
+
+
+def _utc_timestamp(value: object, field: str) -> datetime:
+    raw = _non_empty_string(value, field)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        raise PkpsValidationError(f"{field} must be a valid UTC timestamp") from None
+    if parsed.tzinfo is None or parsed.utcoffset() != timezone.utc.utcoffset(parsed):
+        raise PkpsValidationError(f"{field} must be a valid UTC timestamp")
+    return parsed.astimezone(timezone.utc)
+
+
+def _source(value: object) -> dict[str, object]:
+    source = dict(_object(value, "source"))
+    if source.get("type") not in {"youtube", "article"}:
+        raise PkpsValidationError("source.type must be 'youtube' or 'article'")
+    url = _non_empty_string(source.get("url"), "source.url")
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        raise PkpsValidationError(
+            "source.url must be an absolute HTTP/HTTPS URL"
+        ) from None
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise PkpsValidationError("source.url must be an absolute HTTP/HTTPS URL")
+    if "title" in source:
+        _non_empty_string(source["title"], "source.title")
+    return source
+
+
+@dataclass(frozen=True)
+class PkpsPackage:
+    package_id: str
+    schema_version: int
+    producer: Mapping[str, str]
+    created_at: datetime
+    source: Mapping[str, object]
+    lesson_path: str
+    lesson_sha256: str
+    lesson_bytes: int
+    lesson_text: str
+    manifest: Mapping[str, object]
+
+
+def _validate_manifest(manifest: object, lesson_content: bytes) -> PkpsPackage:
+    document = _object(manifest, "manifest")
+    _valid_json_strings(document)
+    schema_version = document.get("schema_version")
+    if type(schema_version) is not int or schema_version != 1:
+        raise PkpsValidationError("unsupported PKPS schema_version")
+    package_id = _non_empty_string(document.get("package_id"), "package_id")
+    producer_data = _object(document.get("producer"), "producer")
+    if producer_data.get("name") != "gyte-study-tools":
+        raise PkpsValidationError("producer.name must be 'gyte-study-tools'")
+    producer = {
+        "name": "gyte-study-tools",
+        "version": _non_empty_string(producer_data.get("version"), "producer.version"),
+    }
+    created_at = _utc_timestamp(document.get("created_at"), "created_at")
+    lesson = _object(document.get("lesson"), "lesson")
+    lesson_path = _relative_path(lesson.get("path"))
+    sha256 = lesson.get("sha256")
+    if (
+        type(sha256) is not str
+        or len(sha256) != 64
+        or any(char not in "0123456789abcdef" for char in sha256)
+    ):
+        raise PkpsValidationError(
+            "lesson.sha256 must be 64 lowercase hexadecimal characters"
+        )
+    byte_count = lesson.get("bytes")
+    if type(byte_count) is not int or byte_count <= 0:
+        raise PkpsValidationError("lesson.bytes must be a positive integer")
+    if byte_count > MAX_LESSON_BYTES:
+        raise PkpsValidationError("lesson.bytes exceeds the PKPS v1 limit")
+    source = _source(document.get("source"))
+    if len(lesson_content) != byte_count:
+        raise PkpsValidationError("lesson byte count does not match manifest")
+    if hashlib.sha256(lesson_content).hexdigest() != sha256:
+        raise PkpsValidationError("lesson SHA-256 does not match manifest")
+    try:
+        lesson_text = lesson_content.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        raise PkpsValidationError("lesson is not valid UTF-8 Markdown") from None
+    return PkpsPackage(
+        package_id=package_id,
+        schema_version=schema_version,
+        producer=producer,
+        created_at=created_at,
+        source=source,
+        lesson_path=lesson_path,
+        lesson_sha256=sha256,
+        lesson_bytes=byte_count,
+        lesson_text=lesson_text,
+        manifest=document,
+    )
+
+
+def _safe_file(root: Path, relative: str) -> Path:
+    target = root
+    for part in PurePosixPath(relative).parts:
+        target /= part
+        try:
+            mode = target.lstat().st_mode
+        except OSError:
+            raise PkpsPackageError(f"package file is missing: {relative}") from None
+        if stat.S_ISLNK(mode):
+            raise PkpsPackageError(f"package path contains a symlink: {relative}")
+    try:
+        if not target.is_file():
+            raise PkpsPackageError(f"package path is not a file: {relative}")
+    except OSError:
+        raise PkpsPackageError(f"could not inspect package file: {relative}") from None
+    return target
+
+
+def _read_regular_file(
+    path: Path,
+    *,
+    maximum_bytes: int,
+    label: str,
+) -> bytes:
+    try:
+        info = path.stat()
+    except OSError:
+        raise PkpsPackageError(f"could not inspect {label}") from None
+
+    if not stat.S_ISREG(info.st_mode):
+        raise PkpsPackageError(f"{label} is not a regular file")
+    if info.st_size > maximum_bytes:
+        raise PkpsPackageError(f"{label} exceeds the PKPS v1 size limit")
+
+    try:
+        content = path.read_bytes()
+    except OSError:
+        raise PkpsPackageError(f"could not read {label}") from None
+
+    if len(content) > maximum_bytes:
+        raise PkpsPackageError(f"{label} exceeds the PKPS v1 size limit")
+
+    return content
+
+
+def _load_directory(root: Path) -> PkpsPackage:
+    try:
+        mode = root.lstat().st_mode
+    except OSError:
+        raise PkpsPackageError("could not inspect package path") from None
+
+    if stat.S_ISLNK(mode) or not stat.S_ISDIR(mode):
+        raise PkpsPackageError(
+            "package path must be a non-symlink directory or ZIP file"
+        )
+
+    manifest_path = _safe_file(root, "pkps-manifest.json")
+    manifest_content = _read_regular_file(
+        manifest_path,
+        maximum_bytes=MAX_MANIFEST_BYTES,
+        label="manifest",
+    )
+
+    try:
+        raw_manifest = manifest_content.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        raise PkpsPackageError("manifest is not valid UTF-8") from None
+
+    try:
+        manifest = json.loads(
+            raw_manifest,
+            parse_constant=_reject_constant,
+            object_pairs_hook=_unique_object,
+        )
+    except (json.JSONDecodeError, ValueError, UnicodeError):
+        raise PkpsValidationError("manifest is not valid JSON") from None
+
+    lesson = _object(
+        _object(manifest, "manifest").get("lesson"),
+        "lesson",
+    )
+    lesson_path = _relative_path(lesson.get("path"))
+    lesson_file = _safe_file(root, lesson_path)
+    content = _read_regular_file(
+        lesson_file,
+        maximum_bytes=MAX_LESSON_BYTES,
+        label="lesson",
+    )
+
+    return _validate_manifest(manifest, content)
+
+
+def _zip_relative(name: str) -> PurePosixPath:
+    if not name or "\\" in name:
+        raise PkpsPackageError("ZIP entry path is invalid")
+    path = PurePosixPath(name)
+    if path.is_absolute() or any(part in ("", ".", "..") for part in path.parts):
+        raise PkpsPackageError("ZIP entry path is not normalized")
+    expected = path.as_posix() + ("/" if name.endswith("/") else "")
+    if expected != name:
+        raise PkpsPackageError("ZIP entry path is not normalized")
+    return path
+
+
+def _read_zip_entry(
+    archive: zipfile.ZipFile,
+    entry: zipfile.ZipInfo,
+    *,
+    maximum_bytes: int,
+    label: str,
+) -> bytes:
+    if entry.file_size < 0 or entry.file_size > maximum_bytes:
+        raise PkpsPackageError(f"{label} exceeds the PKPS v1 size limit")
+
+    try:
+        content = archive.read(entry)
+    except (OSError, RuntimeError, zipfile.BadZipFile):
+        raise PkpsPackageError(f"could not read ZIP package {label}") from None
+
+    if len(content) > maximum_bytes or len(content) != entry.file_size:
+        raise PkpsPackageError(f"{label} exceeds the PKPS v1 size limit")
+
+    return content
+
+
+def _load_zip(path: Path) -> PkpsPackage:
+    try:
+        mode = path.lstat().st_mode
+    except OSError:
+        raise PkpsPackageError("could not inspect package path") from None
+
+    if stat.S_ISLNK(mode) or not stat.S_ISREG(mode):
+        raise PkpsPackageError(
+            "package path must be a non-symlink directory or ZIP file"
+        )
+
+    try:
+        with zipfile.ZipFile(path) as archive:
+            entries = archive.infolist()
+
+            if not entries:
+                raise PkpsPackageError("ZIP package is empty")
+            if len(entries) > MAX_ZIP_ENTRIES:
+                raise PkpsPackageError("ZIP package exceeds the PKPS v1 entry limit")
+
+            total_uncompressed = 0
+            seen: set[str] = set()
+            roots: set[str] = set()
+            files: dict[str, zipfile.ZipInfo] = {}
+
+            for entry in entries:
+                if entry.file_size < 0:
+                    raise PkpsPackageError("ZIP package contains an invalid entry size")
+
+                total_uncompressed += entry.file_size
+                if total_uncompressed > MAX_ZIP_UNCOMPRESSED_BYTES:
+                    raise PkpsPackageError(
+                        "ZIP package exceeds the PKPS v1 uncompressed-size limit"
+                    )
+
+                relative = _zip_relative(entry.filename)
+                normalized = relative.as_posix()
+
+                if normalized in seen:
+                    raise PkpsPackageError("ZIP package has duplicate entries")
+
+                seen.add(normalized)
+                roots.add(relative.parts[0])
+
+                entry_mode = entry.external_attr >> 16
+                if stat.S_ISLNK(entry_mode):
+                    raise PkpsPackageError("ZIP package contains a symlink")
+
+                if not entry.is_dir():
+                    files[normalized] = entry
+
+            for name in files:
+                if any(name.startswith(f"{other}/") for other in files):
+                    raise PkpsPackageError("ZIP package has incompatible file roots")
+
+            if len(roots) != 1:
+                raise PkpsPackageError(
+                    "ZIP package must have exactly one root directory"
+                )
+
+            root = next(iter(roots))
+            manifest_name = f"{root}/pkps-manifest.json"
+            manifest_entry = files.get(manifest_name)
+
+            if manifest_entry is None:
+                raise PkpsPackageError("ZIP package has no manifest at its root")
+
+            manifest_content = _read_zip_entry(
+                archive,
+                manifest_entry,
+                maximum_bytes=MAX_MANIFEST_BYTES,
+                label="manifest",
+            )
+
+            try:
+                raw_manifest = manifest_content.decode(
+                    "utf-8",
+                    errors="strict",
+                )
+            except UnicodeDecodeError:
+                raise PkpsPackageError("manifest is not valid UTF-8") from None
+
+            try:
+                manifest = json.loads(
+                    raw_manifest,
+                    parse_constant=_reject_constant,
+                    object_pairs_hook=_unique_object,
+                )
+            except (
+                json.JSONDecodeError,
+                ValueError,
+                UnicodeError,
+            ):
+                raise PkpsValidationError("manifest is not valid JSON") from None
+
+            lesson = _object(
+                _object(manifest, "manifest").get("lesson"),
+                "lesson",
+            )
+            lesson_path = _relative_path(lesson.get("path"))
+            lesson_entry = files.get(f"{root}/{lesson_path}")
+
+            if lesson_entry is None:
+                raise PkpsPackageError("ZIP package lesson is missing")
+
+            content = _read_zip_entry(
+                archive,
+                lesson_entry,
+                maximum_bytes=MAX_LESSON_BYTES,
+                label="lesson",
+            )
+
+    except PkpsImportError:
+        raise
+    except (OSError, RuntimeError, zipfile.BadZipFile):
+        raise PkpsPackageError("could not read ZIP package") from None
+
+    return _validate_manifest(manifest, content)
+
+
+def load_pkps_package(path: Path) -> PkpsPackage:
+    """Read a directory package or a securely inspected ZIP package."""
+    try:
+        mode = path.lstat().st_mode
+    except OSError:
+        raise PkpsPackageError("could not inspect package path") from None
+
+    try:
+        if stat.S_ISLNK(mode):
+            raise PkpsPackageError("package path must not be a symlink")
+        if stat.S_ISDIR(mode):
+            return _load_directory(path)
+        if stat.S_ISREG(mode) and path.suffix.lower() == ".zip":
+            return _load_zip(path)
+        raise PkpsPackageError(
+            "package path must be a non-symlink directory or ZIP file"
+        )
+    except PkpsImportError:
+        raise
+    except (OSError, ValueError, TypeError, UnicodeError):
+        raise PkpsPackageError("could not read PKPS package") from None
+
+
+@dataclass(frozen=True)
+class PkpsImportResult:
+    package: PkpsPackage
+    candidate: LessonCandidate
+    reused: bool
+
+
+def _pkps_metadata(candidate: LessonCandidate) -> Mapping[str, object] | None:
+    pkps = candidate.provenance.run_metadata.get("pkps")
+    return pkps if isinstance(pkps, Mapping) else None
+
+
+class PkpsImportService:
+    """Validate PKPS and stage it through the existing candidate repository."""
+
+    def __init__(
+        self, repository: CandidateRepository, clock: Callable[[], datetime]
+    ) -> None:
+        self._repository = repository
+        self._clock = clock
+
+    def import_package(self, path: Path) -> PkpsImportResult:
+        package = load_pkps_package(path)
+        try:
+            existing = self._repository.list()
+        except CandidateRepositoryError:
+            raise PkpsPersistenceError("candidate storage is unavailable") from None
+        for candidate in existing:
+            metadata = _pkps_metadata(candidate)
+            if metadata is None or metadata.get("package_id") != package.package_id:
+                continue
+            if metadata.get("lesson_sha256") != package.lesson_sha256:
+                raise PkpsConflictError(
+                    "package_id already exists with different lesson content"
+                )
+            return PkpsImportResult(package, candidate, reused=True)
+
+        imported_at = self._clock()
+        if imported_at.tzinfo is None or imported_at.utcoffset() is None:
+            raise PkpsPersistenceError("PKPS import clock must be timezone-aware")
+        try:
+            provenance = CandidateProvenance(
+                source_kind=SourceKind.MARKDOWN,
+                source_logical_name=f"pkps:{package.package_id}",
+                source_fingerprint=f"sha256:{package.lesson_sha256}",
+                ingested_at=imported_at,
+                run_metadata={
+                    "pkps": {
+                        "package_id": package.package_id,
+                        "schema_version": package.schema_version,
+                        "producer": dict(package.producer),
+                        "created_at": package.created_at.isoformat(),
+                        "source": dict(package.source),
+                        "lesson_sha256": package.lesson_sha256,
+                        "lesson_bytes": package.lesson_bytes,
+                        "imported_at": imported_at.astimezone(timezone.utc).isoformat(),
+                        "manifest": json.loads(canonical_json(package.manifest)),
+                    }
+                },
+            )
+            candidate = LessonCandidate(text=package.lesson_text, provenance=provenance)
+        except (TypeError, ValueError, UnicodeError):
+            raise PkpsValidationError("package provenance is not persistable") from None
+        try:
+            created = self._repository.create(candidate)
+        except CandidateRepositoryError as exc:
+            # An identical TritaLeLe identity can only be safely reused when it
+            # carries the same PKPS package provenance.
+            try:
+                persisted = self._repository.get(candidate.candidate_id)
+            except CandidateRepositoryError:
+                raise PkpsPersistenceError("could not stage PKPS candidate") from None
+            metadata = _pkps_metadata(persisted)
+            if (
+                metadata is not None
+                and metadata.get("package_id") == package.package_id
+                and metadata.get("lesson_sha256") == package.lesson_sha256
+            ):
+                return PkpsImportResult(package, persisted, reused=True)
+            raise PkpsPersistenceError("could not stage PKPS candidate") from exc
+        return PkpsImportResult(package, created, reused=False)

--- a/src/lele_manager/cli/lele.py
+++ b/src/lele_manager/cli/lele.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from lele_manager.cli import tritalele
+from lele_manager.cli import pkps
 from lele_manager.core.doctor import (
     DoctorOperationalError,
     DoctorProblem,
@@ -344,6 +345,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     tritalele.register_commands(subparsers)
+    pkps.register_commands(subparsers)
 
     return parser
 
@@ -849,6 +851,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     try:
         if hasattr(args, "tritalele_command"):
             code = tritalele.run_command(args)
+        elif hasattr(args, "pkps_command"):
+            code = pkps.run_command(args)
         elif args.command == "search":
             code = cmd_search(base_url, args)
         elif args.command == "export":

--- a/src/lele_manager/cli/pkps.py
+++ b/src/lele_manager/cli/pkps.py
@@ -1,0 +1,117 @@
+"""CLI adapter for Personal Knowledge Publishing System package imports."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.application.pkps_import import (
+    PkpsConflictError,
+    PkpsImportError,
+    PkpsImportResult,
+    PkpsImportService,
+    PkpsPackageError,
+    PkpsPersistenceError,
+    PkpsValidationError,
+)
+from lele_manager.core.paths import candidates_path
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def register_commands(subparsers: Any) -> None:
+    """Register the ``lele pkps import`` command group."""
+    pkps = subparsers.add_parser(
+        "pkps", help="Importa package Personal Knowledge Publishing System (PKPS)."
+    )
+    nested = pkps.add_subparsers(dest="pkps_command", required=True, metavar="{import}")
+    importer = nested.add_parser(
+        "import", help="Valida un package PKPS e lo mette in staging TritaLeLe."
+    )
+    importer.add_argument("package_path", type=Path, metavar="PACKAGE_PATH")
+    importer.add_argument(
+        "--json", action="store_true", help="Stampa solo JSON stabile."
+    )
+    importer.set_defaults(pkps_command="import")
+
+
+def _repository() -> JsonCandidateRepository:
+    try:
+        return JsonCandidateRepository(candidates_path())
+    except (OSError, RuntimeError):
+        raise PkpsPersistenceError(
+            "candidate storage configuration is unavailable"
+        ) from None
+
+
+def _payload(result: PkpsImportResult) -> dict[str, object]:
+    package = result.package
+    return {
+        "package_id": package.package_id,
+        "schema_version": package.schema_version,
+        "producer": dict(package.producer),
+        "source": dict(package.source),
+        "lesson_sha256": package.lesson_sha256,
+        "lesson_bytes": package.lesson_bytes,
+        "candidate_id": result.candidate.candidate_id,
+        "candidate_status": result.candidate.state.value,
+        "reused": result.reused,
+        "idempotent": result.reused,
+        "provenance_available": True,
+    }
+
+
+def _print_json(value: object, *, file: Any = None) -> None:
+    print(json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2), file=file)
+
+
+def _error(args: argparse.Namespace, code: str, message: str, exit_code: int) -> int:
+    if args.json:
+        _print_json({"error": {"code": code, "message": message}}, file=sys.stderr)
+    else:
+        print(f"[errore] {message}", file=sys.stderr)
+    return exit_code
+
+
+def _human(result: PkpsImportResult) -> None:
+    package = result.package
+    outcome = "riutilizzato (idempotente)" if result.reused else "messo in staging"
+    print(f"[ok] Package PKPS {outcome}.")
+    print(f"Package: {package.package_id} (schema v{package.schema_version})")
+    print(
+        f"Candidato: {result.candidate.candidate_id} | stato={result.candidate.state.value}"
+    )
+    print(f"Lesson: sha256={package.lesson_sha256} | bytes={package.lesson_bytes}")
+    print("Provenienza PKPS: disponibile nel candidato TritaLeLe.")
+
+
+def run_command(args: argparse.Namespace) -> int:
+    """Run a PKPS leaf and translate only stable domain failures."""
+    try:
+        if args.pkps_command != "import":
+            raise RuntimeError("unregistered PKPS command")
+        result = PkpsImportService(_repository(), _utc_now).import_package(
+            args.package_path
+        )
+        if args.json:
+            _print_json(_payload(result))
+        else:
+            _human(result)
+        return 0
+    except PkpsConflictError as error:
+        return _error(args, "package_id_conflict", str(error), 1)
+    except PkpsValidationError as error:
+        return _error(args, "invalid_package", str(error), 1)
+    except PkpsPackageError as error:
+        return _error(args, "unreadable_package", str(error), 1)
+    except PkpsPersistenceError as error:
+        return _error(args, "candidate_storage_unavailable", str(error), 2)
+    except PkpsImportError as error:
+        return _error(args, "pkps_import_failed", str(error), 1)

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -16,6 +16,7 @@ DOCUMENT_PAIRS = (
         Path("docs/it/documentation-policy.md"),
     ),
     (Path("docs/projection-store.md"), Path("docs/it/projection-store.md")),
+    (Path("docs/pkps-package.md"), Path("docs/it/pkps-package.md")),
     (
         Path("docs/gui-user-guide.md"),
         Path("docs/it/gui-user-guide.md"),

--- a/tests/test_pkps_hardening.py
+++ b/tests/test_pkps_hardening.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from lele_manager.adapters.json_candidate_repository import (
+    JsonCandidateRepository,
+)
+from lele_manager.application.candidate_approval import (
+    CandidateApprovalService,
+    CanonicalLessonSpec,
+    RefreshOutcome,
+    VaultWriteOutcome,
+)
+from lele_manager.application.candidate_review import (
+    CandidateReviewService,
+)
+import lele_manager.application.pkps_import as pkps_import
+from lele_manager.application.pkps_import import (
+    PkpsConflictError,
+    PkpsImportService,
+    PkpsPackageError,
+    PkpsPersistenceError,
+    load_pkps_package,
+)
+from lele_manager.cli import lele as lele_cli
+from lele_manager.cli import pkps as pkps_cli
+
+
+NOW = datetime(2026, 8, 6, 10, 0, tzinfo=timezone.utc)
+
+
+def _manifest(
+    content: bytes,
+    *,
+    package_id: str = "gyte:lesson-001",
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "package_id": package_id,
+        "producer": {
+            "name": "gyte-study-tools",
+            "version": "0.5.0-dev",
+        },
+        "created_at": "2026-08-06T09:00:00Z",
+        "lesson": {
+            "path": "lesson.md",
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "bytes": len(content),
+        },
+        "source": {
+            "type": "article",
+            "url": "https://example.test/article",
+            "title": "Synthetic PKPS lesson",
+            "external_id": "article-001",
+        },
+    }
+
+
+def _write_package(
+    root: Path,
+    *,
+    content: bytes = b"# Synthetic PKPS lesson\n",
+    package_id: str = "gyte:lesson-001",
+) -> Path:
+    root.mkdir()
+    (root / "lesson.md").write_bytes(content)
+    (root / "pkps-manifest.json").write_text(
+        json.dumps(
+            _manifest(content, package_id=package_id),
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return root
+
+
+def _service(
+    tmp_path: Path,
+) -> tuple[PkpsImportService, JsonCandidateRepository]:
+    repository = JsonCandidateRepository(tmp_path / "candidates.json")
+    return (
+        PkpsImportService(repository, lambda: NOW),
+        repository,
+    )
+
+
+class RecordingVault:
+    def __init__(self) -> None:
+        self.lessons: list[CanonicalLessonSpec] = []
+
+    def publish(
+        self,
+        lesson: CanonicalLessonSpec,
+    ) -> VaultWriteOutcome:
+        self.lessons.append(lesson)
+        return VaultWriteOutcome.CREATED
+
+    def verify(
+        self,
+        lesson: CanonicalLessonSpec,
+    ) -> VaultWriteOutcome:
+        self.lessons.append(lesson)
+        return VaultWriteOutcome.IDENTICAL
+
+
+class RecordingRefresh:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def refresh(self) -> RefreshOutcome:
+        self.calls += 1
+        return RefreshOutcome()
+
+
+def test_rejects_zip_package_path_symlink(
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "package.zip"
+
+    with zipfile.ZipFile(archive, "w") as target:
+        target.writestr("root/file.txt", "x")
+
+    linked = tmp_path / "linked.zip"
+    linked.symlink_to(archive)
+
+    with pytest.raises(
+        PkpsPackageError,
+        match="must not be a symlink",
+    ):
+        load_pkps_package(linked)
+
+
+def test_rejects_directory_manifest_over_resource_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_package(tmp_path / "package")
+    monkeypatch.setattr(pkps_import, "MAX_MANIFEST_BYTES", 16)
+
+    with pytest.raises(
+        PkpsPackageError,
+        match="manifest exceeds",
+    ):
+        load_pkps_package(package)
+
+
+def test_rejects_directory_lesson_over_resource_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    package = _write_package(
+        tmp_path / "package",
+        content=b"# lesson\n",
+    )
+    monkeypatch.setattr(pkps_import, "MAX_LESSON_BYTES", 4)
+
+    with pytest.raises(
+        PkpsPackageError,
+        match="lesson exceeds",
+    ):
+        load_pkps_package(package)
+
+
+def test_rejects_zip_entry_count_over_resource_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content = b"# lesson\n"
+    archive = tmp_path / "package.zip"
+
+    with zipfile.ZipFile(archive, "w") as target:
+        target.writestr(
+            "root/pkps-manifest.json",
+            json.dumps(_manifest(content)),
+        )
+        target.writestr("root/lesson.md", content)
+        target.writestr("root/extra.txt", "x")
+
+    monkeypatch.setattr(pkps_import, "MAX_ZIP_ENTRIES", 2)
+
+    with pytest.raises(
+        PkpsPackageError,
+        match="entry limit",
+    ):
+        load_pkps_package(archive)
+
+
+def test_rejects_zip_uncompressed_size_over_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content = b"# lesson\n"
+    archive = tmp_path / "package.zip"
+
+    with zipfile.ZipFile(archive, "w") as target:
+        target.writestr(
+            "root/pkps-manifest.json",
+            json.dumps(_manifest(content)),
+        )
+        target.writestr("root/lesson.md", content)
+
+    monkeypatch.setattr(
+        pkps_import,
+        "MAX_ZIP_UNCOMPRESSED_BYTES",
+        8,
+    )
+
+    with pytest.raises(
+        PkpsPackageError,
+        match="uncompressed-size limit",
+    ):
+        load_pkps_package(archive)
+
+
+def test_different_package_ids_with_same_content_are_distinct(
+    tmp_path: Path,
+) -> None:
+    content = b"# Shared content\n"
+    first_package = _write_package(
+        tmp_path / "first",
+        content=content,
+        package_id="gyte:first",
+    )
+    second_package = _write_package(
+        tmp_path / "second",
+        content=content,
+        package_id="gyte:second",
+    )
+    service, repository = _service(tmp_path)
+
+    first = service.import_package(first_package)
+    second = service.import_package(second_package)
+
+    assert first.candidate.candidate_id != second.candidate.candidate_id
+    assert len(repository.list()) == 2
+
+
+def test_idempotent_reimport_preserves_original_provenance(
+    tmp_path: Path,
+) -> None:
+    package = _write_package(tmp_path / "package")
+    service, repository = _service(tmp_path)
+
+    first = service.import_package(package)
+    first_provenance = first.candidate.provenance
+    second = service.import_package(package)
+
+    assert second.reused is True
+    assert second.candidate.provenance == first_provenance
+    assert repository.list() == (first.candidate,)
+
+
+def test_same_package_id_with_different_content_conflicts(
+    tmp_path: Path,
+) -> None:
+    package = _write_package(tmp_path / "package")
+    service, _ = _service(tmp_path)
+
+    service.import_package(package)
+
+    replacement = b"# Changed content\n"
+    (package / "lesson.md").write_bytes(replacement)
+    (package / "pkps-manifest.json").write_text(
+        json.dumps(_manifest(replacement)),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(PkpsConflictError):
+        service.import_package(package)
+
+
+def test_pkps_provenance_survives_normal_approval(
+    tmp_path: Path,
+) -> None:
+    package = _write_package(tmp_path / "package")
+    service, repository = _service(tmp_path)
+    imported = service.import_package(package)
+
+    original_pkps = imported.candidate.provenance.run_metadata["pkps"]
+    vault = RecordingVault()
+    refresh = RecordingRefresh()
+
+    assert vault.lessons == []
+
+    review = CandidateReviewService(repository, lambda: NOW)
+    revised = review.revise_candidate(
+        imported.candidate.candidate_id,
+        expected_revision=0,
+        proposed_text=None,
+        proposed_metadata={
+            "topic": "science",
+            "source": "article",
+            "importance": 4,
+            "tags": ["pkps", "gyte"],
+            "date": "2026-08-06",
+            "title": "Synthetic PKPS lesson",
+        },
+        reason="prepare canonical metadata",
+    )
+    accepted = review.accept_candidate(
+        revised.candidate_id,
+        expected_revision=revised.revision,
+        reason="review complete",
+    )
+
+    assert vault.lessons == []
+
+    approval = CandidateApprovalService(
+        repository,
+        vault,
+        refresh,
+        lambda: NOW,
+    ).approve(
+        accepted.candidate_id,
+        expected_revision=accepted.revision,
+    )
+
+    assert approval.candidate_state_changed is True
+    assert len(vault.lessons) == 1
+    assert refresh.calls == 1
+
+    canonical_pkps = vault.lessons[0].provenance["run_metadata"]["pkps"]
+
+    assert canonical_pkps["package_id"] == original_pkps["package_id"]
+    assert canonical_pkps["schema_version"] == 1
+    assert canonical_pkps["producer"] == {
+        "name": "gyte-study-tools",
+        "version": "0.5.0-dev",
+    }
+    assert canonical_pkps["source"]["url"] == ("https://example.test/article")
+    assert canonical_pkps["lesson_sha256"] == (
+        hashlib.sha256(b"# Synthetic PKPS lesson\n").hexdigest()
+    )
+    assert canonical_pkps["lesson_bytes"] == len(b"# Synthetic PKPS lesson\n")
+    assert canonical_pkps["manifest"]["source"]["external_id"] == ("article-001")
+
+
+def test_cli_unreadable_package_has_controlled_human_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv(
+        "LELE_DATA_DIR",
+        str(tmp_path / "data"),
+    )
+
+    with pytest.raises(SystemExit) as result:
+        lele_cli.main(["pkps", "import", str(tmp_path / "missing")])
+
+    captured = capsys.readouterr()
+
+    assert result.value.code == 1
+    assert captured.out == ""
+    assert "[errore]" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_cli_invalid_manifest_has_controlled_json_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    package = _write_package(tmp_path / "package")
+    (package / "pkps-manifest.json").write_text(
+        "{",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv(
+        "LELE_DATA_DIR",
+        str(tmp_path / "data"),
+    )
+
+    with pytest.raises(SystemExit) as result:
+        lele_cli.main(["pkps", "import", str(package), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert result.value.code == 1
+    assert captured.out == ""
+    assert payload["error"]["code"] == "invalid_package"
+    assert "Traceback" not in captured.err
+
+
+def test_cli_package_conflict_has_controlled_json_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    package = _write_package(tmp_path / "package")
+    monkeypatch.setenv(
+        "LELE_DATA_DIR",
+        str(tmp_path / "data"),
+    )
+
+    with pytest.raises(SystemExit) as first:
+        lele_cli.main(["pkps", "import", str(package), "--json"])
+
+    assert first.value.code == 0
+    capsys.readouterr()
+
+    replacement = b"# replacement\n"
+    (package / "lesson.md").write_bytes(replacement)
+    (package / "pkps-manifest.json").write_text(
+        json.dumps(_manifest(replacement)),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as second:
+        lele_cli.main(["pkps", "import", str(package), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert second.value.code == 1
+    assert payload["error"]["code"] == "package_id_conflict"
+    assert "Traceback" not in captured.err
+
+
+def test_cli_storage_failure_has_controlled_json_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    package = _write_package(tmp_path / "package")
+
+    def unavailable_repository() -> JsonCandidateRepository:
+        raise PkpsPersistenceError("candidate storage configuration is unavailable")
+
+    monkeypatch.setattr(
+        pkps_cli,
+        "_repository",
+        unavailable_repository,
+    )
+
+    with pytest.raises(SystemExit) as result:
+        lele_cli.main(["pkps", "import", str(package), "--json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.err)
+
+    assert result.value.code == 2
+    assert captured.out == ""
+    assert payload["error"]["code"] == ("candidate_storage_unavailable")
+    assert "Traceback" not in captured.err

--- a/tests/test_pkps_import.py
+++ b/tests/test_pkps_import.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import zipfile
+
+import pytest
+
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.application.pkps_import import (
+    PkpsConflictError,
+    PkpsImportError,
+    PkpsImportService,
+    PkpsPackageError,
+    PkpsValidationError,
+    load_pkps_package,
+)
+from lele_manager.cli import lele as lele_cli
+
+
+NOW = datetime(2026, 8, 6, 10, 0, tzinfo=timezone.utc)
+
+
+def _manifest(content: bytes, **changes: object) -> dict[str, object]:
+    document: dict[str, object] = {
+        "schema_version": 1,
+        "package_id": "gyte:lesson-001",
+        "producer": {"name": "gyte-study-tools", "version": "0.1.0"},
+        "created_at": "2026-08-06T09:00:00Z",
+        "lesson": {
+            "path": "lesson.md",
+            "sha256": hashlib.sha256(content).hexdigest(),
+            "bytes": len(content),
+        },
+        "source": {
+            "type": "youtube",
+            "url": "https://example.test/watch?v=1",
+            "title": "Synthetic",
+        },
+    }
+    document.update(changes)
+    return document
+
+
+def _directory(root: Path, content: bytes = b"# Synthetic lesson\n") -> Path:
+    root.mkdir()
+    (root / "lesson.md").write_bytes(content)
+    (root / "pkps-manifest.json").write_text(
+        json.dumps(_manifest(content)), encoding="utf-8"
+    )
+    return root
+
+
+def _service(tmp_path: Path) -> tuple[PkpsImportService, JsonCandidateRepository]:
+    repository = JsonCandidateRepository(tmp_path / "candidates.json")
+    return PkpsImportService(repository, lambda: NOW), repository
+
+
+def test_imports_directory_as_staged_candidate_with_persistent_provenance(
+    tmp_path: Path,
+) -> None:
+    package = _directory(tmp_path / "package")
+    service, repository = _service(tmp_path)
+
+    result = service.import_package(package)
+
+    assert result.reused is False
+    assert result.candidate.state.value == "staged"
+    assert repository.list() == (result.candidate,)
+    pkps = result.candidate.provenance.run_metadata["pkps"]
+    assert pkps["package_id"] == "gyte:lesson-001"
+    assert pkps["imported_at"] == NOW.isoformat()
+    assert pkps["manifest"]["source"]["title"] == "Synthetic"
+
+
+def test_reimport_is_idempotent_and_package_id_content_conflicts(
+    tmp_path: Path,
+) -> None:
+    package = _directory(tmp_path / "package")
+    service, repository = _service(tmp_path)
+
+    first = service.import_package(package)
+    second = service.import_package(package)
+
+    assert second.reused is True
+    assert second.candidate == first.candidate
+    assert len(repository.list()) == 1
+    replacement = b"# Changed lesson\n"
+    (package / "lesson.md").write_bytes(replacement)
+    (package / "pkps-manifest.json").write_text(
+        json.dumps(_manifest(replacement)), encoding="utf-8"
+    )
+    with pytest.raises(PkpsConflictError):
+        service.import_package(package)
+
+
+def test_imports_single_root_zip(tmp_path: Path) -> None:
+    content = b"# Zip lesson\n"
+    archive = tmp_path / "package.zip"
+    with zipfile.ZipFile(archive, "w") as target:
+        target.writestr(
+            "pkps-package/pkps-manifest.json", json.dumps(_manifest(content))
+        )
+        target.writestr("pkps-package/lesson.md", content)
+
+    result = _service(tmp_path)[0].import_package(archive)
+
+    assert result.candidate.text == content.decode()
+
+
+@pytest.mark.parametrize(
+    ("change", "error"),
+    [
+        ({"schema_version": 2}, PkpsValidationError),
+        ({"producer": {"name": "other", "version": "1"}}, PkpsValidationError),
+        (
+            {"lesson": {"path": "/lesson.md", "sha256": "0" * 64, "bytes": 1}},
+            PkpsValidationError,
+        ),
+        (
+            {"lesson": {"path": "../lesson.md", "sha256": "0" * 64, "bytes": 1}},
+            PkpsValidationError,
+        ),
+        (
+            {"lesson": {"path": "missing.md", "sha256": "0" * 64, "bytes": 1}},
+            PkpsPackageError,
+        ),
+        (
+            {"lesson": {"path": "lesson.md", "sha256": "0" * 64, "bytes": 1}},
+            PkpsValidationError,
+        ),
+        (
+            {
+                "lesson": {
+                    "path": "lesson.md",
+                    "sha256": hashlib.sha256(b"# Synthetic lesson\n").hexdigest(),
+                    "bytes": True,
+                }
+            },
+            PkpsValidationError,
+        ),
+        ({"package_id": ""}, PkpsValidationError),
+        ({"source": {"type": "article", "url": "http://["}}, PkpsValidationError),
+    ],
+)
+def test_rejects_invalid_manifest_contract(
+    tmp_path: Path, change: dict[str, object], error: type[Exception]
+) -> None:
+    package = _directory(tmp_path / "package")
+    content = (package / "lesson.md").read_bytes()
+    manifest = _manifest(content)
+    manifest.update(change)
+    (package / "pkps-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(error):
+        load_pkps_package(package)
+
+
+def test_rejects_malformed_json_and_external_lesson_symlink(tmp_path: Path) -> None:
+    package = _directory(tmp_path / "package")
+    (package / "pkps-manifest.json").write_text("{", encoding="utf-8")
+    with pytest.raises(PkpsValidationError):
+        load_pkps_package(package)
+
+    package = _directory(tmp_path / "surrogate")
+    content = (package / "lesson.md").read_bytes()
+    manifest = _manifest(content)
+    manifest["source"] = {
+        "type": "article",
+        "url": "https://example.test/a",
+        "external_id": "\ud800",
+    }
+    (package / "pkps-manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=True), encoding="utf-8"
+    )
+    with pytest.raises(PkpsValidationError):
+        load_pkps_package(package)
+
+    package = _directory(tmp_path / "linked")
+    external = tmp_path / "external.md"
+    external.write_text("# external\n", encoding="utf-8")
+    (package / "lesson.md").unlink()
+    (package / "lesson.md").symlink_to(external)
+    with pytest.raises(PkpsPackageError):
+        load_pkps_package(package)
+
+    package = _directory(tmp_path / "manifest-linked")
+    external_manifest = tmp_path / "external-manifest.json"
+    external_manifest.write_text("{}", encoding="utf-8")
+    (package / "pkps-manifest.json").unlink()
+    (package / "pkps-manifest.json").symlink_to(external_manifest)
+    with pytest.raises(PkpsPackageError):
+        load_pkps_package(package)
+
+
+def test_rejects_inconsistent_lesson_size(tmp_path: Path) -> None:
+    package = _directory(tmp_path / "package")
+    content = (package / "lesson.md").read_bytes()
+    manifest = _manifest(content)
+    manifest["lesson"] = {
+        "path": "lesson.md",
+        "sha256": hashlib.sha256(content).hexdigest(),
+        "bytes": len(content) + 1,
+    }
+    (package / "pkps-manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(PkpsValidationError):
+        load_pkps_package(package)
+
+
+def test_rejects_ambiguous_or_unsafe_zip(tmp_path: Path) -> None:
+    archive = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(archive, "w") as target:
+        target.writestr("a/pkps-manifest.json", "{}")
+        target.writestr("b/lesson.md", "x")
+    with pytest.raises(PkpsPackageError):
+        load_pkps_package(archive)
+
+
+@pytest.mark.parametrize("kind", ["traversal", "duplicate", "symlink"])
+def test_rejects_unsafe_zip_entries(tmp_path: Path, kind: str) -> None:
+    archive = tmp_path / f"{kind}.zip"
+    with zipfile.ZipFile(archive, "w") as target:
+        if kind == "traversal":
+            target.writestr("root/../pkps-manifest.json", "{}")
+        elif kind == "duplicate":
+            target.writestr("root/pkps-manifest.json", "{}")
+            target.writestr("root/pkps-manifest.json", "{}")
+        else:
+            link = zipfile.ZipInfo("root/lesson.md")
+            link.external_attr = 0o120777 << 16
+            target.writestr(link, "outside.md")
+
+    with pytest.raises(PkpsPackageError):
+        load_pkps_package(archive)
+
+
+def test_malformed_boundary_input_raises_only_domain_error(tmp_path: Path) -> None:
+    package = _directory(tmp_path / "package")
+    (package / "pkps-manifest.json").write_bytes(b"\xff")
+
+    with pytest.raises(PkpsImportError):
+        load_pkps_package(package)
+
+
+def test_cli_emits_human_and_json_without_writing_vault_or_projection(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    package = _directory(tmp_path / "package")
+    data = tmp_path / "data"
+    vault = tmp_path / "vault"
+    monkeypatch.setenv("LELE_DATA_DIR", str(data))
+    monkeypatch.setenv("LELE_VAULT_DIR", str(vault))
+
+    with pytest.raises(SystemExit) as first:
+        lele_cli.main(["pkps", "import", str(package)])
+    assert first.value.code == 0
+    assert "Package PKPS" in capsys.readouterr().out
+    assert not vault.exists()
+    assert not (data / "lessons.jsonl").exists()
+
+    with pytest.raises(SystemExit) as second:
+        lele_cli.main(["pkps", "import", str(package), "--json"])
+    assert second.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["package_id"] == "gyte:lesson-001"
+    assert payload["candidate_status"] == "staged"
+    assert payload["reused"] is True
+    assert payload["provenance_available"] is True


### PR DESCRIPTION
## Summary

Adds the **local PKPS package consumer boundary of LeLe Manager**.

The new `lele pkps import` command accepts versioned lesson packages produced
by GYTE Study Tools and stages their Markdown lesson as an isolated TritaLeLe
candidate.

This pull request does **not** implement the independent PKPS project, its
cross-repository orchestration, or its future canonical protocol ownership.
It implements only the LeLe Manager receiving side that such a system can use.

## Architecture

- reuses the existing TritaLeLe candidate lifecycle;
- never writes directly to the canonical vault or projection store;
- persists normalized package provenance with the candidate;
- preserves the ordinary review and approval workflow;
- supports directory and single-root ZIP packages;
- provides stable human-readable and JSON CLI output;
- remains a local LeLe application boundary rather than a PKPS orchestrator.

## Safety and integrity

- validates schema version, producer, timestamps and JSON types;
- verifies lesson byte count and SHA-256;
- rejects absolute, traversing and non-normalized paths;
- rejects symlinks and unsafe ZIP entries;
- enforces resource limits for manifests, lessons and ZIP archives;
- handles idempotent imports and explicit package-ID conflicts;
- converts known technical failures into stable domain errors.

## Validation

- Ruff: passed
- mypy: 57 source files passed
- focused PKPS and candidate tests: 103 passed
- full Python suite: 560 passed
- Playwright E2E: 19 passed, 1 expected skip
- GUI production build: passed
- wheel installation smoke: passed
- sdist rebuild and installation smoke: passed
- Twine metadata checks: passed
- documentation tests after terminology clarification: passed
- credential and private-artifact scans: passed

Closes #153
