### PR TITLE
chore: prepare v1.10.1 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,49 @@ jobs:
           path: dist/release/*
           if-no-files-found: error
 
+  github-release:
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    name: Publish GitHub Release
+    needs:
+      - native-packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download native packages
+        uses: actions/download-artifact@v6
+        with:
+          pattern: lele-manager-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Verify native assets
+        shell: bash
+        run: |
+          shopt -s nullglob
+          version="${GITHUB_REF_NAME#v}"
+          assets=(release-assets/LeLe-Manager-v"${version}"-*)
+          if (( ${#assets[@]} != 3 )); then
+            printf 'Expected 3 native assets for %s, found %d\n' \
+              "${GITHUB_REF_NAME}" "${#assets[@]}"
+            printf '%s\n' "${assets[@]}"
+            false
+          fi
+          printf 'Native release assets for %s:\n' "${GITHUB_REF_NAME}"
+          printf '  %s\n' "${assets[@]}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            release-assets/LeLe-Manager-v"${GITHUB_REF_NAME#v}"-* \
+            --repo "${GITHUB_REPOSITORY}" \
+            --verify-tag \
+            --generate-notes \
+            --title "LeLe Manager ${GITHUB_REF_NAME}"
+
+
   publish:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_pypi && vars.PYPI_ENABLED == 'true' }}
     name: Publish to PyPI
@@ -99,7 +142,7 @@ jobs:
       contents: read
     steps:
       - name: Download dist artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,34 @@ The format is based on **Keep a Changelog**.
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-08-08
+
 ### Added
-- **LeLe Manager PKPS consumer boundary:** local v1 GYTE lesson-package
-  import through the existing TritaLeLe candidate staging boundary. Directory
-  and single-root ZIP packages are strictly validated, retain immutable
-  provenance, are idempotent by package ID/content hash, and never write the
-  vault or derived artifacts before explicit approval.
+- **LeLe Manager PKPS consumer boundary:** local PKPS v1 GYTE lesson-package
+  import through the existing TritaLeLe staging boundary, with strict
+  validation for directories and single-root ZIP packages, immutable
+  provenance, idempotency by package ID/content hash, and no vault or derived
+  artifact writes before explicit approval.
+- **Native desktop packaging:** self-contained packages for Linux, macOS, and
+  Windows, with a local FastAPI launcher, health-endpoint readiness wait, and
+  automatic browser opening of the GUI.
+- Platform-specific `LEGGIMI_PRIMA.txt` guides for Linux, macOS, and Windows.
+
+### Changed
+- Introduced and consolidated the **LeLe Manager brand design system**.
+- Extended **Giada UI** foundation adoption across the GUI.
+- Completed GUI localization.
+- Added subtle, non-intrusive motion to the LeLe mascot.
+- GUI and native builds now use cross-platform Python entrypoints.
+- The Release workflow now builds native artifacts on Linux, macOS, and
+  Windows and requires explicit opt-in for manual PyPI publishing.
+- CI, release, and security workflows now use GitHub Actions versions
+  compatible with Node.js 24.
+
+### Compatibility
+- No intentional breaking changes were introduced in the public API or CLI.
+- Persistent data remains outside the native installation directory so
+  upgrades do not require moving the vault.
 
 ## [1.10.0] - 2026-08-04
 
@@ -246,7 +268,8 @@ _See [1.2.0] — same commit tag point; version marker for milestone tracking._
 - Date parsing (YAML → JSON).
 - NaN/NaT handling in the API layer.
 
-[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.10.1...HEAD
+[1.10.1]: https://github.com/gcomneno/lele-manager/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/gcomneno/lele-manager/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/gcomneno/lele-manager/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/gcomneno/lele-manager/compare/v1.7.0...v1.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lele-manager"
-version = "1.10.0"
+version = "1.10.1"
 description = "Lesson Learned Manager: archivio intelligente di lesson learned testuali."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -63,3 +63,15 @@ def test_brand_design_docs_are_declared_in_sdist_manifest() -> None:
         "docs/it/brand-design-system.md",
     ):
         assert f"include {documentation_path}" in manifest
+
+def test_tag_release_publishes_exact_native_version_assets() -> None:
+    release = read(".github/workflows/release.yml")
+
+    assert "github-release:" in release
+    assert "actions/download-artifact@v6" in release
+    assert "pattern: lele-manager-*" in release
+    assert "merge-multiple: true" in release
+    assert 'version="${GITHUB_REF_NAME#v}"' in release
+    assert 'LeLe-Manager-v"${version}"-*' in release
+    assert 'gh release create "${GITHUB_REF_NAME}"' in release
+    assert "--verify-tag" in release


### PR DESCRIPTION
## Summary

Prepare LeLe Manager v1.10.1 for release.

### Changes

- bump project version from 1.10.0 to 1.10.1;
- finalize the v1.10.1 changelog;
- add tag-only GitHub Release publication for native Linux, macOS, and Windows assets;
- require native asset versions to match the pushed tag;
- update `actions/download-artifact` to v6;
- add release-workflow contract coverage.

### Local validation

- `pytest`: 578 passed;
- `ruff`: passed;
- `mypy`: passed;
- `git diff --check`: clean.

No release tag has been created yet.