### PR TITLE
fix(gui): align GiadaWare signature tongue

### DIFF
--- a/frontend/e2e/mascot-motion.spec.ts
+++ b/frontend/e2e/mascot-motion.spec.ts
@@ -198,6 +198,7 @@ test('keeps the GiadaWare signature tongue decorative and motion-safe', async ({
     /lele-signature-tongue$/,
   )
   await expect(tongue).toHaveCSS('animation-duration', '31s')
+  await expect(tongue).toHaveCSS('left', '18px')
 
   await page.emulateMedia({ reducedMotion: 'reduce' })
 

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -477,7 +477,7 @@
 
   .signature-tongue {
     position: absolute;
-    left: 23px;
+    left: 18px;
     top: 20px;
     z-index: 2;
     width: 4px;


### PR DESCRIPTION
## Summary

- move the GiadaWare signature tongue exactly 5 px to the left (`23px` → `18px`);
- preserve its size, timing, reduced-motion behavior, and all other mascot/signature styling;
- add a focused Playwright assertion for the final tongue position.

## Validation

- `E2E_PORT=8766 npx playwright test e2e/mascot-motion.spec.ts` → 6 passed;
- `git diff --check` → clean.

The alternate E2E port is intentional: the default Playwright configuration reuses an already-running local server outside CI, which was serving the previous built GUI assets.

Fixes #161