### PR TITLE
frontend: redesign the application shell and product navigation

### DIFF
--- a/frontend/e2e/product-shell.spec.ts
+++ b/frontend/e2e/product-shell.spec.ts
@@ -11,13 +11,13 @@ test.describe('product shell hierarchy', () => {
     })
 
     await expect(
-      navigation.getByRole('heading', { name: 'Knowledge' }),
+      navigation.getByRole('region', { name: 'Knowledge' }),
     ).toBeVisible()
     await expect(
-      navigation.getByRole('heading', { name: 'Capture' }),
+      navigation.getByRole('region', { name: 'Capture' }),
     ).toBeVisible()
     await expect(
-      navigation.getByRole('heading', { name: 'Manage' }),
+      navigation.getByRole('region', { name: 'Manage' }),
     ).toBeVisible()
 
     for (const label of [
@@ -94,13 +94,13 @@ test.describe('product shell hierarchy', () => {
     })
 
     await expect(
-      navigation.getByRole('heading', { name: 'Conoscenza' }),
+      navigation.getByRole('region', { name: 'Conoscenza' }),
     ).toBeVisible()
     await expect(
-      navigation.getByRole('heading', { name: 'Acquisizione' }),
+      navigation.getByRole('region', { name: 'Acquisizione' }),
     ).toBeVisible()
     await expect(
-      navigation.getByRole('heading', { name: 'Gestione' }),
+      navigation.getByRole('region', { name: 'Gestione' }),
     ).toBeVisible()
 
     await expect(
@@ -128,7 +128,7 @@ test.describe('product shell responsive layouts', () => {
 
     await expect(navigation).toBeVisible()
     await expect(
-      navigation.getByRole('heading', { name: 'Knowledge' }),
+      navigation.getByRole('region', { name: 'Knowledge' }),
     ).toBeVisible()
     await expect(
       navigation.getByRole('link', { name: 'Browse' }),
@@ -173,7 +173,7 @@ test.describe('product shell responsive layouts', () => {
       'Manage',
     ]) {
       await expect(
-        navigation.getByRole('heading', { name: group }),
+        navigation.getByRole('region', { name: group }),
       ).toBeVisible()
     }
 

--- a/frontend/e2e/product-shell.spec.ts
+++ b/frontend/e2e/product-shell.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('product shell hierarchy', () => {
+  test('groups navigation into Knowledge, Capture, and Manage', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+
+    await expect(
+      navigation.getByRole('heading', { name: 'Knowledge' }),
+    ).toBeVisible()
+    await expect(
+      navigation.getByRole('heading', { name: 'Capture' }),
+    ).toBeVisible()
+    await expect(
+      navigation.getByRole('heading', { name: 'Manage' }),
+    ).toBeVisible()
+
+    for (const label of [
+      'Browse',
+      'Timeline',
+      'Statistics',
+      'New LeLe',
+      'Collection',
+      'Vault',
+      'Duplicates',
+      'System',
+    ]) {
+      await expect(
+        navigation.getByRole('link', { name: label }),
+      ).toHaveCount(1)
+    }
+  })
+
+  test('uses deterministic local SVG navigation icons', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+
+    await expect(navigation.locator('svg')).toHaveCount(8)
+
+    for (const emoji of [
+      '🏠',
+      '🕒',
+      '📊',
+      '✨',
+      '🗂️',
+      '🧠',
+      '🧪',
+      '⚙️',
+    ]) {
+      await expect(navigation).not.toContainText(emoji)
+    }
+  })
+
+  test('shows bounded runtime and workspace context', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/')
+
+    const context = page.getByTestId('shell-context')
+    const version = page.getByTestId('shell-version')
+    const workspace = page.getByTestId('shell-workspace')
+
+    await expect(context).toBeVisible()
+    await expect(version).toHaveText(/\S+/)
+    await expect(workspace).toHaveText(/\S+/)
+
+    const workspaceText = await workspace.textContent()
+
+    expect(workspaceText).not.toContain('/')
+    expect(workspaceText).not.toContain('\\')
+  })
+
+  test('localizes navigation group labels without changing routes', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/')
+
+    await page
+      .getByLabel('Language')
+      .selectOption('it')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+
+    await expect(
+      navigation.getByRole('heading', { name: 'Conoscenza' }),
+    ).toBeVisible()
+    await expect(
+      navigation.getByRole('heading', { name: 'Acquisizione' }),
+    ).toBeVisible()
+    await expect(
+      navigation.getByRole('heading', { name: 'Gestione' }),
+    ).toBeVisible()
+
+    await expect(
+      navigation.getByRole('link', { name: 'Esplora' }),
+    ).toHaveAttribute('href', '#/')
+    await expect(
+      navigation.getByRole('link', { name: 'Cronologia' }),
+    ).toHaveAttribute('href', '#/timeline')
+    await expect(
+      navigation.getByRole('link', { name: 'Sistema' }),
+    ).toHaveAttribute('href', '#/ops')
+  })
+})
+
+test.describe('product shell responsive layouts', () => {
+  test('keeps grouped navigation usable on a narrow desktop', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 900, height: 600 })
+    await page.goto('/app/#/')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+
+    await expect(navigation).toBeVisible()
+    await expect(
+      navigation.getByRole('heading', { name: 'Knowledge' }),
+    ).toBeVisible()
+    await expect(
+      navigation.getByRole('link', { name: 'Browse' }),
+    ).toBeVisible()
+    await expect(
+      navigation.getByRole('link', { name: 'System' }),
+    ).toBeVisible()
+
+    await expect(page.getByTestId('shell-context')).toBeVisible()
+    await expect(
+      page.getByTestId('giadaware-signature'),
+    ).toBeVisible()
+
+    const signatureBox = await page
+      .getByTestId('giadaware-signature')
+      .boundingBox()
+
+    expect(signatureBox).not.toBeNull()
+
+    if (signatureBox) {
+      expect(signatureBox.y).toBeGreaterThanOrEqual(0)
+      expect(signatureBox.y + signatureBox.height)
+        .toBeLessThanOrEqual(600)
+    }
+  })
+
+  test('keeps navigation deterministic on mobile width', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/app/#/')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+
+    await expect(navigation).toBeVisible()
+
+    for (const group of [
+      'Knowledge',
+      'Capture',
+      'Manage',
+    ]) {
+      await expect(
+        navigation.getByRole('heading', { name: group }),
+      ).toBeVisible()
+    }
+
+    for (const label of [
+      'Browse',
+      'Timeline',
+      'Statistics',
+      'New LeLe',
+      'Collection',
+      'Vault',
+      'Duplicates',
+      'System',
+    ]) {
+      await expect(
+        navigation.getByRole('link', { name: label }),
+      ).toBeVisible()
+    }
+
+    await expect(
+      page.getByTestId('shell-context'),
+    ).toBeHidden()
+    await expect(
+      page.getByTestId('giadaware-signature'),
+    ).toBeHidden()
+
+    const viewportWidth = await page.evaluate(
+      () => document.documentElement.clientWidth,
+    )
+    const scrollWidth = await page.evaluate(
+      () => document.documentElement.scrollWidth,
+    )
+
+    expect(scrollWidth).toBeLessThanOrEqual(viewportWidth)
+  })
+
+  test('keeps mobile navigation keyboard reachable', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await page.goto('/app/#/')
+
+    const system = page.getByRole('link', {
+      name: 'System',
+    })
+
+    for (let step = 0; step < 24; step += 1) {
+      if (
+        await system.evaluate(
+          (element) => document.activeElement === element,
+        )
+      ) {
+        break
+      }
+
+      await page.keyboard.press('Tab')
+    }
+
+    await expect(system).toBeFocused()
+
+    await page.keyboard.press('Enter')
+
+    await expect(page).toHaveURL(/#\/ops$/)
+    await expect(
+      page.getByRole('heading', {
+        name: 'Status and maintenance',
+      }),
+    ).toBeVisible()
+  })
+})

