### PR TITLE
feat: add multiplatform native release packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -50,15 +50,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -91,15 +91,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,52 @@ jobs:
           name: dist
           path: dist/*
 
+  native-packages:
+    name: Native package (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: Linux
+          - os: macos-latest
+            platform: macOS
+          - os: windows-latest
+            platform: Windows
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+
+      - name: Build native application
+        run: python scripts/build-native-app.py
+
+      - name: Package native release
+        run: python scripts/package-native-release.py
+
+      - name: Upload native package
+        uses: actions/upload-artifact@v4
+        with:
+          name: lele-manager-${{ matrix.platform }}
+          path: dist/release/*
+          if-no-files-found: error
+
   publish:
     if: ${{ github.event_name == 'workflow_dispatch' && vars.PYPI_ENABLED == 'true' }}
     name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
     name: Build sdist and wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -38,7 +38,7 @@ jobs:
       - name: Build release artifacts
         run: ./scripts/build-release-artifacts.sh
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/*
@@ -57,15 +57,15 @@ jobs:
             platform: Windows
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -83,7 +83,7 @@ jobs:
         run: python scripts/package-native-release.py
 
       - name: Upload native package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lele-manager-${{ matrix.platform }}
           path: dist/release/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      publish_pypi:
+        description: "Publish Python artifacts to PyPI"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -84,7 +90,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    if: ${{ github.event_name == 'workflow_dispatch' && vars.PYPI_ENABLED == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_pypi && vars.PYPI_ENABLED == 'true' }}
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/docs/multiplatform-release-packaging.md
+++ b/docs/multiplatform-release-packaging.md
@@ -1,0 +1,140 @@
+# Multiplatform release packaging
+
+> Status: implementation contract
+> Pilot project: LeLe Manager
+
+## Goal
+
+A stable LeLe Manager release must be usable by a non-technical person without
+installing Python, Node.js, npm, development tools, or project dependencies.
+
+The normal user flow is:
+
+1. download the package for the operating system;
+2. extract or open it;
+3. launch LeLe Manager;
+4. wait for the browser to open automatically;
+5. use the web GUI.
+
+## Supported platforms
+
+Release packaging is organized by operating system and architecture.
+
+Canonical artifact naming:
+
+- `LeLe-Manager-vX.Y.Z-Linux-<arch>.tar.gz`
+- `LeLe-Manager-vX.Y.Z-macOS-<arch>.zip`
+- `LeLe-Manager-vX.Y.Z-Windows-<arch>.zip`
+
+The architecture suffix keeps the contract extensible without changing the
+release naming scheme.
+
+## User contract
+
+The packaged application must:
+
+- include the Python runtime and all required Python dependencies;
+- include the compiled Svelte GUI;
+- require no Python, pip, Node.js, npm, or virtual environment on the target
+  computer;
+- provide one obvious launcher;
+- start the local LeLe Manager backend automatically;
+- wait until the local service is ready;
+- open the default browser on the LeLe Manager GUI automatically;
+- keep user data outside the application installation directory;
+- preserve user data across application upgrades;
+- show a useful error message if startup fails.
+
+## Persistent user data
+
+Runtime data must not be stored inside the unpacked release directory.
+
+LeLe Manager uses `platformdirs` to resolve an operating-system-appropriate
+user data directory.
+
+The packaged launcher must create the required directories on first startup,
+including a default Markdown Vault when one does not already exist.
+
+Environment variables explicitly supplied by an advanced user may continue to
+override normal defaults where the existing application contract allows it.
+
+## Launcher
+
+A product-level launcher will be responsible for:
+
+1. resolving persistent user directories;
+2. preparing first-run directories when necessary;
+3. configuring LeLe Manager runtime paths;
+4. starting the FastAPI application;
+5. waiting for the local health endpoint;
+6. opening `/app/` in the default browser;
+7. keeping the local server alive until the application is closed.
+
+The launcher must be implemented in application code rather than duplicating
+business logic in separate shell, Batch, or PowerShell implementations.
+
+OS-specific files may provide only the thin entry point required to invoke the
+packaged launcher.
+
+## Packaging strategy
+
+The distributable application must be self-contained.
+
+Packaging must be produced natively for each target platform in CI rather than
+cross-building platform executables from another operating system.
+
+The existing Python wheel and source distribution remain supported technical
+artifacts. They are not the primary installation path for non-technical users.
+
+## GitHub Actions
+
+Stable release automation must build packages on native runners for:
+
+- Linux;
+- macOS;
+- Windows.
+
+The workflow must verify each packaged application before publishing it as a
+GitHub Release asset.
+
+A release must not publish an artifact merely because packaging completed:
+the packaged executable must pass a startup/smoke verification first.
+
+## User documentation
+
+Each release package must include a short first-run guide appropriate to the
+target operating system.
+
+The guide must explain actions in user terms, for example:
+
+- where to click to download the package;
+- how to open or extract it;
+- exactly which launcher to double-click;
+- what happens next;
+- what to do if the browser does not open.
+
+Documentation must not assume knowledge of terminals, Python, virtual
+environments, package managers, APIs, or web servers.
+
+## Version and tag invariants
+
+Before a release tag is created:
+
+- the application/package version must already equal the intended tag;
+- source and packaged GUI must be synchronized;
+- tests and packaging smoke checks must be green;
+- all intended native release artifacts must be reproducibly buildable.
+
+The release tag is the final release seal, not the mechanism that prepares the
+release.
+
+For example, tag `v1.10.1` requires application version `1.10.1`.
+
+## Wider GiadaWare policy
+
+LeLe Manager is the pilot implementation of this release contract.
+
+Once validated here, the same user-facing release principle should be applied
+to installable applications listed in the GiadaWare GitHub showcase under
+`1 · SELECTED PROJECTS`, adapted only where a project's runtime architecture
+requires a different native packaging mechanism.

--- a/packaging/guides/LEGGIMI_PRIMA-Linux.txt
+++ b/packaging/guides/LEGGIMI_PRIMA-Linux.txt
@@ -1,0 +1,30 @@
+LELE MANAGER — COME APRIRLO SU LINUX
+
+1. Apri la cartella LeLe-Manager.
+2. Cerca il file chiamato LeLe-Manager.
+3. Fai doppio clic sul file LeLe-Manager.
+4. Se il computer ti chiede se vuoi eseguirlo, conferma.
+5. Aspetta qualche secondo.
+6. LeLe Manager si aprirà automaticamente nel browser.
+
+Quando il programma è aperto puoi usare normalmente:
+- Esplora
+- Nuova LeLe
+- Vault
+
+IMPORTANTE
+
+Non devi installare Python.
+Non devi installare Node.js.
+Non devi aprire il terminale.
+Non devi configurare niente.
+
+Quando chiudi LeLe Manager, puoi chiudere anche la finestra del programma
+eventualmente rimasta aperta.
+
+SE NON SI APRE
+
+Aspetta circa 10 secondi e prova di nuovo.
+
+Se ancora non parte, annota quello che compare sullo schermo e chiedi aiuto
+alla persona che ti ha mandato LeLe Manager.

--- a/packaging/guides/LEGGIMI_PRIMA-Windows.txt
+++ b/packaging/guides/LEGGIMI_PRIMA-Windows.txt
@@ -1,0 +1,29 @@
+LELE MANAGER — COME APRIRLO SU WINDOWS
+
+1. Apri la cartella che hai appena estratto.
+2. Apri la cartella LeLe-Manager.
+3. Cerca il file chiamato LeLe-Manager.exe.
+4. Fai doppio clic su LeLe-Manager.exe.
+5. Se Windows ti chiede conferma, scegli di eseguire il programma.
+6. Aspetta qualche secondo.
+7. LeLe Manager si aprirà automaticamente nel browser.
+
+Quando il programma è aperto puoi usare normalmente:
+- Esplora
+- Nuova LeLe
+- Vault
+
+IMPORTANTE
+
+Non devi installare Python.
+Non devi installare Node.js.
+Non devi aprire PowerShell o il Prompt dei comandi.
+Non devi configurare niente.
+
+SE IL BROWSER NON SI APRE
+
+Aspetta circa 10 secondi e prova di nuovo.
+
+Se Windows mostra un messaggio di sicurezza, leggilo prima di confermare.
+Se ancora non parte, annota quello che compare sullo schermo e chiedi aiuto
+alla persona che ti ha mandato LeLe Manager.

--- a/packaging/guides/LEGGIMI_PRIMA-macOS.txt
+++ b/packaging/guides/LEGGIMI_PRIMA-macOS.txt
@@ -1,0 +1,30 @@
+LELE MANAGER — COME APRIRLO SU macOS
+
+1. Apri il file ZIP che hai scaricato.
+2. Apri la cartella che viene creata.
+3. Apri la cartella LeLe-Manager.
+4. Fai doppio clic su LeLe-Manager.
+5. Aspetta qualche secondo.
+6. LeLe Manager si aprirà automaticamente nel browser.
+
+Quando il programma è aperto puoi usare normalmente:
+- Esplora
+- Nuova LeLe
+- Vault
+
+IMPORTANTE
+
+Non devi installare Python.
+Non devi installare Node.js.
+Non devi aprire il Terminale.
+Non devi configurare niente.
+
+SE macOS BLOCCA L'APERTURA
+
+Apri Impostazioni di Sistema.
+Vai in Privacy e sicurezza.
+Controlla se macOS mostra un messaggio relativo a LeLe Manager e, se riconosci
+il programma che hai appena scaricato, usa l'opzione disponibile per aprirlo.
+
+Se ancora non parte, annota quello che compare sullo schermo e chiedi aiuto
+alla persona che ti ha mandato LeLe Manager.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,13 @@ dependencies = [
 
 [project.scripts]
 lele = "lele_manager.cli.lele:main"
+lele-manager = "lele_manager.launcher:main"
 
 [project.optional-dependencies]
 dev = [
     "pytest",
     "pytest-cov",
+    "pyinstaller>=6.21.0,<7",
     "fastapi",
     "uvicorn",
     "pandas",

--- a/scripts/build-gui.py
+++ b/scripts/build-gui.py
@@ -52,7 +52,7 @@ def main() -> int:
     install_dependencies(npm)
     build_frontend(npm)
 
-    print("==> Copying dist → src/lele_manager/gui/static")
+    print("==> Copying dist -> src/lele_manager/gui/static")
     copy_distribution()
 
     print(f"OK: GUI build in {TARGET}")

--- a/scripts/build-gui.py
+++ b/scripts/build-gui.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Build the LeLe Manager Svelte GUI and copy it into the Python package."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FRONTEND = ROOT / "frontend"
+FRONTEND_DIST = FRONTEND / "dist"
+TARGET = ROOT / "src" / "lele_manager" / "gui" / "static"
+
+
+def npm_executable() -> str:
+    npm = shutil.which("npm")
+    if npm is None:
+        raise SystemExit("ERRORE: npm non trovato nel PATH.")
+    return npm
+
+
+def run(*args: str) -> None:
+    subprocess.run(args, cwd=FRONTEND, check=True)
+
+
+def install_dependencies(npm: str) -> None:
+    if (FRONTEND / "package-lock.json").is_file():
+        run(npm, "ci")
+    else:
+        run(npm, "install")
+
+
+def build_frontend(npm: str) -> None:
+    run(npm, "run", "build")
+
+
+def copy_distribution() -> None:
+    if not FRONTEND_DIST.is_dir():
+        raise SystemExit(
+            f"ERRORE: build frontend assente: {FRONTEND_DIST}"
+        )
+
+    shutil.rmtree(TARGET, ignore_errors=True)
+    shutil.copytree(FRONTEND_DIST, TARGET)
+
+
+def main() -> int:
+    npm = npm_executable()
+
+    print("==> Building LeLe Manager GUI (Vite + Svelte)")
+    install_dependencies(npm)
+    build_frontend(npm)
+
+    print("==> Copying dist → src/lele_manager/gui/static")
+    copy_distribution()
+
+    print(f"OK: GUI build in {TARGET}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-gui.sh
+++ b/scripts/build-gui.sh
@@ -1,24 +1,17 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-FRONTEND="$ROOT/frontend"
-TARGET="$ROOT/src/lele_manager/gui/static"
+cd "$ROOT"
 
-echo "==> Building LeLe Manager GUI (Vite + Svelte)"
-cd "$FRONTEND"
-
-if [[ -f package-lock.json ]]; then
-  npm ci
-else
-  npm install
+PYTHON_BIN="python"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
 fi
 
-npm run build
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    echo "ERRORE: Python non trovato."
+else
+    "$PYTHON_BIN" "$ROOT/scripts/build-gui.py"
+fi
 
-echo "==> Copying dist → src/lele_manager/gui/static"
-rm -rf "$TARGET"
-mkdir -p "$TARGET"
-cp -r dist/* "$TARGET/"
-
-echo "OK: GUI build in $TARGET"
+printf '\nPrompt interattivo disponibile.\n'

--- a/scripts/build-native-app.py
+++ b/scripts/build-native-app.py
@@ -19,7 +19,10 @@ def run(*args: str) -> None:
 
 
 def build_gui() -> None:
-    run(str(ROOT / "scripts" / "build-gui.sh"))
+    run(
+        sys.executable,
+        str(ROOT / "scripts" / "build-gui.py"),
+    )
 
 
 def clean_native_outputs() -> None:

--- a/scripts/build-native-app.py
+++ b/scripts/build-native-app.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Build the native LeLe Manager application bundle with PyInstaller."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_NAME = "LeLe-Manager"
+BUILD_ROOT = ROOT / "build" / "native"
+DIST_ROOT = ROOT / "dist" / "native"
+
+
+def run(*args: str) -> None:
+    subprocess.run(args, cwd=ROOT, check=True)
+
+
+def build_gui() -> None:
+    run(str(ROOT / "scripts" / "build-gui.sh"))
+
+
+def clean_native_outputs() -> None:
+    shutil.rmtree(BUILD_ROOT, ignore_errors=True)
+    shutil.rmtree(DIST_ROOT, ignore_errors=True)
+
+
+def build_native_bundle() -> None:
+    launcher = ROOT / "src" / "lele_manager" / "launcher.py"
+
+    run(
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--noconfirm",
+        "--clean",
+        "--onedir",
+        "--name",
+        APP_NAME,
+        "--distpath",
+        str(DIST_ROOT),
+        "--workpath",
+        str(BUILD_ROOT),
+        "--specpath",
+        str(BUILD_ROOT),
+        "--collect-data",
+        "lele_manager",
+        str(launcher),
+    )
+
+
+def main() -> int:
+    print("==> Building compiled GUI")
+    build_gui()
+
+    print("==> Cleaning previous native bundle")
+    clean_native_outputs()
+
+    print("==> Building native application bundle")
+    build_native_bundle()
+
+    bundle = DIST_ROOT / APP_NAME
+
+    if not bundle.is_dir():
+        raise SystemExit(f"ERRORE: bundle nativo non creato: {bundle}")
+
+    print()
+    print("OK: native application bundle:")
+    print(f"    {bundle}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-native-app.sh
+++ b/scripts/build-native-app.sh
@@ -1,20 +1,17 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
-APP_NAME="LeLe-Manager"
+PYTHON_BIN="python"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+fi
 
-echo "==> Building compiled GUI"
-"$ROOT/scripts/build-gui.sh"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    echo "ERRORE: Python non trovato."
+else
+    "$PYTHON_BIN" "$ROOT/scripts/build-native-app.py"
+fi
 
-echo "==> Cleaning previous native bundle"
-rm -rf "$ROOT/build/native" "$ROOT/dist/native"
-
-echo "==> Building native application bundle"
-python -m PyInstaller   --noconfirm   --clean   --onedir   --name "$APP_NAME"   --distpath "$ROOT/dist/native"   --workpath "$ROOT/build/native"   --specpath "$ROOT/build/native"   --collect-data lele_manager   "$ROOT/src/lele_manager/launcher.py"
-
-echo
-echo "OK: native application bundle:"
-echo "    $ROOT/dist/native/$APP_NAME"
+printf '\nPrompt interattivo disponibile.\n'

--- a/scripts/build-native-app.sh
+++ b/scripts/build-native-app.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+APP_NAME="LeLe-Manager"
+
+echo "==> Building compiled GUI"
+"$ROOT/scripts/build-gui.sh"
+
+echo "==> Cleaning previous native bundle"
+rm -rf "$ROOT/build/native" "$ROOT/dist/native"
+
+echo "==> Building native application bundle"
+python -m PyInstaller   --noconfirm   --clean   --onedir   --name "$APP_NAME"   --distpath "$ROOT/dist/native"   --workpath "$ROOT/build/native"   --specpath "$ROOT/build/native"   --collect-data lele_manager   "$ROOT/src/lele_manager/launcher.py"
+
+echo
+echo "OK: native application bundle:"
+echo "    $ROOT/dist/native/$APP_NAME"

--- a/scripts/package-native-release.py
+++ b/scripts/package-native-release.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Create an end-user release archive from a native PyInstaller bundle."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import sys
+import tarfile
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+DIST_NATIVE = ROOT / "dist" / "native"
+RELEASE_DIR = ROOT / "dist" / "release"
+APP_NAME = "LeLe-Manager"
+
+
+def project_version() -> str:
+    with PYPROJECT.open("rb") as stream:
+        data = tomllib.load(stream)
+    return str(data["project"]["version"])
+
+
+def normalized_architecture() -> str:
+    machine = platform.machine().lower()
+
+    aliases = {
+        "amd64": "x86_64",
+        "x86_64": "x86_64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }
+
+    return aliases.get(machine, machine)
+
+
+def require_linux() -> None:
+    if sys.platform != "linux":
+        raise SystemExit(
+            "ERRORE: questo primo packaging step supporta soltanto Linux."
+        )
+
+
+def main() -> int:
+    require_linux()
+
+    version = project_version()
+    architecture = normalized_architecture()
+
+    source = DIST_NATIVE / APP_NAME
+    executable = source / APP_NAME
+    guide = ROOT / "packaging" / "guides" / "LEGGIMI_PRIMA-Linux.txt"
+
+    if not source.is_dir():
+        raise SystemExit(
+            f"ERRORE: bundle nativo assente: {source}\n"
+            "Esegui prima scripts/build-native-app.sh."
+        )
+
+    if not executable.is_file():
+        raise SystemExit(f"ERRORE: eseguibile assente: {executable}")
+
+    if not guide.is_file():
+        raise SystemExit(f"ERRORE: guida assente: {guide}")
+
+    RELEASE_DIR.mkdir(parents=True, exist_ok=True)
+
+    package_name = f"{APP_NAME}-v{version}-Linux-{architecture}"
+    staging = RELEASE_DIR / package_name
+    archive = RELEASE_DIR / f"{package_name}.tar.gz"
+
+    if staging.exists():
+        shutil.rmtree(staging)
+
+    if archive.exists():
+        archive.unlink()
+
+    shutil.copytree(source, staging / APP_NAME)
+    shutil.copy2(guide, staging / "LEGGIMI_PRIMA.txt")
+
+    with tarfile.open(archive, "w:gz") as output:
+        output.add(staging, arcname=package_name)
+
+    shutil.rmtree(staging)
+
+    print(f"Versione:     {version}")
+    print(f"Piattaforma:  Linux")
+    print(f"Architettura: {architecture}")
+    print(f"Artefatto:    {archive}")
+    print(f"Dimensione:   {archive.stat().st_size} byte")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package-native-release.py
+++ b/scripts/package-native-release.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import tarfile
 import tomllib
+import zipfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -25,33 +26,62 @@ def project_version() -> str:
 
 def normalized_architecture() -> str:
     machine = platform.machine().lower()
-
     aliases = {
         "amd64": "x86_64",
         "x86_64": "x86_64",
         "aarch64": "arm64",
         "arm64": "arm64",
     }
-
     return aliases.get(machine, machine)
 
 
-def require_linux() -> None:
-    if sys.platform != "linux":
-        raise SystemExit(
-            "ERRORE: questo primo packaging step supporta soltanto Linux."
-        )
+def platform_contract() -> tuple[str, str, str]:
+    """Return release OS label, guide suffix, and archive format."""
+    if sys.platform.startswith("linux"):
+        return "Linux", "Linux", "tar.gz"
+
+    if sys.platform == "darwin":
+        return "macOS", "macOS", "zip"
+
+    if sys.platform == "win32":
+        return "Windows", "Windows", "zip"
+
+    raise SystemExit(f"ERRORE: piattaforma non supportata: {sys.platform}")
+
+
+def create_tar_gz(source: Path, archive: Path, package_name: str) -> None:
+    with tarfile.open(archive, "w:gz") as output:
+        output.add(source, arcname=package_name)
+
+
+def create_zip(source: Path, archive: Path, package_name: str) -> None:
+    with zipfile.ZipFile(
+        archive,
+        "w",
+        compression=zipfile.ZIP_DEFLATED,
+        compresslevel=9,
+    ) as output:
+        for path in source.rglob("*"):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(source)
+            output.write(path, Path(package_name) / relative)
 
 
 def main() -> int:
-    require_linux()
-
+    os_label, guide_suffix, archive_format = platform_contract()
     version = project_version()
     architecture = normalized_architecture()
 
     source = DIST_NATIVE / APP_NAME
-    executable = source / APP_NAME
-    guide = ROOT / "packaging" / "guides" / "LEGGIMI_PRIMA-Linux.txt"
+    executable_name = f"{APP_NAME}.exe" if os_label == "Windows" else APP_NAME
+    executable = source / executable_name
+    guide = (
+        ROOT
+        / "packaging"
+        / "guides"
+        / f"LEGGIMI_PRIMA-{guide_suffix}.txt"
+    )
 
     if not source.is_dir():
         raise SystemExit(
@@ -67,9 +97,11 @@ def main() -> int:
 
     RELEASE_DIR.mkdir(parents=True, exist_ok=True)
 
-    package_name = f"{APP_NAME}-v{version}-Linux-{architecture}"
+    package_name = f"{APP_NAME}-v{version}-{os_label}-{architecture}"
     staging = RELEASE_DIR / package_name
-    archive = RELEASE_DIR / f"{package_name}.tar.gz"
+
+    extension = ".tar.gz" if archive_format == "tar.gz" else ".zip"
+    archive = RELEASE_DIR / f"{package_name}{extension}"
 
     if staging.exists():
         shutil.rmtree(staging)
@@ -80,14 +112,17 @@ def main() -> int:
     shutil.copytree(source, staging / APP_NAME)
     shutil.copy2(guide, staging / "LEGGIMI_PRIMA.txt")
 
-    with tarfile.open(archive, "w:gz") as output:
-        output.add(staging, arcname=package_name)
+    if archive_format == "tar.gz":
+        create_tar_gz(staging, archive, package_name)
+    else:
+        create_zip(staging, archive, package_name)
 
     shutil.rmtree(staging)
 
     print(f"Versione:     {version}")
-    print(f"Piattaforma:  Linux")
+    print(f"Piattaforma:  {os_label}")
     print(f"Architettura: {architecture}")
+    print(f"Formato:      {archive_format}")
     print(f"Artefatto:    {archive}")
     print(f"Dimensione:   {archive.stat().st_size} byte")
     return 0

--- a/src/lele_manager/launcher.py
+++ b/src/lele_manager/launcher.py
@@ -1,0 +1,112 @@
+"""Desktop-style launcher for the packaged LeLe Manager web application."""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+import uvicorn
+
+from lele_manager.api.server import app
+from lele_manager.core.config import resolve_data_path, resolve_model_path
+from lele_manager.core.vault import resolve_vault_dir
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+HEALTH_TIMEOUT_SECONDS = 30.0
+
+
+def find_available_port(
+    host: str = DEFAULT_HOST,
+    preferred_port: int = DEFAULT_PORT,
+) -> int:
+    """Use the preferred local port when free, otherwise ask the OS for one."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, preferred_port))
+        except OSError:
+            sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+def prepare_runtime() -> tuple[Path, Path, Path]:
+    """Create the persistent runtime locations required on first launch."""
+    data_path = resolve_data_path()
+    model_path = resolve_model_path()
+    vault_dir = resolve_vault_dir()
+
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+    model_path.parent.mkdir(parents=True, exist_ok=True)
+    vault_dir.mkdir(parents=True, exist_ok=True)
+
+    return data_path, model_path, vault_dir
+
+
+def wait_until_ready(
+    url: str,
+    *,
+    timeout: float = HEALTH_TIMEOUT_SECONDS,
+    interval: float = 0.1,
+) -> bool:
+    """Wait until the local health endpoint answers successfully."""
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1.0) as response:
+                if 200 <= response.status < 300:
+                    return True
+        except (urllib.error.URLError, OSError):
+            pass
+
+        time.sleep(interval)
+
+    return False
+
+
+def open_browser_when_ready(
+    health_url: str,
+    app_url: str,
+    *,
+    timeout: float = HEALTH_TIMEOUT_SECONDS,
+) -> None:
+    """Open the GUI only after the local application is ready."""
+    if wait_until_ready(health_url, timeout=timeout):
+        webbrowser.open(app_url)
+
+
+def main() -> int:
+    """Prepare persistent state, start LeLe Manager, and open its GUI."""
+    prepare_runtime()
+
+    port = find_available_port()
+    base_url = f"http://{DEFAULT_HOST}:{port}"
+    health_url = f"{base_url}/health"
+    app_url = f"{base_url}/app/"
+
+    browser_thread = threading.Thread(
+        target=open_browser_when_ready,
+        args=(health_url, app_url),
+        daemon=True,
+    )
+    browser_thread.start()
+
+    config = uvicorn.Config(
+        app,
+        host=DEFAULT_HOST,
+        port=port,
+        log_level="info",
+    )
+    server = uvicorn.Server(config)
+    server.run()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+
+import lele_manager.launcher as launcher
+
+
+def test_prepare_runtime_creates_required_directories(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    data = tmp_path / "data" / "lessons.jsonl"
+    model = tmp_path / "cache" / "topic_model.joblib"
+    vault = tmp_path / "vault"
+
+    monkeypatch.setattr(launcher, "resolve_data_path", lambda: data)
+    monkeypatch.setattr(launcher, "resolve_model_path", lambda: model)
+    monkeypatch.setattr(launcher, "resolve_vault_dir", lambda: vault)
+
+    assert launcher.prepare_runtime() == (data, model, vault)
+
+    assert data.parent.is_dir()
+    assert model.parent.is_dir()
+    assert vault.is_dir()
+
+
+def test_open_browser_when_health_is_ready(monkeypatch) -> None:
+    opened: list[str] = []
+
+    monkeypatch.setattr(
+        launcher,
+        "wait_until_ready",
+        lambda url, timeout: True,
+    )
+    monkeypatch.setattr(
+        launcher.webbrowser,
+        "open",
+        lambda url: opened.append(url),
+    )
+
+    launcher.open_browser_when_ready(
+        "http://127.0.0.1:8765/health",
+        "http://127.0.0.1:8765/app/",
+    )
+
+    assert opened == ["http://127.0.0.1:8765/app/"]
+
+
+def test_browser_stays_closed_when_health_never_becomes_ready(
+    monkeypatch,
+) -> None:
+    opened: list[str] = []
+
+    monkeypatch.setattr(
+        launcher,
+        "wait_until_ready",
+        lambda url, timeout: False,
+    )
+    monkeypatch.setattr(
+        launcher.webbrowser,
+        "open",
+        lambda url: opened.append(url),
+    )
+
+    launcher.open_browser_when_ready(
+        "http://127.0.0.1:8765/health",
+        "http://127.0.0.1:8765/app/",
+    )
+
+    assert opened == []
+
+
+def test_find_available_port_falls_back_when_preferred_port_is_busy() -> None:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as occupied:
+        occupied.bind((launcher.DEFAULT_HOST, 0))
+        occupied.listen()
+        busy_port = int(occupied.getsockname()[1])
+
+        selected = launcher.find_available_port(
+            launcher.DEFAULT_HOST,
+            busy_port,
+        )
+
+    assert selected != busy_port
+    assert selected > 0

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -21,7 +21,7 @@ def test_ci_and_release_share_artifact_build_entrypoint() -> None:
 def test_release_workflow_prepares_node_before_build() -> None:
     release = read(".github/workflows/release.yml")
 
-    node_position = release.index("actions/setup-node@v4")
+    node_position = release.index("actions/setup-node@v6")
     build_position = release.index(BUILD_COMMAND)
 
     assert node_position < build_position


### PR DESCRIPTION
## Summary

Add a native desktop release path for LeLe Manager across Linux, macOS, and Windows.

The native packages are self-contained: end users do not need Python, Node.js, npm, or development tooling installed.

## What changes

- add a native launcher that:
  - starts LeLe Manager on localhost;
  - waits for the health endpoint;
  - opens `/app/` automatically in the browser;
  - preserves persistent data outside the installation directory;
- build the compiled Svelte GUI before native packaging;
- build the native application with PyInstaller;
- add cross-platform Python build scripts;
- package platform-specific release archives:
  - `LeLe-Manager-vX.Y.Z-Linux-<arch>.tar.gz`
  - `LeLe-Manager-vX.Y.Z-macOS-<arch>.zip`
  - `LeLe-Manager-vX.Y.Z-Windows-<arch>.zip`
- include OS-specific `LEGGIMI_PRIMA.txt` guides;
- extend the Release workflow with native Linux/macOS/Windows jobs;
- require explicit opt-in before a manual workflow dispatch may publish to PyPI;
- update GitHub Actions to Node 24-compatible major versions.

## Validation

Native release workflow validated successfully on all three hosted platforms:

- Linux x86_64
- macOS arm64
- Windows x86_64
- Python sdist/wheel

Final validation run:
https://github.com/gcomneno/lele-manager/actions/runs/31252509394

The final run completed successfully and produced:

- `lele-manager-Linux`
- `lele-manager-macOS`
- `lele-manager-Windows`
- `dist`

PyPI publishing remained skipped during validation.

The extracted Linux release was also exercised end-to-end outside the repository, including:

- automatic application startup;
- GUI loading and navigation;
- `/health`;
- topic-model training;
- model serialization;
- SciPy/scikit-learn similarity calculation.

## Release note

This PR establishes the packaging pipeline only.

The project version intentionally remains `1.10.0`. The version bump and `v1.10.1` tag will be performed separately as the final release preparation after this packaging work is merged and accepted.