### PR TITLE
frontend: add product dashboard and meaningful first-run states

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Available views:
 
 | View | Purpose |
 |---|---|
+| **Dashboard** | Workspace readiness, bounded knowledge summary, and next useful actions |
 | **Browse** | Advanced search, filters, and Markdown export |
 | **Detail** | Full lesson content and explained similarity |
 | **Editor** | Markdown authoring with live suggestions |
@@ -500,6 +501,11 @@ Saving from the Editor writes the Markdown file into the vault and refreshes
 the JSONL projection through `PUT` or `POST /vault/lessons`.
 
 The GUI requires `LELE_VAULT_DIR`; the default is `~/LeLeVault`.
+
+Opening `/app/` now lands on the **Dashboard**. Browse remains directly
+available at `#/browse`. The Dashboard reports bounded, read-only workspace
+readiness and delegates explicit maintenance or mutation to the existing
+views.
 
 ### TritaLeLe workflow
 

--- a/docs/gui-design.md
+++ b/docs/gui-design.md
@@ -5,6 +5,12 @@
 > **Issue:** [#96](https://github.com/gcomneno/lele-manager/issues/96)  
 > **Milestone:** [v2.0](https://github.com/gcomneno/lele-manager/milestone/3)  
 > **Data:** 2026-07-05
+>
+> **Historical note:** this document records the original GUI-alpha design.
+> Since issue #149, `/` opens the product Dashboard and Browse is available at
+> `/browse`. The wireframes and flows below are intentionally preserved as the
+> historical design baseline; maintained user behavior is documented in
+> [`gui-user-guide.md`](gui-user-guide.md).
 
 ---
 

--- a/docs/gui-user-guide.md
+++ b/docs/gui-user-guide.md
@@ -45,19 +45,22 @@ source names, paths, IDs, API payloads or navigation identities.
 
 ## Daily workflow
 
-1. Check health and vault diagnostics in **Ops**.
-2. Browse, filter and inspect existing lessons.
-3. Create or edit approved lessons through **Editor**.
-4. Review exact and near duplicates through **Duplicates**.
-5. Ingest raw notes through **TritaLeLe**, keeping preview, staging, review and
+1. Open **Dashboard** to see workspace readiness, attention points and the next
+   useful action.
+2. Use **Ops** when explicit diagnostics, import, training or refresh are needed.
+3. Browse, filter and inspect existing lessons.
+4. Create or edit approved lessons through **Editor**.
+5. Review exact and near duplicates through **Duplicates**.
+6. Ingest raw notes through **TritaLeLe**, keeping preview, staging, review and
    approval as separate actions.
-6. Use **Vault**, **Stats** and **Timeline** to inspect the resulting knowledge
+7. Use **Vault**, **Stats** and **Timeline** to inspect the resulting knowledge
    base.
 
 ## GUI views
 
 | View | Purpose |
 |---|---|
+| Dashboard | Inspect workspace readiness, bounded summaries and next useful actions |
 | Browse | Search, filter and export lessons |
 | Detail | Read one lesson and inspect explained similarity |
 | Editor | Create or update canonical Markdown lessons |
@@ -67,6 +70,18 @@ source names, paths, IDs, API payloads or navigation identities.
 | Vault | Inspect the canonical Markdown tree and trigger projection import |
 | Duplicates | Review duplicate and near-duplicate pairs without mutation |
 | Ops | Inspect health, run Vault Doctor, import, train and refresh |
+
+## Dashboard and first-run states
+
+`/app/` opens the Dashboard. Browse remains available at `#/browse`.
+
+The Dashboard reads bounded workspace state only. It can distinguish a fresh
+setup with no vault, an empty vault, a partially ready workspace, a ready
+workspace and recoverable loading errors. It does not run duplicate review,
+Vault Doctor, import, refresh or model training automatically.
+
+The Markdown vault remains authoritative. Dataset projections, caches and
+topic-model artifacts are derived and rebuildable.
 
 ## Screenshots
 

--- a/docs/it/gui-user-guide.md
+++ b/docs/it/gui-user-guide.md
@@ -45,18 +45,21 @@ dataset, topic, fonti, percorsi, ID, payload API o identità di navigazione.
 
 ## Flusso quotidiano
 
-1. Controllare health e diagnostica del vault in **Ops**.
-2. Cercare, filtrare e leggere le lesson esistenti.
-3. Creare o modificare lesson approvate tramite **Editor**.
-4. Revisionare duplicati esatti e near-duplicate tramite **Duplicates**.
-5. Ingerire appunti grezzi tramite **TritaLeLe**, mantenendo separate anteprima,
+1. Aprire **Dashboard** per vedere disponibilità dello spazio di lavoro, punti
+   che richiedono attenzione e prossima azione utile.
+2. Usare **Ops** quando servono diagnostica esplicita, import, training o refresh.
+3. Cercare, filtrare e leggere le lesson esistenti.
+4. Creare o modificare lesson approvate tramite **Editor**.
+5. Revisionare duplicati esatti e near-duplicate tramite **Duplicates**.
+6. Ingerire appunti grezzi tramite **TritaLeLe**, mantenendo separate anteprima,
    staging, revisione e approvazione.
-6. Usare **Vault**, **Stats** e **Timeline** per controllare la knowledge base.
+7. Usare **Vault**, **Stats** e **Timeline** per controllare la knowledge base.
 
 ## Viste della GUI
 
 | Vista | Scopo |
 |---|---|
+| Dashboard | Disponibilità dello spazio di lavoro, riepiloghi bounded e prossime azioni utili |
 | Browse | Ricerca, filtri ed esportazione delle lesson |
 | Detail | Lettura di una lesson e similarità spiegata |
 | Editor | Creazione o aggiornamento di lesson Markdown canoniche |
@@ -66,6 +69,19 @@ dataset, topic, fonti, percorsi, ID, payload API o identità di navigazione.
 | Vault | Albero Markdown canonico e import della proiezione |
 | Duplicates | Revisione non distruttiva di duplicati e near-duplicate |
 | Ops | Health, Vault Doctor, import, training e refresh |
+
+## Dashboard e stati di primo avvio
+
+`/app/` apre la Dashboard. Browse resta disponibile direttamente su
+`#/browse`.
+
+La Dashboard legge soltanto uno stato bounded dello spazio di lavoro. Distingue
+un primo avvio senza vault, un vault vuoto, uno spazio parzialmente pronto, uno
+spazio pronto ed errori di caricamento recuperabili. Non avvia automaticamente
+la revisione duplicati, Vault Doctor, import, refresh o training del modello.
+
+Il vault Markdown resta la fonte autorevole. Proiezioni dataset, cache e
+artefatti del topic model sono derivati e ricostruibili.
 
 ## Screenshot
 

--- a/frontend/e2e/brand-design-system.spec.ts
+++ b/frontend/e2e/brand-design-system.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from '@playwright/test'
 
 test.describe('brand foundation', () => {
   test('shows the packaged mark and consistent core control states', async ({ page }) => {
-    await page.goto('/app/#/')
+    await page.goto('/app/#/browse')
 
-    const brand = page.getByRole('link', { name: 'LeLe Manager, browse' })
+    const brand = page.getByRole('link', { name: 'LeLe Manager, dashboard' })
     await expect(brand).toBeVisible()
     await expect(brand.locator('img')).toHaveAttribute('src', '/app/brand/lele-manager-mark.svg')
     const browsePanel = page.getByRole('region', {
@@ -31,10 +31,10 @@ test.describe('brand foundation', () => {
   })
 
   test('uses default English product labels while preserving navigation hashes', async ({ page }) => {
-    await page.goto('/app/#/')
+    await page.goto('/app/#/browse')
 
     const navigation = [
-      ['Browse', '#/'],
+      ['Browse', '#/browse'],
       ['Timeline', '#/timeline'],
       ['Statistics', '#/stats'],
       ['New LeLe', '#/editor'],
@@ -58,7 +58,7 @@ test.describe('brand foundation', () => {
   })
 
   test('makes keyboard focus visible on navigation and controls', async ({ page }) => {
-    await page.goto('/app/#/')
+    await page.goto('/app/#/browse')
 
     const timeline = page.getByRole('link', { name: 'Timeline' })
     await timeline.focus()
@@ -73,7 +73,7 @@ test.describe('brand foundation', () => {
 })
 
 test('shows the GiadaWare product signature without crowding the product brand', async ({ page }) => {
-  await page.goto('/app/')
+  await page.goto('/app/#/browse')
 
   await expect(page.getByTestId('brand-tagline')).toHaveText(
     'Your local space for your “Lessons Learned”',
@@ -150,7 +150,7 @@ test('pins the maker signature to the desktop viewport across routes', async ({ 
 
 test('keeps browse filter controls clear of the right edge', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 800 })
-  await page.goto('/app/')
+  await page.goto('/app/#/browse')
 
   const grid = page.getByTestId('browse-filter-grid')
   await expect(grid).toBeVisible()

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,427 @@
+import { expect, test, type Page } from '@playwright/test'
+
+interface DashboardFixture {
+  health_status: string
+  vault_exists: boolean
+  vault_markdown_files: number | null
+  projection_exists: boolean
+  model_exists: boolean
+  stats: {
+    n_lessons: number
+    n_topics: number
+    n_unique_tags: number
+    avg_text_length: number
+    avg_importance: number | null
+    top_tags: { tag: string; count: number }[]
+    by_topic: { topic: string; count: number }[]
+  } | null
+  candidates: {
+    total: number
+    staged: number
+    in_review: number
+    rejected: number
+    approved: number
+  } | null
+}
+
+const baseSummary: DashboardFixture = {
+  health_status: 'ok',
+  vault_exists: true,
+  vault_markdown_files: 4,
+  projection_exists: true,
+  model_exists: true,
+  stats: {
+    n_lessons: 4,
+    n_topics: 2,
+    n_unique_tags: 3,
+    avg_text_length: 120,
+    avg_importance: 3.5,
+    top_tags: [],
+    by_topic: [],
+  },
+  candidates: {
+    total: 3,
+    staged: 1,
+    in_review: 1,
+    rejected: 0,
+    approved: 1,
+  },
+}
+
+async function mockDashboard(
+  page: Page,
+  summary: DashboardFixture,
+): Promise<void> {
+  await page.route('**/dashboard/summary', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(summary),
+    }),
+  )
+}
+
+test.describe('product dashboard', () => {
+  test('opens at the root route and keeps Browse explicit', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Dashboard',
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+
+    await expect(
+      navigation.getByRole('link', {
+        name: 'Dashboard',
+        exact: true,
+      }),
+    ).toHaveAttribute('href', '#/')
+
+    await expect(
+      navigation.getByRole('link', {
+        name: 'Browse',
+        exact: true,
+      }),
+    ).toHaveAttribute('href', '#/browse')
+
+    await navigation
+      .getByRole('link', {
+        name: 'Browse',
+        exact: true,
+      })
+      .click()
+
+    await expect(page).toHaveURL(/#\/browse$/)
+    await expect(
+      page.getByRole('heading', {
+        name: 'Browse',
+        exact: true,
+      }),
+    ).toBeVisible()
+  })
+
+  test('renders bounded workspace state without passive operations', async ({
+    page,
+  }) => {
+    const forbiddenRequests: string[] = []
+
+    page.on('request', (request) => {
+      const url = new URL(request.url())
+
+      if (
+        [
+          '/duplicates',
+          '/vault/doctor',
+          '/vault/import',
+          '/ops/refresh',
+          '/train/topic',
+        ].some((path) => url.pathname.startsWith(path))
+      ) {
+        forbiddenRequests.push(
+          `${request.method()} ${url.pathname}`,
+        )
+      }
+    })
+
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByRole('region', {
+        name: 'Workspace readiness',
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('region', {
+        name: 'Workspace summary',
+      }),
+    ).toBeVisible()
+
+    expect(forbiddenRequests).toEqual([])
+  })
+
+  test('shows a deterministic loading state', async ({ page }) => {
+    await page.route('**/dashboard/summary', async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(baseSummary),
+      })
+    })
+
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByText('Loading workspace status…', {
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByText('Workspace ready', {
+        exact: true,
+      }),
+    ).toBeVisible()
+  })
+
+  test('shows fresh first-run state when no vault exists', async ({
+    page,
+  }) => {
+    await mockDashboard(page, {
+      ...baseSummary,
+      vault_exists: false,
+      vault_markdown_files: null,
+      projection_exists: false,
+      model_exists: false,
+      stats: null,
+      candidates: {
+        total: 0,
+        staged: 0,
+        in_review: 0,
+        rejected: 0,
+        approved: 0,
+      },
+    })
+
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByText('Workspace setup required', {
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Open Vault',
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByText(
+        /Markdown vault is the authoritative source/,
+      ),
+    ).toBeVisible()
+  })
+
+  test('shows empty-vault state with useful first actions', async ({
+    page,
+  }) => {
+    await mockDashboard(page, {
+      ...baseSummary,
+      vault_markdown_files: 0,
+      projection_exists: false,
+      model_exists: false,
+      stats: null,
+      candidates: {
+        total: 0,
+        staged: 0,
+        in_review: 0,
+        rejected: 0,
+        approved: 0,
+      },
+    })
+
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByText(
+        'Vault ready, no approved knowledge yet',
+        { exact: true },
+      ),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('button', {
+        name: 'New LeLe',
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Collection',
+        exact: true,
+      }),
+    ).toBeVisible()
+  })
+
+  test('shows partial state and delegates recovery to System', async ({
+    page,
+  }) => {
+    await mockDashboard(page, {
+      ...baseSummary,
+      model_exists: false,
+    })
+
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByText('Workspace partially ready', {
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByText('missing', { exact: true }),
+    ).toHaveCount(1)
+
+    await page
+      .getByRole('button', {
+        name: 'Open System',
+        exact: true,
+      })
+      .click()
+
+    await expect(page).toHaveURL(/#\/ops$/)
+  })
+
+  test('shows ready state with bounded knowledge and candidate summaries', async ({
+    page,
+  }) => {
+    await mockDashboard(page, baseSummary)
+
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByText('Workspace ready', {
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Approved knowledge',
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Collection attention',
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByText('4', { exact: true }).first(),
+    ).toBeVisible()
+  })
+
+  test('shows a recoverable dashboard error', async ({ page }) => {
+    await page.route('**/dashboard/summary', (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          detail: 'dashboard fixture failure',
+        }),
+      }),
+    )
+
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByText(
+        /Workspace status could not be loaded/,
+      ),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Retry',
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('button', {
+        name: 'Open System',
+        exact: true,
+      }),
+    ).toBeVisible()
+  })
+
+  test('keeps the dashboard usable on mobile width', async ({
+    page,
+  }) => {
+    await mockDashboard(page, baseSummary)
+    await page.setViewportSize({
+      width: 390,
+      height: 844,
+    })
+
+    await page.goto('/app/#/')
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Dashboard',
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    const summary = page.getByRole('region', {
+      name: 'Workspace summary',
+    })
+
+    await expect(summary).toBeVisible()
+
+    const geometry = await summary.evaluate((element) => {
+      const box = element.getBoundingClientRect()
+      return {
+        left: box.left,
+        right: box.right,
+        viewport: window.innerWidth,
+      }
+    })
+
+    expect(geometry.left).toBeGreaterThanOrEqual(0)
+    expect(geometry.right).toBeLessThanOrEqual(
+      geometry.viewport + 0.5,
+    )
+
+    await expect(
+      page.getByRole('navigation', {
+        name: 'Primary',
+      }).getByRole('link', {
+        name: 'Dashboard',
+        exact: true,
+      }),
+    ).toBeVisible()
+  })
+
+  test('localizes dashboard state without changing the root route', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/')
+
+    await page
+      .getByLabel('Language')
+      .selectOption('it')
+
+    await expect(
+      page.getByRole('heading', {
+        name: 'Dashboard',
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('region', {
+        name: 'Disponibilità dello spazio di lavoro',
+      }),
+    ).toBeVisible()
+
+    await expect(page).toHaveURL(/#\/$/)
+  })
+})

--- a/frontend/e2e/docs-screenshots.spec.ts
+++ b/frontend/e2e/docs-screenshots.spec.ts
@@ -75,7 +75,7 @@ test.describe('GUI documentation screenshots', () => {
       window.localStorage.setItem('lele-manager.locale', 'it')
     })
 
-    await page.goto('/app/#/')
+    await page.goto('/app/#/browse')
     await expect(page.getByRole('heading', { name: 'Esplora' })).toBeVisible()
     await expect(page.locator('.lesson-card').first()).toBeVisible()
     await prepareDocumentationScreenshot(page)

--- a/frontend/e2e/giada-ui.spec.ts
+++ b/frontend/e2e/giada-ui.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test'
 
 test('renders Browse with direct Giada UI primitives', async ({ page }) => {
   await page.setViewportSize({ width: 1800, height: 900 })
-  await page.goto('/app/')
+  await page.goto('/app/#/browse')
 
   const panel = page.locator('.giu-panel')
   await expect(panel).toHaveCount(1)
@@ -159,7 +159,7 @@ test('renders Stats and Vault with Giada UI primitives', async ({
 test('renders Detail, Editor, and duplicate controls with Giada UI', async ({
   page,
 }) => {
-  await page.goto('/app/#/')
+  await page.goto('/app/#/browse')
 
   const firstCard = page.locator('.lesson-card').first()
   await expect(firstCard).toBeVisible({

--- a/frontend/e2e/localization.spec.ts
+++ b/frontend/e2e/localization.spec.ts
@@ -154,7 +154,8 @@ test.describe('GUI localization', () => {
     await resetLocale(page)
 
     const expected = [
-      ['Browse', '#/'],
+      ['Dashboard', '#/'],
+      ['Browse', '#/browse'],
       ['Timeline', '#/timeline'],
       ['Statistics', '#/stats'],
       ['New LeLe', '#/editor'],
@@ -180,7 +181,8 @@ test.describe('GUI localization', () => {
       .selectOption('it')
 
     const italianExpected = [
-      ['Esplora', '#/'],
+      ['Dashboard', '#/'],
+      ['Esplora', '#/browse'],
       ['Cronologia', '#/timeline'],
       ['Statistiche', '#/stats'],
       ['Nuova LeLe', '#/editor'],
@@ -204,6 +206,7 @@ test.describe('GUI localization', () => {
     page,
   }) => {
     await resetLocale(page)
+    await page.goto('/app/#/browse')
 
     const navigation = page.getByRole('navigation')
 
@@ -373,6 +376,7 @@ test.describe('GUI localization', () => {
     page,
   }) => {
     await resetLocale(page)
+    await page.goto('/app/#/browse')
 
     const firstCard = page.locator('.lesson-card').first()
 
@@ -599,7 +603,7 @@ test.describe('GUI localization', () => {
     page,
   }) => {
     await resetLocale(page)
-    await page.goto('/app/#/')
+    await page.goto('/app/#/browse')
 
     const healthBar = page.locator('.health-bar')
 

--- a/frontend/e2e/product-shell.spec.ts
+++ b/frontend/e2e/product-shell.spec.ts
@@ -21,6 +21,7 @@ test.describe('product shell hierarchy', () => {
     ).toBeVisible()
 
     for (const label of [
+      'Dashboard',
       'Browse',
       'Timeline',
       'Statistics',
@@ -45,7 +46,7 @@ test.describe('product shell hierarchy', () => {
       name: 'Primary',
     })
 
-    await expect(navigation.locator('svg')).toHaveCount(8)
+    await expect(navigation.locator('svg')).toHaveCount(9)
 
     for (const emoji of [
       '🏠',
@@ -104,8 +105,11 @@ test.describe('product shell hierarchy', () => {
     ).toBeVisible()
 
     await expect(
-      navigation.getByRole('link', { name: 'Esplora' }),
+      navigation.getByRole('link', { name: 'Dashboard' }),
     ).toHaveAttribute('href', '#/')
+    await expect(
+      navigation.getByRole('link', { name: 'Esplora' }),
+    ).toHaveAttribute('href', '#/browse')
     await expect(
       navigation.getByRole('link', { name: 'Cronologia' }),
     ).toHaveAttribute('href', '#/timeline')

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('GUI smoke', () => {
   test('browse → click risultato → detail', async ({ page }) => {
-    await page.goto('/app/#/')
+    await page.goto('/app/#/browse')
     await expect(page.getByRole('heading', { name: 'Browse', exact: true })).toBeVisible()
 
     const firstCard = page.locator('.lesson-card').first()

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import Shell from './components/Shell.svelte'
+  import Dashboard from './routes/Dashboard.svelte'
   import Browse from './routes/Browse.svelte'
   import Detail from './routes/Detail.svelte'
   import Editor from './routes/Editor.svelte'
@@ -12,7 +13,7 @@
   import TritaLeLe from './routes/TritaLeLe.svelte'
   import { parseRoute, type Route } from './lib/router'
 
-  let route = $state<Route>({ view: 'browse' })
+  let route = $state<Route>({ view: 'dashboard' })
 
   onMount(() => {
     route = parseRoute()
@@ -25,7 +26,9 @@
 </script>
 
 <Shell {route}>
-  {#if route.view === 'browse'}
+  {#if route.view === 'dashboard'}
+    <Dashboard />
+  {:else if route.view === 'browse'}
     <Browse />
   {:else if route.view === 'detail'}
     <Detail id={route.id} />

--- a/frontend/src/components/NavIcon.svelte
+++ b/frontend/src/components/NavIcon.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   type IconName =
+    | 'dashboard'
     | 'browse'
     | 'timeline'
     | 'stats'
@@ -27,7 +28,12 @@
   stroke-linejoin="round"
   aria-hidden="true"
 >
-  {#if name === 'browse'}
+  {#if name === 'dashboard'}
+    <rect x="4" y="4" width="6" height="6" rx="1" />
+    <rect x="14" y="4" width="6" height="6" rx="1" />
+    <rect x="4" y="14" width="6" height="6" rx="1" />
+    <rect x="14" y="14" width="6" height="6" rx="1" />
+  {:else if name === 'browse'}
     <path d="M4 5.5h6l2 2H20v11H4z" />
     <path d="M4 9h16" />
   {:else if name === 'timeline'}

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -21,7 +21,8 @@
     {
       labelKey: 'navGroupKnowledge' as const,
       links: [
-        { view: 'browse' as const, labelKey: 'navBrowse' as const, hash: '#/', icon: 'browse' as const },
+        { view: 'dashboard' as const, labelKey: 'navDashboard' as const, hash: '#/', icon: 'dashboard' as const },
+        { view: 'browse' as const, labelKey: 'navBrowse' as const, hash: '#/browse', icon: 'browse' as const },
         { view: 'timeline' as const, labelKey: 'navTimeline' as const, hash: '#/timeline', icon: 'timeline' as const },
         { view: 'stats' as const, labelKey: 'navStatistics' as const, hash: '#/stats', icon: 'stats' as const },
       ],
@@ -81,7 +82,7 @@
 
 <div class="shell">
   <aside class="sidebar">
-    <a class="brand" href="#/" aria-label={$messages.brandBrowseAccessible} onclick={(e) => { e.preventDefault(); navigate({ view: 'browse' }) }}>
+    <a class="brand" href="#/" aria-label={$messages.brandHomeAccessible} onclick={(e) => { e.preventDefault(); navigate({ view: 'dashboard' }) }}>
       <img src="/app/brand/lele-manager-mark.svg" alt="" aria-hidden="true" />
       <span>
         <strong>LeLe Manager</strong>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -63,6 +63,24 @@ export interface RuntimeInfoResponse {
   version: string
 }
 
+export interface DashboardCandidateSummary {
+  total: number
+  staged: number
+  in_review: number
+  rejected: number
+  approved: number
+}
+
+export interface DashboardSummaryResponse {
+  health_status: string
+  vault_exists: boolean
+  vault_markdown_files: number | null
+  projection_exists: boolean
+  model_exists: boolean
+  stats: StatsSummaryResponse | null
+  candidates: DashboardCandidateSummary | null
+}
+
 export interface TrainResponse {
   message: string
   n_lessons: number
@@ -350,6 +368,9 @@ export const api = {
   health: () => request<HealthResponse>('/health'),
 
   runtimeInfo: () => request<RuntimeInfoResponse>('/runtime/info'),
+
+  dashboardSummary: () =>
+    request<DashboardSummaryResponse>('/dashboard/summary'),
 
   duplicates: ({ min_score, exact_only, limit }: DuplicateQuery) => {
     const params = new URLSearchParams({

--- a/frontend/src/lib/i18n/en.ts
+++ b/frontend/src/lib/i18n/en.ts
@@ -1,7 +1,50 @@
 export const en = {
   brandBrowseAccessible: 'LeLe Manager, browse',
+  brandHomeAccessible: 'LeLe Manager, dashboard',
+  dashboardTitle: 'Dashboard',
+  dashboardLoading: 'Loading workspace status…',
+  dashboardIntro:
+    'A concise view of workspace readiness, attention, and the next useful action.',
+  dashboardReadiness: 'Workspace readiness',
+  dashboardSummary: 'Workspace summary',
+  dashboardFreshTitle: 'Workspace setup required',
+  dashboardFreshDescription:
+    'No usable Markdown vault is currently available. Open Vault or System to continue setup.',
+  dashboardEmptyTitle: 'Vault ready, no approved knowledge yet',
+  dashboardEmptyDescription:
+    'The Markdown vault is available but contains no lessons yet. Create or collect your first LeLe.',
+  dashboardPartialTitle: 'Workspace partially ready',
+  dashboardPartialDescription:
+    'Approved knowledge exists, but one or more derived local artifacts are missing. You can still use the vault; rebuild derived state from System when needed.',
+  dashboardReadyTitle: 'Workspace ready',
+  dashboardReadyDescription:
+    'Your local knowledge workspace and derived search state are available.',
+  dashboardOwnership:
+    'The Markdown vault is the authoritative source of approved knowledge. Projections, caches, and models are local derived artifacts that can be rebuilt.',
+  dashboardError: 'Workspace status could not be loaded: {error}',
+  dashboardRetry: 'Retry',
+  dashboardOpenVault: 'Open Vault',
+  dashboardOpenSystem: 'Open System',
+  dashboardOpenStatistics: 'Open Statistics',
+  dashboardOpenCollection: 'Open Collection',
+  dashboardVault: 'Markdown vault',
+  dashboardProjection: 'Projection',
+  dashboardModel: 'Search model',
+  dashboardApi: 'Application API',
+  dashboardAvailable: 'available',
+  dashboardMissing: 'missing',
+  dashboardMarkdownFiles: '{count} Markdown files',
+  dashboardKnowledgeTitle: 'Approved knowledge',
+  dashboardKnowledgeDescription:
+    'Bounded statistics from the current local projection.',
+  dashboardCandidatesTitle: 'Collection attention',
+  dashboardCandidatesDescription:
+    'Candidates already present in local staging; no scan is run by this dashboard.',
+  dashboardCandidateStaged: 'Staged',
+  dashboardCandidateReview: 'In review',
   brandTagline: 'Your local space for your “Lessons Learned”',
 
+  navDashboard: 'Dashboard',
   navBrowse: 'Browse',
   navTimeline: 'Timeline',
   navStatistics: 'Statistics',

--- a/frontend/src/lib/i18n/it.ts
+++ b/frontend/src/lib/i18n/it.ts
@@ -2,8 +2,51 @@ import type { Messages } from './en'
 
 export const it = {
   brandBrowseAccessible: 'LeLe Manager, esplora',
+  brandHomeAccessible: 'LeLe Manager, dashboard',
+  dashboardTitle: 'Dashboard',
+  dashboardLoading: 'Caricamento dello stato dello spazio di lavoro…',
+  dashboardIntro:
+    'Una vista sintetica sulla disponibilità dello spazio di lavoro, ciò che richiede attenzione e la prossima azione utile.',
+  dashboardReadiness: 'Disponibilità dello spazio di lavoro',
+  dashboardSummary: 'Riepilogo dello spazio di lavoro',
+  dashboardFreshTitle: 'Configurazione dello spazio di lavoro necessaria',
+  dashboardFreshDescription:
+    'Non è disponibile un vault Markdown utilizzabile. Apri Vault o Sistema per proseguire con la configurazione.',
+  dashboardEmptyTitle: 'Vault pronto, nessuna conoscenza approvata',
+  dashboardEmptyDescription:
+    'Il vault Markdown è disponibile ma non contiene ancora LeLe. Crea o raccogli la prima LeLe.',
+  dashboardPartialTitle: 'Spazio di lavoro parzialmente pronto',
+  dashboardPartialDescription:
+    'La conoscenza approvata esiste, ma manca almeno un artefatto locale derivato. Il vault resta utilizzabile; ricostruisci lo stato derivato da Sistema quando necessario.',
+  dashboardReadyTitle: 'Spazio di lavoro pronto',
+  dashboardReadyDescription:
+    'Lo spazio di conoscenza locale e lo stato derivato per la ricerca sono disponibili.',
+  dashboardOwnership:
+    'Il vault Markdown è la fonte autorevole della conoscenza approvata. Proiezioni, cache e modelli sono artefatti locali derivati e ricostruibili.',
+  dashboardError: 'Impossibile caricare lo stato dello spazio di lavoro: {error}',
+  dashboardRetry: 'Riprova',
+  dashboardOpenVault: 'Apri Vault',
+  dashboardOpenSystem: 'Apri Sistema',
+  dashboardOpenStatistics: 'Apri Statistiche',
+  dashboardOpenCollection: 'Apri Raccolta',
+  dashboardVault: 'Vault Markdown',
+  dashboardProjection: 'Proiezione',
+  dashboardModel: 'Modello di ricerca',
+  dashboardApi: 'API applicativa',
+  dashboardAvailable: 'disponibile',
+  dashboardMissing: 'mancante',
+  dashboardMarkdownFiles: '{count} file Markdown',
+  dashboardKnowledgeTitle: 'Conoscenza approvata',
+  dashboardKnowledgeDescription:
+    'Statistiche limitate dalla proiezione locale corrente.',
+  dashboardCandidatesTitle: 'Attenzione sulla raccolta',
+  dashboardCandidatesDescription:
+    'Candidati già presenti nello staging locale; il dashboard non esegue alcuna scansione.',
+  dashboardCandidateStaged: 'In staging',
+  dashboardCandidateReview: 'In revisione',
   brandTagline: "Lo spazio locale per le tue 'Lessons Learned'",
 
+  navDashboard: 'Dashboard',
   navBrowse: 'Esplora',
   navTimeline: 'Cronologia',
   navStatistics: 'Statistiche',

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -1,4 +1,5 @@
 export type Route =
+  | { view: 'dashboard' }
   | { view: 'browse' }
   | { view: 'detail'; id: string }
   | { view: 'editor'; id?: string }
@@ -12,7 +13,8 @@ export type Route =
 export function parseRoute(hash = location.hash): Route {
   const path = hash.replace(/^#/, '') || '/'
 
-  if (path === '/' || path === '/browse') return { view: 'browse' }
+  if (path === '/') return { view: 'dashboard' }
+  if (path === '/browse') return { view: 'browse' }
   if (path === '/ops') return { view: 'ops' }
   if (path === '/duplicates') return { view: 'duplicates' }
   if (path === '/vault') return { view: 'vault' }
@@ -27,13 +29,15 @@ export function parseRoute(hash = location.hash): Route {
   const detailMatch = path.match(/^\/lesson\/(.+)$/)
   if (detailMatch) return { view: 'detail', id: decodeURIComponent(detailMatch[1]) }
 
-  return { view: 'browse' }
+  return { view: 'dashboard' }
 }
 
 export function routeToHash(route: Route): string {
   switch (route.view) {
-    case 'browse':
+    case 'dashboard':
       return '#/'
+    case 'browse':
+      return '#/browse'
     case 'ops':
       return '#/ops'
     case 'duplicates':

--- a/frontend/src/routes/Dashboard.svelte
+++ b/frontend/src/routes/Dashboard.svelte
@@ -1,0 +1,568 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { FormStatus } from 'giadaware-ui-components'
+  import {
+    Button,
+    FormActions,
+    Panel,
+    Surface,
+  } from 'giadaware-ui-components/studio'
+  import {
+    api,
+    type DashboardSummaryResponse,
+  } from '../lib/api'
+  import { navigate } from '../lib/router'
+  import { formatMessage, messages } from '../lib/i18n'
+
+  let summary = $state<DashboardSummaryResponse | null>(null)
+  let loading = $state(true)
+  let error = $state('')
+
+  type DashboardState =
+    | 'fresh'
+    | 'empty'
+    | 'partial'
+    | 'ready'
+
+  function dashboardState(
+    value: DashboardSummaryResponse,
+  ): DashboardState {
+    if (!value.vault_exists) {
+      return 'fresh'
+    }
+
+    if ((value.vault_markdown_files ?? 0) === 0) {
+      return 'empty'
+    }
+
+    if (
+      !value.projection_exists ||
+      !value.model_exists
+    ) {
+      return 'partial'
+    }
+
+    return 'ready'
+  }
+
+  function titleFor(state: DashboardState): string {
+    switch (state) {
+      case 'fresh':
+        return $messages.dashboardFreshTitle
+      case 'empty':
+        return $messages.dashboardEmptyTitle
+      case 'partial':
+        return $messages.dashboardPartialTitle
+      case 'ready':
+        return $messages.dashboardReadyTitle
+    }
+  }
+
+  function descriptionFor(state: DashboardState): string {
+    switch (state) {
+      case 'fresh':
+        return $messages.dashboardFreshDescription
+      case 'empty':
+        return $messages.dashboardEmptyDescription
+      case 'partial':
+        return $messages.dashboardPartialDescription
+      case 'ready':
+        return $messages.dashboardReadyDescription
+    }
+  }
+
+  async function load() {
+    loading = true
+    error = ''
+
+    try {
+      summary = await api.dashboardSummary()
+    } catch (e) {
+      summary = null
+      error = e instanceof Error ? e.message : String(e)
+    } finally {
+      loading = false
+    }
+  }
+
+  onMount(load)
+</script>
+
+<Panel title={$messages.dashboardTitle} class="dashboard">
+  <p class="dashboard-intro">
+    {$messages.dashboardIntro}
+  </p>
+
+  {#if loading}
+    <p class="meta" aria-live="polite">
+      {$messages.dashboardLoading}
+    </p>
+  {:else if error}
+    <FormStatus
+      message={formatMessage(
+        $messages.dashboardError,
+        { error },
+      )}
+      tone="error"
+      style="--giu-form-status-padding: var(--space-2) var(--space-3)"
+    />
+
+    <div class="dashboard-actions">
+      <FormActions>
+      <Button
+        variant="secondary"
+        size="compact"
+        class="lele-secondary-button"
+        onclick={load}
+      >
+        {$messages.dashboardRetry}
+      </Button>
+
+      <Button
+        variant="secondary"
+        size="compact"
+        class="lele-secondary-button"
+        onclick={() => navigate({ view: 'ops' })}
+      >
+        {$messages.dashboardOpenSystem}
+      </Button>
+    </FormActions>
+    </div>
+  {:else if summary}
+    {@const state = dashboardState(summary)}
+
+    <section
+      class="readiness"
+      aria-label={$messages.dashboardReadiness}
+    >
+      <Surface>
+      <span
+        class="readiness-state"
+        class:is-ready={state === 'ready'}
+        class:is-warning={state !== 'ready'}
+      >
+        {titleFor(state)}
+      </span>
+
+      <p>{descriptionFor(state)}</p>
+
+      {#if state === 'fresh'}
+        <p class="ownership-note">
+          {$messages.dashboardOwnership}
+        </p>
+
+        <div class="dashboard-actions">
+      <FormActions>
+          <Button
+            size="compact"
+            onclick={() => navigate({ view: 'vault' })}
+          >
+            {$messages.dashboardOpenVault}
+          </Button>
+
+          <Button
+            variant="secondary"
+            size="compact"
+            class="lele-secondary-button"
+            onclick={() => navigate({ view: 'ops' })}
+          >
+            {$messages.dashboardOpenSystem}
+          </Button>
+        </FormActions>
+    </div>
+      {:else if state === 'empty'}
+        <p class="ownership-note">
+          {$messages.dashboardOwnership}
+        </p>
+
+        <div class="dashboard-actions">
+      <FormActions>
+          <Button
+            size="compact"
+            onclick={() => navigate({ view: 'editor' })}
+          >
+            {$messages.navNewLele}
+          </Button>
+
+          <Button
+            variant="secondary"
+            size="compact"
+            class="lele-secondary-button"
+            onclick={() => navigate({ view: 'tritalele' })}
+          >
+            {$messages.navCollection}
+          </Button>
+        </FormActions>
+    </div>
+      {:else if state === 'partial'}
+        <div class="dashboard-actions">
+      <FormActions>
+          <Button
+            size="compact"
+            onclick={() => navigate({ view: 'ops' })}
+          >
+            {$messages.dashboardOpenSystem}
+          </Button>
+
+          <Button
+            variant="secondary"
+            size="compact"
+            class="lele-secondary-button"
+            onclick={() => navigate({ view: 'browse' })}
+          >
+            {$messages.navBrowse}
+          </Button>
+        </FormActions>
+    </div>
+      {:else}
+        <div class="dashboard-actions">
+      <FormActions>
+          <Button
+            size="compact"
+            onclick={() => navigate({ view: 'editor' })}
+          >
+            {$messages.navNewLele}
+          </Button>
+
+          <Button
+            variant="secondary"
+            size="compact"
+            class="lele-secondary-button"
+            onclick={() => navigate({ view: 'browse' })}
+          >
+            {$messages.navBrowse}
+          </Button>
+
+          <Button
+            variant="secondary"
+            size="compact"
+            class="lele-secondary-button"
+            onclick={() => navigate({ view: 'tritalele' })}
+          >
+            {$messages.navCollection}
+          </Button>
+        </FormActions>
+    </div>
+      {/if}
+      </Surface>
+    </section>
+
+    <section
+      class="summary-grid"
+      aria-label={$messages.dashboardSummary}
+    >
+      <div class="summary-card">
+        <Surface>
+        <span class="label">
+          {$messages.dashboardVault}
+        </span>
+        <strong>
+          {summary.vault_exists
+            ? $messages.dashboardAvailable
+            : $messages.dashboardMissing}
+        </strong>
+        {#if summary.vault_markdown_files !== null}
+          <span class="meta">
+            {formatMessage(
+              $messages.dashboardMarkdownFiles,
+              { count: summary.vault_markdown_files },
+            )}
+          </span>
+        {/if}
+      </Surface>
+      </div>
+
+      <div class="summary-card">
+
+        <Surface>
+        <span class="label">
+          {$messages.dashboardProjection}
+        </span>
+        <strong>
+          {summary.projection_exists
+            ? $messages.dashboardAvailable
+            : $messages.dashboardMissing}
+        </strong>
+      </Surface>
+
+      </div>
+
+      <div class="summary-card">
+
+        <Surface>
+        <span class="label">
+          {$messages.dashboardModel}
+        </span>
+        <strong>
+          {summary.model_exists
+            ? $messages.dashboardAvailable
+            : $messages.dashboardMissing}
+        </strong>
+      </Surface>
+
+      </div>
+
+      <div class="summary-card">
+
+        <Surface>
+        <span class="label">
+          {$messages.dashboardApi}
+        </span>
+        <strong>{summary.health_status}</strong>
+      </Surface>
+
+      </div>
+    </section>
+
+    {#if summary.stats}
+      <section
+        class="knowledge-summary"
+        aria-labelledby="dashboard-knowledge-title"
+      >
+        <div class="section-heading">
+          <div>
+            <h2 id="dashboard-knowledge-title">
+              {$messages.dashboardKnowledgeTitle}
+            </h2>
+            <p class="meta">
+              {$messages.dashboardKnowledgeDescription}
+            </p>
+          </div>
+
+          <Button
+            variant="secondary"
+            size="compact"
+            class="lele-secondary-button"
+            onclick={() => navigate({ view: 'stats' })}
+          >
+            {$messages.dashboardOpenStatistics}
+          </Button>
+        </div>
+
+        <div class="knowledge-grid">
+          <div class="summary-card">
+            <Surface>
+            <span class="label">LeLe</span>
+            <strong>{summary.stats.n_lessons}</strong>
+          </Surface>
+          </div>
+
+          <div class="summary-card">
+
+            <Surface>
+            <span class="label">Topic</span>
+            <strong>{summary.stats.n_topics}</strong>
+          </Surface>
+
+          </div>
+
+          <div class="summary-card">
+
+            <Surface>
+            <span class="label">
+              {$messages.statsUniqueTags}
+            </span>
+            <strong>{summary.stats.n_unique_tags}</strong>
+          </Surface>
+
+          </div>
+        </div>
+      </section>
+    {/if}
+
+    {#if summary.candidates}
+      <section
+        class="candidate-summary"
+        aria-labelledby="dashboard-candidates-title"
+      >
+        <div class="section-heading">
+          <div>
+            <h2 id="dashboard-candidates-title">
+              {$messages.dashboardCandidatesTitle}
+            </h2>
+            <p class="meta">
+              {$messages.dashboardCandidatesDescription}
+            </p>
+          </div>
+
+          <Button
+            variant="secondary"
+            size="compact"
+            class="lele-secondary-button"
+            onclick={() => navigate({ view: 'tritalele' })}
+          >
+            {$messages.dashboardOpenCollection}
+          </Button>
+        </div>
+
+        <div class="candidate-grid">
+          <div class="summary-card">
+            <Surface>
+            <span class="label">
+              {$messages.dashboardCandidateStaged}
+            </span>
+            <strong>{summary.candidates.staged}</strong>
+          </Surface>
+          </div>
+
+          <div class="summary-card">
+
+            <Surface>
+            <span class="label">
+              {$messages.dashboardCandidateReview}
+            </span>
+            <strong>{summary.candidates.in_review}</strong>
+          </Surface>
+
+          </div>
+        </div>
+      </section>
+    {/if}
+  {/if}
+</Panel>
+
+<style>
+  .dashboard-intro,
+  .ownership-note,
+  .readiness p {
+    max-width: 760px;
+  }
+
+  .dashboard-intro {
+    margin: 0 0 16px;
+    color: var(--muted);
+  }
+
+  .readiness {
+    display: grid;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
+  .readiness p {
+    margin: 0;
+  }
+
+  .readiness-state {
+    width: fit-content;
+    font-weight: 700;
+  }
+
+  .readiness-state::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-right: 7px;
+    border-radius: 999px;
+    background: currentColor;
+    vertical-align: 1px;
+  }
+
+  .is-ready {
+    color: var(--ok);
+  }
+
+  .is-warning {
+    color: var(--warn);
+  }
+
+  .ownership-note {
+    color: var(--muted);
+    font-size: 0.9rem;
+  }
+
+  .dashboard-actions {
+    margin-top: 2px;
+  }
+
+  .summary-grid,
+  .knowledge-grid,
+  .candidate-grid {
+    display: grid;
+    gap: 12px;
+  }
+
+  .summary-grid {
+    grid-template-columns: repeat(
+      4,
+      minmax(0, 1fr)
+    );
+    margin-bottom: 22px;
+  }
+
+  .knowledge-grid {
+    grid-template-columns: repeat(
+      3,
+      minmax(0, 1fr)
+    );
+  }
+
+  .candidate-grid {
+    grid-template-columns: repeat(
+      2,
+      minmax(0, 1fr)
+    );
+  }
+
+  .summary-card {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .summary-card strong {
+    font-size: 1.05rem;
+  }
+
+  .label {
+    color: var(--muted);
+    font-size: 0.8rem;
+  }
+
+  .knowledge-summary,
+  .candidate-summary {
+    display: grid;
+    gap: 12px;
+    margin-top: 22px;
+  }
+
+  .section-heading {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .section-heading h2,
+  .section-heading p {
+    margin: 0;
+  }
+
+  .section-heading h2 {
+    margin-bottom: 3px;
+    font-size: 1rem;
+  }
+
+  @media (max-width: 900px) {
+    .summary-grid {
+      grid-template-columns: repeat(
+        2,
+        minmax(0, 1fr)
+      );
+    }
+  }
+
+  @media (max-width: 620px) {
+    .summary-grid,
+    .knowledge-grid,
+    .candidate-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .section-heading {
+      align-items: start;
+      flex-direction: column;
+    }
+  }
+</style>

--- a/src/lele_manager/api/server.py
+++ b/src/lele_manager/api/server.py
@@ -13,6 +13,12 @@ from fastapi.responses import FileResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from threading import Lock
 
+from lele_manager.adapters.json_candidate_repository import JsonCandidateRepository
+from lele_manager.application.lesson_candidate import (
+    CandidateRepositoryError,
+    CandidateState,
+)
+from lele_manager.core.paths import candidates_path
 from lele_manager.core.analytics import compute_stats_summary, compute_timeline
 from lele_manager.application.dataframes import records_to_legacy_dataframe
 from lele_manager.application.external_lessons import external_lessons_feed
@@ -54,6 +60,7 @@ MODEL_PATH: Path | None = None
 def get_data_path() -> Path:
     return DATA_PATH if DATA_PATH is not None else resolve_data_path()
 
+
 def get_model_path() -> Path:
     return MODEL_PATH if MODEL_PATH is not None else resolve_model_path()
 
@@ -87,13 +94,18 @@ app = FastAPI(
 )
 app.include_router(tritalele_router)
 
+
 # -----------------------------------------------------------------------------
 # Schemi Pydantic
 # -----------------------------------------------------------------------------
 class LessonBase(BaseModel):
     text: str = Field(..., description="Testo della lesson learned")
-    topic: Optional[str] = Field(None, description="Topic/macrocategoria (es. python, cpp, linux)")
-    source: Optional[str] = Field(None, description="Origine: chatgpt, libro, esperimento, note, ...")
+    topic: Optional[str] = Field(
+        None, description="Topic/macrocategoria (es. python, cpp, linux)"
+    )
+    source: Optional[str] = Field(
+        None, description="Origine: chatgpt, libro, esperimento, note, ..."
+    )
     importance: Optional[int] = Field(
         None,
         ge=1,
@@ -239,7 +251,12 @@ class SimilarBatchItemRequest(BaseModel):
 
 
 class SimilarBatchRequest(BaseModel):
-    items: List[SimilarBatchItemRequest] = Field(..., min_length=1, max_length=50, description="Batch di richieste di similarità.")
+    items: List[SimilarBatchItemRequest] = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="Batch di richieste di similarità.",
+    )
 
 
 class SimilarBatchResponse(BaseModel):
@@ -296,6 +313,24 @@ class RuntimeInfoResponse(BaseModel):
 class VaultStatusResponse(BaseModel):
     vault_dir: str
     exists: bool
+
+
+class DashboardCandidateSummary(BaseModel):
+    total: int
+    staged: int
+    in_review: int
+    rejected: int
+    approved: int
+
+
+class DashboardSummaryResponse(BaseModel):
+    health_status: str
+    vault_exists: bool
+    vault_markdown_files: Optional[int] = None
+    projection_exists: bool
+    model_exists: bool
+    stats: Optional["StatsSummaryResponse"] = None
+    candidates: Optional[DashboardCandidateSummary] = None
 
 
 class VaultTreeResponse(BaseModel):
@@ -405,7 +440,17 @@ def load_lessons_df() -> pd.DataFrame:
         ) from e
 
     # Assicuriamoci che almeno queste colonne esistano
-    for col in ["id", "text", "topic", "source", "importance", "tags", "date", "title", "created_at"]:
+    for col in [
+        "id",
+        "text",
+        "topic",
+        "source",
+        "importance",
+        "tags",
+        "date",
+        "title",
+        "created_at",
+    ]:
         if col not in df.columns:
             df[col] = None
 
@@ -434,7 +479,9 @@ def append_lesson_to_jsonl(lesson: Lesson) -> None:
     try:
         legacy_jsonl_append_facade(get_data_path()).append(record)
     except DuplicateLessonIdError as exc:
-        raise HTTPException(status_code=409, detail=f"Lesson ID già esistente: {lesson.id}") from exc
+        raise HTTPException(
+            status_code=409, detail=f"Lesson ID già esistente: {lesson.id}"
+        ) from exc
     except ProjectionStoreError as exc:
         raise HTTPException(
             status_code=409,
@@ -496,7 +543,9 @@ def _build_similar_items(
     df_indexed = df.set_index("id")
     text_map = df_indexed["text"].fillna("").astype(str).to_dict()
     topic_map = (
-        df_indexed["topic"].fillna("").astype(str).to_dict() if "topic" in df_indexed.columns else {}
+        df_indexed["topic"].fillna("").astype(str).to_dict()
+        if "topic" in df_indexed.columns
+        else {}
     )
     tags_series = df_indexed["tags"] if "tags" in df_indexed.columns else None
 
@@ -538,7 +587,9 @@ def _build_similar_meta(
         return None
     data_path = get_data_path()
     model_path = get_model_path()
-    data_mtime_ns, model_mtime_ns = _similarity_cache_key(data_path=data_path, model_path=model_path)
+    data_mtime_ns, model_mtime_ns = _similarity_cache_key(
+        data_path=data_path, model_path=model_path
+    )
     return SimilarMeta(
         data_mtime_ns=int(data_mtime_ns),
         model_mtime_ns=int(model_mtime_ns),
@@ -570,7 +621,9 @@ def build_similarity_index(df: pd.DataFrame):
     Cached in API layer (#26).
     """
     if df.empty:
-        raise HTTPException(status_code=400, detail="Nessuna LeLe presente nel dataset.")
+        raise HTTPException(
+            status_code=400, detail="Nessuna LeLe presente nel dataset."
+        )
 
     model_path = get_model_path()
     data_path = get_data_path()
@@ -594,7 +647,9 @@ def build_similarity_index(df: pd.DataFrame):
             return app.state.sim_index
 
         pipeline = load_topic_model(str(model_path) if model_path else None)
-        index = LessonSimilarityIndex.from_topic_pipeline(df=df, pipeline=pipeline, id_column="id")
+        index = LessonSimilarityIndex.from_topic_pipeline(
+            df=df, pipeline=pipeline, id_column="id"
+        )
 
         app.state.sim_index = index
         app.state.sim_index_key = key
@@ -635,7 +690,9 @@ def _row_to_search_result(row: dict) -> LessonSearchResult:
 
     # importance: prova a convertirla, altrimenti None
     raw_importance = row.get("importance")
-    if raw_importance is None or (isinstance(raw_importance, float) and pd.isna(raw_importance)):
+    if raw_importance is None or (
+        isinstance(raw_importance, float) and pd.isna(raw_importance)
+    ):
         importance_val: Optional[int] = None
     else:
         try:
@@ -732,6 +789,60 @@ def runtime_info() -> RuntimeInfoResponse:
     return RuntimeInfoResponse(version=__version__)
 
 
+def _count_vault_markdown_files(node: object) -> int:
+    if not isinstance(node, dict):
+        return 0
+    if node.get("type") == "file":
+        return 1
+    children = node.get("children")
+    if not isinstance(children, list):
+        return 0
+    return sum(_count_vault_markdown_files(child) for child in children)
+
+
+@app.get("/dashboard/summary", response_model=DashboardSummaryResponse)
+def dashboard_summary() -> DashboardSummaryResponse:
+    """Return bounded, side-effect-free facts used by the product dashboard."""
+    health_state = health()
+    vault_state = vault_status()
+
+    vault_markdown_files: Optional[int] = None
+    if vault_state.exists:
+        tree = build_vault_tree(Path(vault_state.vault_dir))
+        vault_markdown_files = _count_vault_markdown_files(tree.to_dict())
+
+    stats: Optional[StatsSummaryResponse] = None
+    if health_state.has_data:
+        stats = stats_summary()
+
+    candidates: Optional[DashboardCandidateSummary]
+    try:
+        staged_candidates = JsonCandidateRepository(candidates_path()).list()
+    except CandidateRepositoryError:
+        candidates = None
+    else:
+        counts = {state: 0 for state in CandidateState}
+        for candidate in staged_candidates:
+            counts[candidate.state] += 1
+        candidates = DashboardCandidateSummary(
+            total=len(staged_candidates),
+            staged=counts[CandidateState.STAGED],
+            in_review=counts[CandidateState.IN_REVIEW],
+            rejected=counts[CandidateState.REJECTED],
+            approved=counts[CandidateState.APPROVED],
+        )
+
+    return DashboardSummaryResponse(
+        health_status=health_state.status,
+        vault_exists=vault_state.exists,
+        vault_markdown_files=vault_markdown_files,
+        projection_exists=health_state.has_data,
+        model_exists=health_state.has_model,
+        stats=stats,
+        candidates=candidates,
+    )
+
+
 @app.get("/health", response_model=HealthResponse)
 def health() -> HealthResponse:
     """
@@ -785,8 +896,12 @@ def duplicates(
     payload["pairs"] = [
         {
             **pair.to_dict(),
-            "left_lesson": _row_to_duplicate_snapshot(df.iloc[pair.left_position].to_dict()).model_dump(),
-            "right_lesson": _row_to_duplicate_snapshot(df.iloc[pair.right_position].to_dict()).model_dump(),
+            "left_lesson": _row_to_duplicate_snapshot(
+                df.iloc[pair.left_position].to_dict()
+            ).model_dump(),
+            "right_lesson": _row_to_duplicate_snapshot(
+                df.iloc[pair.right_position].to_dict()
+            ).model_dump(),
         }
         for pair in report.pairs
     ]
@@ -909,7 +1024,9 @@ def search_lessons(body: LessonSearchRequest) -> List[LessonSearchResult]:
         na_position="last",
         kind="mergesort",  # stable sort for determinism
     )
-    df = df.drop(columns=["_importance_num", "_created_at_dt", "_id_sort"], errors="ignore")
+    df = df.drop(
+        columns=["_importance_num", "_created_at_dt", "_id_sort"], errors="ignore"
+    )
 
     # Limit
     df = df.head(body.limit)
@@ -977,10 +1094,16 @@ def export_search(
     )
 
 
-@app.get("/lessons/{lesson_id:path}/similar", response_model=SimilarResponse, response_model_exclude_none=True)
+@app.get(
+    "/lessons/{lesson_id:path}/similar",
+    response_model=SimilarResponse,
+    response_model_exclude_none=True,
+)
 def similar_lessons(
     lesson_id: str,
-    explain: bool = Query(default=False, description="Se true, include meta e rank per debug."),
+    explain: bool = Query(
+        default=False, description="Se true, include meta e rank per debug."
+    ),
     top_k: int = Query(
         default=5,
         ge=1,
@@ -999,16 +1122,26 @@ def similar_lessons(
     """
     df = load_lessons_df()
     if df.empty:
-        raise HTTPException(status_code=400, detail="Dataset vuoto, nessuna LeLe disponibile.")
+        raise HTTPException(
+            status_code=400, detail="Dataset vuoto, nessuna LeLe disponibile."
+        )
 
     matches = df[df["id"].astype(str) == lesson_id]
     if matches.empty:
-        raise HTTPException(status_code=404, detail=f"LeLe con id={lesson_id!r} non trovata.")
+        raise HTTPException(
+            status_code=404, detail=f"LeLe con id={lesson_id!r} non trovata."
+        )
 
     query_text = str(matches.iloc[0]["text"])
 
     index = build_similarity_index(df)
-    results_raw = similar_by_lesson_id(df=df, lesson_id=lesson_id, transformer=index.transformer, top_k=top_k, min_score=min_score)
+    results_raw = similar_by_lesson_id(
+        df=df,
+        lesson_id=lesson_id,
+        transformer=index.transformer,
+        top_k=top_k,
+        min_score=min_score,
+    )
     # Togli eventuale self-match se costruito usando il testo della stessa LeLe
     filtered = [r for r in results_raw if r.lesson_id != lesson_id]
 
@@ -1016,7 +1149,9 @@ def similar_lessons(
     query_topic = _to_optional_str(query_row.get("topic"))
     query_tags = _normalize_tags(query_row.get("tags"))
 
-    items = _build_similar_items(df, filtered, explain=explain, query_tags=query_tags if explain else None)
+    items = _build_similar_items(
+        df, filtered, explain=explain, query_tags=query_tags if explain else None
+    )
     meta = _build_similar_meta(
         explain=explain,
         top_k=top_k,
@@ -1044,7 +1179,9 @@ def get_lesson(lesson_id: str) -> Lesson:
 
     matches = df[df["id"].astype(str) == lesson_id]
     if matches.empty:
-        raise HTTPException(status_code=404, detail=f"LeLe con id={lesson_id!r} non trovata.")
+        raise HTTPException(
+            status_code=404, detail=f"LeLe con id={lesson_id!r} non trovata."
+        )
 
     row = matches.iloc[0]
 
@@ -1054,7 +1191,9 @@ def get_lesson(lesson_id: str) -> Lesson:
     title_val = _to_optional_str(row.get("title"))
 
     raw_importance = row.get("importance")
-    if raw_importance is None or (isinstance(raw_importance, float) and pd.isna(raw_importance)):
+    if raw_importance is None or (
+        isinstance(raw_importance, float) and pd.isna(raw_importance)
+    ):
         importance_val = None
     else:
         try:
@@ -1093,7 +1232,12 @@ def add_lesson(lesson_in: LessonCreate) -> Lesson:
 
 
 @app.post("/similar", response_model=SimilarResponse, response_model_exclude_none=True)
-def similar_from_text(body: SimilarTextRequest, explain: bool = Query(default=False, description="Se true, include meta e rank per debug.")) -> SimilarResponse:
+def similar_from_text(
+    body: SimilarTextRequest,
+    explain: bool = Query(
+        default=False, description="Se true, include meta e rank per debug."
+    ),
+) -> SimilarResponse:
     """
     Similarità a partire da testo libero (non richiede lesson_id).
     """
@@ -1103,7 +1247,9 @@ def similar_from_text(body: SimilarTextRequest, explain: bool = Query(default=Fa
 
     df = load_lessons_df()
     if df.empty:
-        raise HTTPException(status_code=400, detail="Dataset vuoto, nessuna LeLe disponibile.")
+        raise HTTPException(
+            status_code=400, detail="Dataset vuoto, nessuna LeLe disponibile."
+        )
 
     # build_similarity_index() gestisce 503 se manca il modello.
     index = build_similarity_index(df)  # cached
@@ -1144,7 +1290,10 @@ def train_topic() -> TrainResponse:
     """
     df = load_lessons_df()
     if df.empty:
-        raise HTTPException(status_code=400, detail="Dataset vuoto: nessuna LeLe da usare per il training.")
+        raise HTTPException(
+            status_code=400,
+            detail="Dataset vuoto: nessuna LeLe da usare per il training.",
+        )
 
     # Usa solo righe addestrabili (evita topic 'nan' generato da astype(str) su NaN)
     df_train = df.dropna(subset=["text", "topic"]).copy()
@@ -1165,7 +1314,11 @@ def train_topic() -> TrainResponse:
 
         # Caso classico: TF-IDF/CountVectorizer rimane senza termini dopo pruning (min_df/max_df)
         # -> vogliamo un messaggio "umano" che contenga segnali tipo "TF-IDF" / "vocabulary"
-        if ("no terms remain" in low) or ("after pruning" in low) or ("empty vocabulary" in low):
+        if (
+            ("no terms remain" in low)
+            or ("after pruning" in low)
+            or ("empty vocabulary" in low)
+        ):
             detail = f"TF-IDF vocabulary empty: {msg}"
             raise HTTPException(status_code=400, detail=detail)
 
@@ -1294,7 +1447,9 @@ def update_lesson(lesson_id: str, body: LessonVaultWrite) -> Lesson:
         vault_dir = require_vault_dir()
         existing = find_markdown_by_id(vault_dir, lesson_id)
         rel_path = existing.relative_to(vault_dir).as_posix() if existing else None
-        _write_lesson_to_vault(lesson_id=lesson_id, payload=body, relative_path=rel_path)
+        _write_lesson_to_vault(
+            lesson_id=lesson_id, payload=body, relative_path=rel_path
+        )
         _sync_vault_import()
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
@@ -1306,7 +1461,9 @@ def update_lesson(lesson_id: str, body: LessonVaultWrite) -> Lesson:
 
 @app.post("/ops/refresh", response_model=OpsRefreshResponse)
 def ops_refresh(
-    train: bool = Query(default=True, description="Se true, riallena anche il topic model."),
+    train: bool = Query(
+        default=True, description="Se true, riallena anche il topic model."
+    ),
 ) -> OpsRefreshResponse:
     """Import vault → JSONL e opzionalmente train topic model (come lele-api-refresh)."""
     try:
@@ -1400,11 +1557,21 @@ else:
             detail="GUI non buildata. Esegui: ./scripts/build-gui.sh",
         )
 
+
 # -----------------------------------------------------------------------------
 # Similarity batch
 # -----------------------------------------------------------------------------
-@app.post("/similar/batch", response_model=SimilarBatchResponse, response_model_exclude_none=True)
-def similar_from_text_batch(body: SimilarBatchRequest, explain: bool = Query(default=False, description="Se true, include meta e rank per debug.")) -> SimilarBatchResponse:
+@app.post(
+    "/similar/batch",
+    response_model=SimilarBatchResponse,
+    response_model_exclude_none=True,
+)
+def similar_from_text_batch(
+    body: SimilarBatchRequest,
+    explain: bool = Query(
+        default=False, description="Se true, include meta e rank per debug."
+    ),
+) -> SimilarBatchResponse:
     """
     Similarità batch a partire da testi liberi.
 
@@ -1413,7 +1580,9 @@ def similar_from_text_batch(body: SimilarBatchRequest, explain: bool = Query(def
     """
     df = load_lessons_df()
     if df.empty:
-        raise HTTPException(status_code=400, detail="Dataset vuoto, nessuna LeLe disponibile.")
+        raise HTTPException(
+            status_code=400, detail="Dataset vuoto, nessuna LeLe disponibile."
+        )
 
     index = build_similarity_index(df)  # cached
 
@@ -1448,13 +1617,18 @@ def similar_from_text_batch(body: SimilarBatchRequest, explain: bool = Query(def
 
     return SimilarBatchResponse(items=out_items)
 
+
 # -----------------------------------------------------------------------------
 # Editor integration (live suggest)
 # -----------------------------------------------------------------------------
-@app.post("/editor/suggest", response_model=SimilarResponse, response_model_exclude_none=True)
+@app.post(
+    "/editor/suggest", response_model=SimilarResponse, response_model_exclude_none=True
+)
 def editor_suggest(
     body: SimilarTextRequest,
-    explain: bool = Query(default=False, description="Se true, include meta e rank per debug."),
+    explain: bool = Query(
+        default=False, description="Se true, include meta e rank per debug."
+    ),
 ) -> SimilarResponse:
     """
     Suggest LeLe simili mentre scrivo (editor integration).

--- a/tests/test_api_basic.py
+++ b/tests/test_api_basic.py
@@ -1,3 +1,4 @@
+import pytest
 import json
 from pathlib import Path
 
@@ -242,9 +243,19 @@ def test_similar_returns_503_when_model_missing(tmp_path, monkeypatch) -> None:
     _write_jsonl(
         data_path,
         [
-            {"id": "1", "text": "python common pytest", "topic": "python", "importance": 3},
+            {
+                "id": "1",
+                "text": "python common pytest",
+                "topic": "python",
+                "importance": 3,
+            },
             {"id": "2", "text": "cpp common cin", "topic": "cpp", "importance": 2},
-            {"id": "3", "text": "python common fixtures", "topic": "python", "importance": 3},
+            {
+                "id": "3",
+                "text": "python common fixtures",
+                "topic": "python",
+                "importance": 3,
+            },
         ],
     )
 
@@ -318,3 +329,52 @@ def test_similar_with_model_present_returns_results(tmp_path, monkeypatch) -> No
     assert "id" in first and "score" in first and "text_preview" in first
     assert isinstance(first["score"], (int, float))
     assert isinstance(first["text_preview"], str)
+
+
+def test_dashboard_summary_is_bounded_and_read_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    vault = tmp_path / "missing-vault"
+    data = tmp_path / "lessons.jsonl"
+    model = tmp_path / "topic-model.joblib"
+    candidates = tmp_path / "candidates.json"
+
+    monkeypatch.setenv("LELE_VAULT_DIR", str(vault))
+    monkeypatch.setenv("LELE_DATA_PATH", str(data))
+    monkeypatch.setenv("LELE_MODEL_PATH", str(model))
+    monkeypatch.setenv("LELE_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(server, "DATA_PATH", data)
+    monkeypatch.setattr(server, "MODEL_PATH", model)
+
+    before = {
+        "vault": vault.exists(),
+        "data": data.exists(),
+        "model": model.exists(),
+        "candidates": candidates.exists(),
+    }
+
+    response = TestClient(server.app).get("/dashboard/summary")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "health_status": "ok",
+        "vault_exists": False,
+        "vault_markdown_files": None,
+        "projection_exists": False,
+        "model_exists": False,
+        "stats": None,
+        "candidates": {
+            "total": 0,
+            "staged": 0,
+            "in_review": 0,
+            "rejected": 0,
+            "approved": 0,
+        },
+    }
+    assert before == {
+        "vault": vault.exists(),
+        "data": data.exists(),
+        "model": model.exists(),
+        "candidates": candidates.exists(),
+    }


### PR DESCRIPTION
## Summary

- make the product Dashboard the root route while keeping Browse explicit at `#/browse`
- add a bounded, read-only `/dashboard/summary` API for workspace readiness
- surface vault, projection, topic-model, knowledge and candidate-review state without triggering maintenance or mutation
- add deterministic first-run states for fresh, empty, partial, ready, loading and recoverable error conditions
- add contextual actions that delegate to existing workflows instead of performing implicit work
- add Dashboard to the primary Knowledge navigation with a deterministic local SVG icon
- keep EN/IT localization aligned
- update maintained GUI documentation and preserve `gui-design.md` as the historical GUI-alpha baseline

## Verification

- production GUI build: passed
- `npm run check`: 0 errors, 0 warnings
- Playwright: 64 passed, 1 documentation-screenshot test skipped
- Python: 580 passed
- `git diff --check`: clean

Closes #149