--- a/frontend/src/components/NavIcon.svelte
+++ b/frontend/src/components/NavIcon.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  type IconName =
+    | 'browse'
+    | 'timeline'
+    | 'stats'
+    | 'new'
+    | 'collection'
+    | 'vault'
+    | 'duplicates'
+    | 'system'
+
+  interface Props {
+    name: IconName
+  }
+
+  let { name }: Props = $props()
+</script>
+
+<svg
+  viewBox="0 0 24 24"
+  width="18"
+  height="18"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.8"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  {#if name === 'browse'}
+    <path d="M4 5.5h6l2 2H20v11H4z" />
+    <path d="M4 9h16" />
+  {:else if name === 'timeline'}
+    <circle cx="12" cy="12" r="8" />
+    <path d="M12 7v5l3 2" />
+  {:else if name === 'stats'}
+    <path d="M5 19V10" />
+    <path d="M12 19V5" />
+    <path d="M19 19v-7" />
+  {:else if name === 'new'}
+    <path d="M12 5v14M5 12h14" />
+  {:else if name === 'collection'}
+    <rect x="5" y="6" width="14" height="13" rx="2" />
+    <path d="M8 3h8M8 10h8M8 14h5" />
+  {:else if name === 'vault'}
+    <rect x="4" y="5" width="16" height="14" rx="3" />
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12 9V7M12 17v-2M9 12H7M17 12h-2" />
+  {:else if name === 'duplicates'}
+    <rect x="4" y="4" width="11" height="11" rx="2" />
+    <rect x="9" y="9" width="11" height="11" rx="2" />
+  {:else}
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12 3v2M12 19v2M3 12h2M19 12h2" />
+    <path d="m5.6 5.6 1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4" />
+  {/if}
+</svg>

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -90,8 +90,13 @@
     </a>
     <nav aria-label="Primary">
       {#each navigationGroups as group}
-        <section class="nav-group">
-          <h2>{$messages[group.labelKey]}</h2>
+        <section
+          class="nav-group"
+          aria-label={$messages[group.labelKey]}
+        >
+          <span class="nav-group-title">
+            {$messages[group.labelKey]}
+          </span>
           <div class="nav-group-links">
             {#each group.links as link}
               <a
@@ -330,7 +335,8 @@
     gap: 4px;
   }
 
-  .nav-group h2 {
+  .nav-group-title {
+    display: block;
     margin: 0;
     padding: 0 12px;
     color: var(--color-text-inverse-muted);
@@ -494,10 +500,17 @@
 
   @media (max-width: 800px) {
     .shell {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr);
+      width: 100%;
+      max-width: 100%;
+      overflow-x: clip;
     }
 
     .sidebar {
+      box-sizing: border-box;
+      width: 100%;
+      min-width: 0;
+      max-width: 100%;
       flex-direction: row;
       flex-wrap: wrap;
       align-items: center;
@@ -533,15 +546,24 @@
     }
 
     nav {
+      box-sizing: border-box;
       width: 100%;
+      min-width: 0;
+      max-width: 100%;
       gap: 10px;
+    }
+
+    .nav-group,
+    .nav-group-links {
+      min-width: 0;
+      max-width: 100%;
     }
 
     .nav-group {
       gap: 3px;
     }
 
-    .nav-group h2 {
+    .nav-group-title {
       padding: 0 4px;
     }
 
@@ -1313,7 +1335,7 @@
       gap: 1px;
     }
 
-    .nav-group h2 {
+    .nav-group-title {
       font-size: 0.62rem;
       line-height: 1.1;
     }

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
+  import { api } from '../lib/api'
   import { navigate, type Route } from '../lib/router'
   import {
     locale,
@@ -6,6 +8,7 @@
     setLocale,
   } from '../lib/i18n'
   import HealthBar from './HealthBar.svelte'
+  import NavIcon from './NavIcon.svelte'
 
   interface Props {
     route: Route
@@ -14,16 +17,62 @@
 
   let { route, children }: Props = $props()
 
-  const links = [
-    { view: 'browse' as const, labelKey: 'navBrowse' as const, hash: '#/', icon: '🏠' },
-    { view: 'timeline' as const, labelKey: 'navTimeline' as const, hash: '#/timeline', icon: '🕒' },
-    { view: 'stats' as const, labelKey: 'navStatistics' as const, hash: '#/stats', icon: '📊' },
-    { view: 'editor' as const, labelKey: 'navNewLele' as const, hash: '#/editor', icon: '✨' },
-    { view: 'tritalele' as const, labelKey: 'navCollection' as const, hash: '#/tritalele', icon: '🗂️' },
-    { view: 'vault' as const, labelKey: 'navVault' as const, hash: '#/vault', icon: '🧠' },
-    { view: 'duplicates' as const, labelKey: 'navDuplicates' as const, hash: '#/duplicates', icon: '🧪' },
-    { view: 'ops' as const, labelKey: 'navSystem' as const, hash: '#/ops', icon: '⚙️' },
+  const navigationGroups = [
+    {
+      labelKey: 'navGroupKnowledge' as const,
+      links: [
+        { view: 'browse' as const, labelKey: 'navBrowse' as const, hash: '#/', icon: 'browse' as const },
+        { view: 'timeline' as const, labelKey: 'navTimeline' as const, hash: '#/timeline', icon: 'timeline' as const },
+        { view: 'stats' as const, labelKey: 'navStatistics' as const, hash: '#/stats', icon: 'stats' as const },
+      ],
+    },
+    {
+      labelKey: 'navGroupCapture' as const,
+      links: [
+        { view: 'editor' as const, labelKey: 'navNewLele' as const, hash: '#/editor', icon: 'new' as const },
+        { view: 'tritalele' as const, labelKey: 'navCollection' as const, hash: '#/tritalele', icon: 'collection' as const },
+      ],
+    },
+    {
+      labelKey: 'navGroupManage' as const,
+      links: [
+        { view: 'vault' as const, labelKey: 'navVault' as const, hash: '#/vault', icon: 'vault' as const },
+        { view: 'duplicates' as const, labelKey: 'navDuplicates' as const, hash: '#/duplicates', icon: 'duplicates' as const },
+        { view: 'ops' as const, labelKey: 'navSystem' as const, hash: '#/ops', icon: 'system' as const },
+      ],
+    },
   ]
+
+  let appVersion = $state<string | null>(null)
+  let workspaceName = $state<string | null>(null)
+
+  function basename(path: string): string {
+    const parts = path.split(/[\\/]+/).filter(Boolean)
+    return parts.at(-1) ?? path
+  }
+
+  onMount(() => {
+    let active = true
+
+    void Promise.allSettled([
+      api.runtimeInfo(),
+      api.vaultStatus(),
+    ]).then(([runtime, vault]) => {
+      if (!active) return
+
+      if (runtime.status === 'fulfilled') {
+        appVersion = runtime.value.version
+      }
+
+      if (vault.status === 'fulfilled') {
+        workspaceName = basename(vault.value.vault_dir)
+      }
+    })
+
+    return () => {
+      active = false
+    }
+  })
 
   function isActive(view: Route['view']) {
     return route.view === view || (view === 'editor' && route.view === 'editor')
@@ -39,21 +88,45 @@
         <small class="brand-tagline" data-testid="brand-tagline">{$messages.brandTagline}</small>
       </span>
     </a>
-    <nav>
-      {#each links as link}
-        <a
-          href={link.hash}
-          class:active={isActive(link.view)}
-          onclick={(e) => {
-            e.preventDefault()
-            navigate({ view: link.view })
-          }}
-        >
-          <span class="nav-link-icon" aria-hidden="true">{link.icon}</span>
-          <span>{$messages[link.labelKey]}</span>
-        </a>
+    <nav aria-label="Primary">
+      {#each navigationGroups as group}
+        <section class="nav-group">
+          <h2>{$messages[group.labelKey]}</h2>
+          <div class="nav-group-links">
+            {#each group.links as link}
+              <a
+                href={link.hash}
+                class:active={isActive(link.view)}
+                onclick={(e) => {
+                  e.preventDefault()
+                  navigate({ view: link.view })
+                }}
+              >
+                <span class="nav-link-icon" aria-hidden="true">
+                  <NavIcon name={link.icon} />
+                </span>
+                <span>{$messages[link.labelKey]}</span>
+              </a>
+            {/each}
+          </div>
+        </section>
       {/each}
     </nav>
+
+    <dl class="shell-context" data-testid="shell-context">
+      {#if workspaceName}
+        <div>
+          <dt>{$messages.shellWorkspace}</dt>
+          <dd data-testid="shell-workspace">{workspaceName}</dd>
+        </div>
+      {/if}
+      {#if appVersion}
+        <div>
+          <dt>{$messages.shellVersion}</dt>
+          <dd data-testid="shell-version">{appVersion}</dd>
+        </div>
+      {/if}
+    </dl>
     <div
       class="language-control"
       data-testid="language-control"
@@ -249,7 +322,27 @@
 
   nav {
     display: grid;
-    gap: 6px;
+    gap: 14px;
+  }
+
+  .nav-group {
+    display: grid;
+    gap: 4px;
+  }
+
+  .nav-group h2 {
+    margin: 0;
+    padding: 0 12px;
+    color: var(--color-text-inverse-muted);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .nav-group-links {
+    display: grid;
+    gap: 3px;
   }
 
   nav a {
@@ -278,6 +371,41 @@
   nav a.active {
     background: rgba(255, 255, 255, 0.1);
     opacity: 1;
+  }
+
+  .shell-context {
+    display: grid;
+    gap: 6px;
+    margin: 0;
+    padding: 10px 4px 0;
+    border-top: 1px solid rgb(255 255 255 / 14%);
+  }
+
+  .shell-context div {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: baseline;
+  }
+
+  .shell-context dt,
+  .shell-context dd {
+    margin: 0;
+    min-width: 0;
+    font-size: 0.68rem;
+  }
+
+  .shell-context dt {
+    color: var(--color-text-inverse-muted);
+  }
+
+  .shell-context dd {
+    max-width: 110px;
+    overflow: hidden;
+    color: var(--sidebar-text);
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .language-control {
@@ -387,7 +515,8 @@
       align-self: stretch;
     }
 
-    .product-signature {
+    .product-signature,
+    .shell-context {
       display: none;
     }
 
@@ -404,8 +533,26 @@
     }
 
     nav {
-      grid-auto-flow: column;
-      grid-auto-columns: max-content;
+      width: 100%;
+      gap: 10px;
+    }
+
+    .nav-group {
+      gap: 3px;
+    }
+
+    .nav-group h2 {
+      padding: 0 4px;
+    }
+
+    .nav-group-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }
+
+    nav a {
+      padding: 8px 10px;
     }
 
   }
@@ -1144,9 +1291,9 @@
   /* Compact desktop sidebar for short viewports */
   @media (min-width: 801px) and (max-height: 700px) {
     .sidebar {
-      padding-top: 12px;
-      padding-bottom: 12px;
-      gap: 8px;
+      padding-top: 10px;
+      padding-bottom: 10px;
+      gap: 6px;
     }
 
     .brand > span {
@@ -1159,26 +1306,51 @@
     }
 
     nav {
-      gap: 2px;
+      gap: 5px;
+    }
+
+    .nav-group {
+      gap: 1px;
+    }
+
+    .nav-group h2 {
+      font-size: 0.62rem;
+      line-height: 1.1;
+    }
+
+    .nav-group-links {
+      gap: 1px;
     }
 
     nav a {
-      padding: 6px 10px;
+      padding: 4px 10px;
+    }
+
+    .shell-context {
+      gap: 2px;
+      padding-top: 5px;
+    }
+
+    .shell-context dt,
+    .shell-context dd {
+      font-size: 0.64rem;
+      line-height: 1.15;
     }
 
     .language-control {
-      gap: 3px;
-      padding-top: var(--space-2);
+      gap: 2px;
+      padding-top: 5px;
     }
 
     .language-control select {
-      min-height: 32px;
-      padding-top: 4px;
-      padding-bottom: 4px;
+      min-height: 30px;
+      padding-top: 3px;
+      padding-bottom: 3px;
     }
 
     .product-signature {
-      padding-top: var(--space-2);
+      padding-top: 4px;
+      padding-bottom: 0;
     }
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,6 +59,10 @@ export interface HealthResponse {
   has_model: boolean
 }
 
+export interface RuntimeInfoResponse {
+  version: string
+}
+
 export interface TrainResponse {
   message: string
   n_lessons: number
@@ -344,6 +348,8 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
 export const api = {
   health: () => request<HealthResponse>('/health'),
+
+  runtimeInfo: () => request<RuntimeInfoResponse>('/runtime/info'),
 
   duplicates: ({ min_score, exact_only, limit }: DuplicateQuery) => {
     const params = new URLSearchParams({

--- a/frontend/src/lib/i18n/en.ts
+++ b/frontend/src/lib/i18n/en.ts
@@ -11,6 +11,12 @@ export const en = {
   navDuplicates: 'Duplicates',
   navSystem: 'System',
 
+  navGroupKnowledge: 'Knowledge',
+  navGroupCapture: 'Capture',
+  navGroupManage: 'Manage',
+  shellVersion: 'Version',
+  shellWorkspace: 'Workspace',
+
   languageLabel: 'Language',
   languageEnglish: 'English',
   languageItalian: 'Italian',

--- a/frontend/src/lib/i18n/it.ts
+++ b/frontend/src/lib/i18n/it.ts
@@ -13,6 +13,12 @@ export const it = {
   navDuplicates: 'Duplicati',
   navSystem: 'Sistema',
 
+  navGroupKnowledge: 'Conoscenza',
+  navGroupCapture: 'Acquisizione',
+  navGroupManage: 'Gestione',
+  shellVersion: 'Versione',
+  shellWorkspace: 'Spazio di lavoro',
+
   languageLabel: 'Lingua',
   languageEnglish: 'Inglese',
   languageItalian: 'Italiano',

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -289,6 +289,10 @@ class HealthResponse(BaseModel):
     has_model: bool
 
 
+class RuntimeInfoResponse(BaseModel):
+    version: str
+
+
 class VaultStatusResponse(BaseModel):
     vault_dir: str
     exists: bool
@@ -720,6 +724,12 @@ def integration_lessons(
             for lesson in feed.lessons
         ],
     )
+
+
+@app.get("/runtime/info", response_model=RuntimeInfoResponse)
+def runtime_info() -> RuntimeInfoResponse:
+    """Return bounded application identity used by the installed GUI."""
+    return RuntimeInfoResponse(version=__version__)
 
 
 @app.get("/health", response_model=HealthResponse)

--- a/tests/test_api_basic.py
+++ b/tests/test_api_basic.py
@@ -15,6 +15,15 @@ def _write_jsonl(path: Path, records: list[dict]) -> None:
             f.write(json.dumps(rec, ensure_ascii=False) + "\n")
 
 
+def test_runtime_info_exposes_authoritative_application_version() -> None:
+    client = TestClient(server.app)
+
+    resp = client.get("/runtime/info")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"version": server.__version__}
+
+
 def test_health_without_data_and_model(tmp_path, monkeypatch) -> None:
     """Se DATA_PATH e MODEL_PATH puntano a file inesistenti, /health deve dire has_data=False, has_model=False."""
     data_path = tmp_path / "data" / "lessons.jsonl"


### PR DESCRIPTION
## Summary

- group primary navigation into Knowledge, Capture, and Manage
- replace route emoji with deterministic local SVG icons
- expose a bounded read-only runtime version contract
- show compact privacy-conscious workspace identity from the configured vault
- preserve existing routes, New LeLe CTA, GiadaWare signature, localization, and reduced-motion behavior
- make the grouped shell deterministic across desktop, short/narrow desktop, and mobile layouts

## Runtime contract

Adds:

- `GET /runtime/info`

The endpoint exposes only the authoritative LeLe Manager version.

The shell continues to reuse the existing `/vault/status` contract and displays only the vault directory basename rather than the full path.

## Scope boundaries

This PR intentionally does **not**:

- replace `#/` / Browse with a dashboard — owned by #149
- add first-run/readiness states — owned by #149
- add Settings, About, effective-path detail, or diagnostic export — owned by #150
- introduce a new lifecycle/process supervisor

## Verification

- backend targeted tests: passing
- `npm run check`: 0 errors, 0 warnings
- product shell E2E: 7/7 passing
- brand/design-system E2E: 7/7 passing
- localization E2E: 11/11 passing
- combined shell/localization gate: 22/22 passing
- `git diff --check`: clean

Fixes #148