### PR TITLE
release: road-test native artifacts for v1.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Package native release
         run: python scripts/package-native-release.py
 
+      - name: Smoke published-style native release
+        run: python scripts/smoke-native-release.py
+
       - name: Upload native package
         uses: actions/upload-artifact@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,49 @@ The format is based on **Keep a Changelog**.
 
 ## [Unreleased]
 
+### Added
+- **Commercial-grade product experience for v1.11.0:** coherent product shell
+  and navigation hierarchy, Dashboard and explicit first-run states, read-only
+  Settings/runtime transparency, bounded support diagnostics, and an About
+  surface with product identity, MIT license, GiadaWare attribution and
+  local-first support links.
+- Direct Giada UI consumption across the shipped GUI through the pinned
+  immutable-artifact model, with English/Italian localization and persistent
+  explicit locale selection.
+- Published-style native release smoke for Linux, macOS and Windows release
+  jobs. CI now extracts the actual release archive, launches the packaged
+  executable, and checks loopback health, runtime version, packaged GUI,
+  license, About and Settings/runtime before artifact upload.
+
+### Changed
+- `/app/` now opens on the Dashboard while Browse and existing domain workflows
+  remain directly reachable.
+- Native builds fail before PyInstaller packaging when installed
+  `lele-manager` metadata does not match the source project version, preventing
+  stale-version executables from being published.
+- Native release verification uses isolated data, cache and vault directories
+  and rejects runtime paths outside that temporary road-test environment.
+- README and maintained GUI guides now document native packages as the normal
+  non-technical installation path while preserving source-checkout development
+  instructions.
+
+### Compatibility
+- No intentional breaking changes are introduced in the public API, CLI,
+  Markdown vault authority, TritaLeLe approval boundary or local-first storage
+  model.
+- No account, telemetry, cloud storage or remote knowledge dependency is
+  introduced.
+- Persistent user data remains outside native installation directories.
+
+### Verification
+- Full Python suite: 601 tests passed.
+- Frontend type/Svelte checks completed with zero errors and warnings.
+- Full and runtime-only npm audits report zero vulnerabilities.
+- Playwright: 68 passed, 1 intentional documentation-screenshot skip.
+- Python sdist/wheel build, metadata check and installed-wheel smoke passed.
+- Linux published-style native archive was extracted, launched and verified
+  successfully with runtime data isolated outside the release package.
+
 ## [1.10.1] - 2026-08-08
 
 ### Added

--- a/README.it.md
+++ b/README.it.md
@@ -73,9 +73,24 @@ pytest tests/test_documentation.py
   vedere il [contratto projection store](docs/it/projection-store.md) e
   [ADR 0001](docs/adr/0001-storage-backend.md), fonte tecnica canonica inglese.
 
-## Setup
+## Installazione e avvio
 
-Clonare il repository e creare un ambiente virtuale:
+Per il normale utilizzo utente, scaricare da GitHub Releases il pacchetto nativo
+per il proprio sistema operativo, estrarlo e avviare **LeLe-Manager**. I
+pacchetti nativi per Linux, macOS e Windows sono autosufficienti: non richiedono
+Python, Node.js, npm, un ambiente virtuale o un checkout del repository.
+
+Al primo avvio LeLe Manager prepara fuori dalla directory di installazione le
+directory applicative locali e il vault Markdown predefinito, avvia
+l'applicazione FastAPI locale, attende che sia pronta e apre `/app/` nel browser
+predefinito. I dati utente persistenti sopravvivono quindi alla sostituzione o
+all'aggiornamento della cartella applicativa estratta.
+
+Ogni archive nativo include `LEGGIMI_PRIMA.txt` con istruzioni di primo avvio
+specifiche per la piattaforma.
+
+Per lo sviluppo dai sorgenti, clonare il repository e creare un ambiente
+virtuale:
 
 ```bash
 git clone git@github.com:gcomneno/lele-manager.git
@@ -496,6 +511,7 @@ Viste disponibili:
 
 | Vista | Scopo |
 |---|---|
+| **Dashboard** | Stato dello spazio di lavoro, riepilogo bounded e prossime azioni utili |
 | **Browse** | Ricerca avanzata, filtri ed export Markdown |
 | **Detail** | Contenuto completo e similarità spiegata |
 | **Editor** | Authoring Markdown con suggerimenti live |
@@ -505,6 +521,8 @@ Viste disponibili:
 | **Stats** | Conteggi, tag, topic e medie |
 | **Vault** | Albero filesystem reale e import |
 | **Ops** | Health, training, import vault e refresh completo |
+| **Impostazioni** | Percorsi locali effettivi, ruoli di archiviazione e diagnostica bounded esplicita |
+| **Informazioni** | Identità prodotto, versione, licenza MIT, dichiarazione local-first e collegamenti di supporto |
 
 Il salvataggio dall'Editor scrive il file Markdown nel vault e aggiorna la
 proiezione JSONL tramite `PUT` o `POST /vault/lessons`.
@@ -570,7 +588,14 @@ LeLe Manager segue Semantic Versioning:
 - PATCH: bugfix e miglioramenti interni.
 
 Una release stabile comprende import del vault, proiezione JSONL, modelli topic
-e similarità, endpoint FastAPI, client `lele` e test verdi.
+e similarità, endpoint FastAPI, client `lele`, GUI incorporata e verifiche
+Python, frontend, sicurezza, packaging e release nativa tutte verdi.
+
+Gli archive nativi vengono verificati dopo il packaging e prima dell'upload:
+la CI estrae l'artefatto nello stesso formato destinato alla pubblicazione,
+avvia l'eseguibile packaged su loopback con runtime isolato, verifica health,
+GUI, licenza, Informazioni e Impostazioni/runtime e controlla che i percorsi
+persistenti restino fuori dalla directory applicativa estratta.
 
 Esempio di tag annotato:
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,24 @@ pytest tests/test_documentation.py
   [the projection-store contract](docs/projection-store.md) and
   [ADR 0001](docs/adr/0001-storage-backend.md).
 
-## Setup
+## Install and run
 
-Clone the repository and create a virtual environment:
+For normal end-user use, download the native package for your operating system
+from GitHub Releases, extract it, and launch **LeLe-Manager**. The native
+packages for Linux, macOS, and Windows are self-contained: they do not require
+Python, Node.js, npm, a virtual environment, or a repository checkout.
+
+On first launch, LeLe Manager prepares its local application directories and
+default Markdown vault outside the installation directory, starts the local
+FastAPI application, waits for it to become healthy, and opens `/app/` in the
+default browser. Persistent user data therefore survives replacing or upgrading
+the extracted application package.
+
+Each native archive includes `LEGGIMI_PRIMA.txt` with platform-specific
+first-run instructions.
+
+For development from source, clone the repository and create a virtual
+environment:
 
 ```bash
 git clone git@github.com:gcomneno/lele-manager.git
@@ -496,6 +511,8 @@ Available views:
 | **Stats** | Counts, tags, topics, and averages |
 | **Vault** | Real filesystem tree and import |
 | **Ops** | Health, training, vault import, and full refresh |
+| **Settings** | Effective local paths, storage roles, and explicit bounded diagnostics |
+| **About** | Product identity, version, MIT license, local-first statement, and support links |
 
 Saving from the Editor writes the Markdown file into the vault and refreshes
 the JSONL projection through `PUT` or `POST /vault/lessons`.
@@ -590,7 +607,14 @@ LeLe Manager follows Semantic Versioning:
 - PATCH: bug fixes and internal improvements.
 
 A stable release includes vault import, JSONL projection, topic and similarity
-models, FastAPI endpoints, the `lele` client, and a green test suite.
+models, FastAPI endpoints, the `lele` client, the packaged GUI, and green Python,
+frontend, security, packaging, and native-release verification.
+
+Native release archives are verified after packaging and before upload by
+extracting the published-style artifact, starting its packaged executable on
+loopback with isolated runtime directories, checking health, GUI, license,
+About and Settings/runtime surfaces, and confirming persistent paths remain
+outside the extracted application package.
 
 Example annotated tag:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,79 @@
+## v1.11.0 — Commercial-grade local-first product experience
+
+> Draft release notes. The v1.11.0 version/tag seal is intentionally not
+> applied by issue #152.
+
+LeLe Manager v1.11.0 completes the first commercial-grade product-experience
+tranche without changing the local-first architecture or the authority of the
+Markdown vault.
+
+### Product experience
+
+- coherent product shell and grouped navigation;
+- Dashboard as the default `/app/` destination;
+- explicit first-run, empty, partial and ready workspace states;
+- Settings with effective local runtime paths and semantic storage roles;
+- explicit bounded support diagnostics with preview-before-export;
+- About with authoritative version, GiadaWare attribution, MIT license,
+  local-first statement and support links;
+- direct Giada UI adoption in shipped GUI code;
+- English/Italian GUI localization with persistent explicit selection;
+- keyboard, focus, responsive and deterministic Playwright coverage.
+
+### Local-first guarantees
+
+The Markdown vault remains authoritative for approved lessons. Projection data
+and topic models remain derived or rebuildable. TritaLeLe candidates still
+require explicit approval before publication.
+
+LeLe Manager introduces no account, telemetry, cloud storage or remote
+knowledge service.
+
+### Native packages
+
+Linux, macOS and Windows native archives remain the normal non-technical
+installation path. They are self-contained and do not require Python, Node.js,
+npm, a virtual environment or a repository checkout.
+
+The release workflow now road-tests the actual published-style native archive
+before upload. It extracts the archive, launches the packaged executable on
+loopback with isolated data/cache/vault directories and verifies:
+
+- `/health`;
+- `/runtime/info`;
+- packaged `/app/`;
+- packaged `/app/LICENSE`;
+- `/about`;
+- `/settings/runtime`;
+- version coherence;
+- runtime-path isolation outside the extracted release package.
+
+Native builds also reject stale installed package metadata before PyInstaller
+can create a version-incoherent executable.
+
+### Verification performed for issue #152
+
+- 601 Python tests passed;
+- Ruff passed;
+- mypy passed for 59 source files;
+- Svelte/TypeScript checks: 0 errors, 0 warnings;
+- full npm audit: 0 vulnerabilities;
+- runtime-only npm audit: 0 vulnerabilities;
+- Playwright: 68 passed, 1 intentional screenshot skip;
+- Python sdist and wheel metadata checks passed;
+- installed-wheel smoke passed;
+- Linux x86_64 published-style native archive successfully built, extracted,
+  launched and verified.
+
+### Upgrade compatibility
+
+No intentional breaking changes are introduced in the public API or CLI.
+Persistent user data remains outside native installation directories, so
+replacing the extracted application package does not require moving the vault
+or persistent application state.
+
+---
+
 ## v1.1.1 — Documentation hardening
 
 This is a small patch release focused on repo/product hygiene.

--- a/docs/gui-user-guide.md
+++ b/docs/gui-user-guide.md
@@ -10,7 +10,17 @@ remains in [`gui-design.md`](gui-design.md).
 
 ## Start the GUI
 
-The normal local workflow is:
+For normal installed-product use, download and extract the native package for
+Linux, macOS, or Windows and launch **LeLe-Manager** from the extracted
+`LeLe-Manager` directory. No Python, Node.js, npm, virtual environment, frontend
+build, or repository checkout is required. The packaged launcher prepares local
+runtime directories, starts the loopback application, waits for `/health`, and
+opens `/app/` automatically.
+
+Each native archive includes `LEGGIMI_PRIMA.txt` with platform-specific
+first-run instructions.
+
+For development from a repository checkout, use:
 
 ```bash
 export LELE_VAULT_DIR="$HOME/LeLeVault"
@@ -18,7 +28,7 @@ export LELE_VAULT_DIR="$HOME/LeLeVault"
 ./scripts/lele-api-dev.sh
 ```
 
-Open:
+Then open:
 
 ```text
 http://127.0.0.1:8000/app/

--- a/docs/it/gui-user-guide.md
+++ b/docs/it/gui-user-guide.md
@@ -10,7 +10,17 @@ design resta disponibile in [`../gui-design.md`](../gui-design.md).
 
 ## Avviare la GUI
 
-Il normale flusso locale è:
+Per il normale utilizzo del prodotto installato, scaricare ed estrarre il
+pacchetto nativo per Linux, macOS o Windows e avviare **LeLe-Manager** dalla
+directory `LeLe-Manager` estratta. Non servono Python, Node.js, npm, ambiente
+virtuale, build del frontend o checkout del repository. Il launcher packaged
+prepara le directory runtime locali, avvia l'applicazione su loopback, attende
+`/health` e apre automaticamente `/app/`.
+
+Ogni archive nativo include `LEGGIMI_PRIMA.txt` con istruzioni di primo avvio
+specifiche per la piattaforma.
+
+Per lo sviluppo da checkout del repository usare:
 
 ```bash
 export LELE_VAULT_DIR="$HOME/LeLeVault"
@@ -18,7 +28,7 @@ export LELE_VAULT_DIR="$HOME/LeLeVault"
 ./scripts/lele-api-dev.sh
 ```
 
-Aprire:
+Quindi aprire:
 
 ```text
 http://127.0.0.1:8000/app/

--- a/docs/multiplatform-release-packaging.md
+++ b/docs/multiplatform-release-packaging.md
@@ -100,6 +100,13 @@ GitHub Release asset.
 A release must not publish an artifact merely because packaging completed:
 the packaged executable must pass a startup/smoke verification first.
 
+The native release job therefore verifies the same published-style archive that
+would be uploaded to GitHub. CI extracts that archive into an isolated temporary
+directory, starts the packaged executable with isolated runtime paths, waits for
+the loopback health endpoint, and checks the packaged GUI, license, About and
+runtime Settings surfaces before upload. The verification also confirms that
+persistent runtime paths resolve outside the extracted release directory.
+
 ## User documentation
 
 Each release package must include a short first-run guide appropriate to the

--- a/scripts/build-native-app.py
+++ b/scripts/build-native-app.py
@@ -4,14 +4,42 @@
 from __future__ import annotations
 
 import shutil
+import tomllib
 import subprocess
 import sys
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 APP_NAME = "LeLe-Manager"
 BUILD_ROOT = ROOT / "build" / "native"
 DIST_ROOT = ROOT / "dist" / "native"
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def project_version() -> str:
+    with PYPROJECT.open("rb") as stream:
+        data = tomllib.load(stream)
+    return str(data["project"]["version"])
+
+
+def verify_installed_version() -> None:
+    expected = project_version()
+
+    try:
+        installed = version("lele-manager")
+    except PackageNotFoundError as exc:
+        raise SystemExit(
+            "ERRORE: lele-manager non risulta installato nell'ambiente di "
+            "build. Installa il checkout corrente prima della build nativa."
+        ) from exc
+
+    if installed != expected:
+        raise SystemExit(
+            "ERRORE: metadata lele-manager non allineata al checkout: "
+            f"installata={installed}, attesa={expected}. "
+            'Riallinea l\'ambiente con: python -m pip install -e ".[dev]"'
+        )
 
 
 def run(*args: str) -> None:
@@ -55,6 +83,9 @@ def build_native_bundle() -> None:
 
 
 def main() -> int:
+    print("==> Verifying installed application version")
+    verify_installed_version()
+
     print("==> Building compiled GUI")
     build_gui()
 

--- a/scripts/smoke-native-release.py
+++ b/scripts/smoke-native-release.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Smoke-test the actual published-style native LeLe Manager release archive."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import tomllib
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+RELEASE_DIR = ROOT / "dist" / "release"
+APP_NAME = "LeLe-Manager"
+
+NO_BROWSER_ENV = "LELE_MANAGER_NO_BROWSER"
+PORT_ENV = "LELE_MANAGER_PORT"
+
+HTTP_TIMEOUT_SECONDS = 2.0
+STARTUP_TIMEOUT_SECONDS = 30.0
+PROCESS_STOP_TIMEOUT_SECONDS = 10.0
+
+EXPECTED_RUNTIME_PATH_KEYS = {
+    "vault",
+    "application_data",
+    "lesson_projection",
+    "candidate_staging",
+    "cache",
+    "topic_model",
+}
+
+
+def project_version() -> str:
+    with PYPROJECT.open("rb") as stream:
+        data = tomllib.load(stream)
+    return str(data["project"]["version"])
+
+
+def platform_contract() -> tuple[str, str]:
+    if sys.platform.startswith("linux"):
+        return "Linux", ".tar.gz"
+    if sys.platform == "darwin":
+        return "macOS", ".zip"
+    if sys.platform == "win32":
+        return "Windows", ".zip"
+    raise RuntimeError(f"Piattaforma non supportata: {sys.platform}")
+
+
+def find_release_archive(
+    release_dir: Path,
+    version: str,
+    os_label: str,
+    extension: str,
+) -> Path:
+    pattern = f"{APP_NAME}-v{version}-{os_label}-*{extension}"
+    matches = sorted(
+        path
+        for path in release_dir.glob(pattern)
+        if path.is_file()
+    )
+
+    if len(matches) != 1:
+        raise RuntimeError(
+            "Atteso esattamente un archive native-release "
+            f"per {os_label} {version}, trovati {len(matches)}: "
+            f"{matches}"
+        )
+
+    return matches[0]
+
+
+def _safe_zip_destination(root: Path, member: str) -> Path:
+    destination = (root / member).resolve()
+    resolved_root = root.resolve()
+
+    if not destination.is_relative_to(resolved_root):
+        raise RuntimeError(
+            f"Archive ZIP non sicuro, percorso fuori destinazione: {member}"
+        )
+
+    return destination
+
+
+def extract_release_archive(archive: Path, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+
+    if archive.name.endswith(".tar.gz"):
+        with tarfile.open(archive, "r:gz") as stream:
+            stream.extractall(destination, filter="data")
+        return
+
+    if archive.suffix == ".zip":
+        with zipfile.ZipFile(archive) as stream:
+            for member in stream.infolist():
+                _safe_zip_destination(destination, member.filename)
+            stream.extractall(destination)
+        return
+
+    raise RuntimeError(f"Formato archive non supportato: {archive}")
+
+
+def find_packaged_executable(
+    extraction_root: Path,
+    version: str,
+    os_label: str,
+) -> Path:
+    executable_name = (
+        f"{APP_NAME}.exe"
+        if os_label == "Windows"
+        else APP_NAME
+    )
+    candidates = sorted(
+        extraction_root.glob(
+            f"{APP_NAME}-v{version}-{os_label}-*/"
+            f"{APP_NAME}/{executable_name}"
+        )
+    )
+
+    if len(candidates) != 1 or not candidates[0].is_file():
+        raise RuntimeError(
+            "Eseguibile packaged non trovato in modo univoco: "
+            f"{candidates}"
+        )
+
+    return candidates[0]
+
+
+def choose_free_loopback_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _fetch_bytes(url: str) -> bytes:
+    with urllib.request.urlopen(  # nosec B310
+        url,
+        timeout=HTTP_TIMEOUT_SECONDS,
+    ) as response:
+        if not 200 <= response.status < 300:
+            raise RuntimeError(
+                f"HTTP {response.status} durante il road test: {url}"
+            )
+        return response.read()
+
+
+def fetch_text(url: str) -> str:
+    return _fetch_bytes(url).decode("utf-8")
+
+
+def fetch_json(url: str) -> dict[str, Any]:
+    payload = json.loads(fetch_text(url))
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Payload JSON non-object da {url}")
+    return payload
+
+
+def wait_until_ready(
+    process: subprocess.Popen[str],
+    base_url: str,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + STARTUP_TIMEOUT_SECONDS
+    health_url = f"{base_url}/health"
+
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                "L'eseguibile packaged è terminato prima di diventare pronto "
+                f"(exit code {process.returncode})."
+            )
+
+        try:
+            payload = fetch_json(health_url)
+            if payload.get("status") == "ok":
+                return payload
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            OSError,
+            json.JSONDecodeError,
+            RuntimeError,
+        ):
+            pass
+
+        time.sleep(0.1)
+
+    raise RuntimeError(
+        "Timeout in attesa di /health dall'eseguibile packaged."
+    )
+
+
+def terminate_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+
+    process.terminate()
+    try:
+        process.wait(timeout=PROCESS_STOP_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=PROCESS_STOP_TIMEOUT_SECONDS)
+
+
+def assert_isolated_runtime_paths(
+    settings: dict[str, Any],
+    extraction_root: Path,
+    runtime_root: Path,
+) -> None:
+    items = settings.get("paths")
+    if not isinstance(items, list):
+        raise RuntimeError("/settings/runtime non contiene una lista paths.")
+
+    seen: set[str] = set()
+    resolved_release = extraction_root.resolve()
+    resolved_runtime = runtime_root.resolve()
+
+    for item in items:
+        if not isinstance(item, dict):
+            raise RuntimeError("Elemento runtime path non valido.")
+
+        key = item.get("key")
+        raw_path = item.get("path")
+
+        if not isinstance(key, str) or not isinstance(raw_path, str):
+            raise RuntimeError("Runtime path privo di key/path valida.")
+
+        seen.add(key)
+        effective = Path(raw_path).resolve()
+
+        if effective.is_relative_to(resolved_release):
+            raise RuntimeError(
+                f"Runtime path {key} ricade dentro il release archive: "
+                f"{effective}"
+            )
+
+        if not effective.is_relative_to(resolved_runtime):
+            raise RuntimeError(
+                f"Runtime path {key} non è isolato nel runtime temporaneo: "
+                f"{effective}"
+            )
+
+    missing = EXPECTED_RUNTIME_PATH_KEYS - seen
+    if missing:
+        raise RuntimeError(
+            "Runtime path mancanti da /settings/runtime: "
+            + ", ".join(sorted(missing))
+        )
+
+
+def validate_running_release(
+    base_url: str,
+    version: str,
+    extraction_root: Path,
+    runtime_root: Path,
+    process: subprocess.Popen[str],
+) -> None:
+    health = wait_until_ready(process, base_url)
+    if health.get("status") != "ok":
+        raise RuntimeError("/health non riporta status=ok.")
+
+    runtime = fetch_json(f"{base_url}/runtime/info")
+    if runtime.get("version") != version:
+        raise RuntimeError(
+            "Versione runtime diversa dal progetto: "
+            f"{runtime.get('version')!r} != {version!r}"
+        )
+
+    gui_html = fetch_text(f"{base_url}/app/")
+    if "LeLe Manager" not in gui_html:
+        raise RuntimeError("/app/ non identifica LeLe Manager.")
+
+    license_text = fetch_text(f"{base_url}/app/LICENSE")
+    if "MIT License" not in license_text:
+        raise RuntimeError("/app/LICENSE non contiene la licenza MIT attesa.")
+
+    about = fetch_json(f"{base_url}/about")
+    if about.get("product_name") != "LeLe Manager":
+        raise RuntimeError("/about espone un product_name inatteso.")
+    if about.get("version") != version:
+        raise RuntimeError("/about non è allineato alla versione runtime.")
+    if about.get("license_id") != "MIT":
+        raise RuntimeError("/about non espone license_id=MIT.")
+
+    settings = fetch_json(f"{base_url}/settings/runtime")
+    if settings.get("version") != version:
+        raise RuntimeError(
+            "/settings/runtime non è allineato alla versione runtime."
+        )
+
+    assert_isolated_runtime_paths(
+        settings,
+        extraction_root,
+        runtime_root,
+    )
+
+
+def main() -> int:
+    version = project_version()
+    os_label, extension = platform_contract()
+    archive = find_release_archive(
+        RELEASE_DIR,
+        version,
+        os_label,
+        extension,
+    )
+
+    print(f"Archive:     {archive}")
+    print(f"Versione:    {version}")
+    print(f"Piattaforma: {os_label}")
+
+    with tempfile.TemporaryDirectory(
+        prefix="lele-manager-native-road-test-"
+    ) as temporary:
+        temp_root = Path(temporary)
+        extraction_root = temp_root / "published"
+        runtime_root = temp_root / "runtime"
+        log_path = temp_root / "native.log"
+
+        extract_release_archive(archive, extraction_root)
+        executable = find_packaged_executable(
+            extraction_root,
+            version,
+            os_label,
+        )
+
+        port = choose_free_loopback_port()
+        base_url = f"http://127.0.0.1:{port}"
+
+        environment = os.environ.copy()
+        environment.pop("LELE_DATA_PATH", None)
+        environment.pop("LELE_MODEL_PATH", None)
+        environment[NO_BROWSER_ENV] = "1"
+        environment[PORT_ENV] = str(port)
+        environment["LELE_DATA_DIR"] = str(runtime_root / "data")
+        environment["LELE_CACHE_DIR"] = str(runtime_root / "cache")
+        environment["LELE_VAULT_DIR"] = str(runtime_root / "vault")
+
+        print(f"Eseguibile:  {executable}")
+        print(f"Loopback:    {base_url}")
+
+        with log_path.open("w", encoding="utf-8") as log:
+            process = subprocess.Popen(
+                [str(executable)],
+                cwd=executable.parent,
+                env=environment,
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            try:
+                validate_running_release(
+                    base_url,
+                    version,
+                    extraction_root,
+                    runtime_root,
+                    process,
+                )
+            finally:
+                terminate_process(process)
+
+        print("OK: published-style native archive avviato e verificato.")
+        print("OK: runtime data esterni alla directory del release package.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lele_manager/launcher.py
+++ b/src/lele_manager/launcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import socket
 import threading
 import time
@@ -19,6 +20,41 @@ from lele_manager.core.vault import resolve_vault_dir
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
 HEALTH_TIMEOUT_SECONDS = 30.0
+AUTOMATION_NO_BROWSER_ENV = "LELE_MANAGER_NO_BROWSER"
+AUTOMATION_PORT_ENV = "LELE_MANAGER_PORT"
+
+
+def resolve_automation_port(
+    environment: dict[str, str] | None = None,
+) -> int | None:
+    """Resolve the optional internal fixed port used by release automation."""
+    values = os.environ if environment is None else environment
+    raw = values.get(AUTOMATION_PORT_ENV)
+
+    if raw is None:
+        return None
+
+    try:
+        port = int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{AUTOMATION_PORT_ENV} must be an integer between 1 and 65535."
+        ) from exc
+
+    if not 1 <= port <= 65535:
+        raise ValueError(
+            f"{AUTOMATION_PORT_ENV} must be an integer between 1 and 65535."
+        )
+
+    return port
+
+
+def browser_opening_enabled(
+    environment: dict[str, str] | None = None,
+) -> bool:
+    """Return False only for the explicit internal release-smoke override."""
+    values = os.environ if environment is None else environment
+    return values.get(AUTOMATION_NO_BROWSER_ENV) != "1"
 
 
 def find_available_port(
@@ -85,17 +121,27 @@ def main() -> int:
     """Prepare persistent state, start LeLe Manager, and open its GUI."""
     prepare_runtime()
 
-    port = find_available_port()
+    try:
+        automation_port = resolve_automation_port()
+    except ValueError as exc:
+        raise SystemExit(f"ERRORE: {exc}") from exc
+
+    port = (
+        automation_port
+        if automation_port is not None
+        else find_available_port()
+    )
     base_url = f"http://{DEFAULT_HOST}:{port}"
     health_url = f"{base_url}/health"
     app_url = f"{base_url}/app/"
 
-    browser_thread = threading.Thread(
-        target=open_browser_when_ready,
-        args=(health_url, app_url),
-        daemon=True,
-    )
-    browser_thread.start()
+    if browser_opening_enabled():
+        browser_thread = threading.Thread(
+            target=open_browser_when_ready,
+            args=(health_url, app_url),
+            daemon=True,
+        )
+        browser_thread.start()
 
     config = uvicorn.Config(
         app,

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -83,3 +83,31 @@ def test_find_available_port_falls_back_when_preferred_port_is_busy() -> None:
 
     assert selected != busy_port
     assert selected > 0
+
+def test_release_automation_hooks_are_disabled_by_default() -> None:
+    environment: dict[str, str] = {}
+
+    assert launcher.resolve_automation_port(environment) is None
+    assert launcher.browser_opening_enabled(environment) is True
+
+
+def test_release_automation_hooks_accept_explicit_smoke_values() -> None:
+    environment = {
+        launcher.AUTOMATION_PORT_ENV: "43210",
+        launcher.AUTOMATION_NO_BROWSER_ENV: "1",
+    }
+
+    assert launcher.resolve_automation_port(environment) == 43210
+    assert launcher.browser_opening_enabled(environment) is False
+
+
+def test_release_automation_port_rejects_invalid_values() -> None:
+    for raw in ("not-a-port", "0", "65536", "-1"):
+        environment = {launcher.AUTOMATION_PORT_ENV: raw}
+
+        try:
+            launcher.resolve_automation_port(environment)
+        except ValueError as exc:
+            assert launcher.AUTOMATION_PORT_ENV in str(exc)
+        else:
+            raise AssertionError(f"invalid automation port accepted: {raw}")

--- a/tests/test_native_release_smoke.py
+++ b/tests/test_native_release_smoke.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import runpy
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+SMOKE: dict[str, Any] = runpy.run_path(
+    str(Path("scripts/smoke-native-release.py"))
+)
+
+find_release_archive = SMOKE["find_release_archive"]
+extract_release_archive = SMOKE["extract_release_archive"]
+assert_isolated_runtime_paths = SMOKE["assert_isolated_runtime_paths"]
+
+
+def test_find_release_archive_requires_exactly_one_match(
+    tmp_path: Path,
+) -> None:
+    archive = tmp_path / "LeLe-Manager-v1.2.3-Linux-x86_64.tar.gz"
+    archive.write_bytes(b"archive")
+
+    assert find_release_archive(
+        tmp_path,
+        "1.2.3",
+        "Linux",
+        ".tar.gz",
+    ) == archive
+
+
+def test_find_release_archive_rejects_ambiguous_matches(
+    tmp_path: Path,
+) -> None:
+    for arch in ("x86_64", "arm64"):
+        (
+            tmp_path
+            / f"LeLe-Manager-v1.2.3-Linux-{arch}.tar.gz"
+        ).write_bytes(b"archive")
+
+    try:
+        find_release_archive(
+            tmp_path,
+            "1.2.3",
+            "Linux",
+            ".tar.gz",
+        )
+    except RuntimeError as exc:
+        assert "esattamente un archive" in str(exc)
+    else:
+        raise AssertionError("ambiguous release archives accepted")
+
+
+def test_extract_release_archive_supports_tar_and_zip(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.txt"
+    source.write_text("LeLe Manager", encoding="utf-8")
+
+    tar_path = tmp_path / "release.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as stream:
+        stream.add(source, arcname="package/source.txt")
+
+    zip_path = tmp_path / "release.zip"
+    with zipfile.ZipFile(zip_path, "w") as stream:
+        stream.write(source, "package/source.txt")
+
+    tar_target = tmp_path / "tar-target"
+    zip_target = tmp_path / "zip-target"
+
+    extract_release_archive(tar_path, tar_target)
+    extract_release_archive(zip_path, zip_target)
+
+    assert (tar_target / "package/source.txt").read_text() == "LeLe Manager"
+    assert (zip_target / "package/source.txt").read_text() == "LeLe Manager"
+
+
+def test_runtime_paths_must_stay_outside_extracted_release(
+    tmp_path: Path,
+) -> None:
+    extraction_root = tmp_path / "published"
+    runtime_root = tmp_path / "runtime"
+
+    settings = {
+        "paths": [
+            {
+                "key": key,
+                "path": str(runtime_root / key),
+            }
+            for key in (
+                "vault",
+                "application_data",
+                "lesson_projection",
+                "candidate_staging",
+                "cache",
+                "topic_model",
+            )
+        ]
+    }
+
+    assert_isolated_runtime_paths(
+        settings,
+        extraction_root,
+        runtime_root,
+    )
+
+
+def test_runtime_path_inside_release_is_rejected(
+    tmp_path: Path,
+) -> None:
+    extraction_root = tmp_path / "published"
+    runtime_root = tmp_path / "runtime"
+
+    settings = {
+        "paths": [
+            {
+                "key": key,
+                "path": str(
+                    extraction_root / key
+                    if key == "vault"
+                    else runtime_root / key
+                ),
+            }
+            for key in (
+                "vault",
+                "application_data",
+                "lesson_projection",
+                "candidate_staging",
+                "cache",
+                "topic_model",
+            )
+        ]
+    }
+
+    try:
+        assert_isolated_runtime_paths(
+            settings,
+            extraction_root,
+            runtime_root,
+        )
+    except RuntimeError as exc:
+        assert "dentro il release archive" in str(exc)
+    else:
+        raise AssertionError("runtime path inside release accepted")
+
+def test_runtime_path_outside_temporary_runtime_is_rejected(
+    tmp_path: Path,
+) -> None:
+    extraction_root = tmp_path / "published"
+    runtime_root = tmp_path / "runtime"
+    external_root = tmp_path / "external"
+
+    settings = {
+        "paths": [
+            {
+                "key": key,
+                "path": str(
+                    external_root / key
+                    if key == "topic_model"
+                    else runtime_root / key
+                ),
+            }
+            for key in (
+                "vault",
+                "application_data",
+                "lesson_projection",
+                "candidate_staging",
+                "cache",
+                "topic_model",
+            )
+        ]
+    }
+
+    try:
+        assert_isolated_runtime_paths(
+            settings,
+            extraction_root,
+            runtime_root,
+        )
+    except RuntimeError as exc:
+        assert "non è isolato nel runtime temporaneo" in str(exc)
+    else:
+        raise AssertionError("external runtime path accepted")

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -83,3 +83,21 @@ def test_tag_release_publishes_exact_native_version_assets() -> None:
     assert 'LeLe-Manager-v"${version}"-*' in release
     assert 'gh release create "${GITHUB_REF_NAME}"' in release
     assert "--verify-tag" in release
+
+def test_native_release_is_smoked_before_upload() -> None:
+    release = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    package = release.index("Package native release")
+    smoke = release.index("Smoke published-style native release")
+    upload = release.index("Upload native package")
+
+    assert package < smoke < upload
+    assert "python scripts/smoke-native-release.py" in release
+
+def test_native_build_rejects_stale_installed_version() -> None:
+    script = Path("scripts/build-native-app.py").read_text(encoding="utf-8")
+
+    assert "verify_installed_version()" in script
+    assert 'version("lele-manager")' in script
+    assert '"project"]["version"]' in script
+    assert "metadata lele-manager non allineata" in script


### PR DESCRIPTION
## Summary

Completes the final v1.11.0 release rehearsal tracked by #152.

- adds a published-style native release smoke before artifact upload;
- extracts and launches the actual packaged native archive;
- verifies loopback health, runtime version, packaged GUI and license, About,
  Settings/runtime, and runtime-path isolation;
- prevents PyInstaller native builds when installed package metadata is stale
  relative to `pyproject.toml`;
- keeps normal launcher behavior unchanged outside explicit internal smoke
  hooks;
- updates README, GUI guides, changelog, release notes, and the multiplatform
  packaging contract for the completed product-experience tranche.

## Road test

Linux x86_64 published-style archive:

- native PyInstaller bundle built successfully;
- release archive created successfully;
- extracted packaged executable launched successfully;
- `/health`, `/runtime/info`, `/app/`, `/app/LICENSE`, `/about`, and
  `/settings/runtime` verified;
- persistent runtime paths verified outside the extracted release package.

The road test also caught a real stale-metadata defect: an archive named
`1.10.1` initially contained a packaged runtime reporting `1.10.0`. Native
builds now fail fast when installed metadata and source version differ.

## Verification

- `ruff check .` — passed
- `mypy src/lele_manager` — passed, 59 source files
- `pytest -q` — 601 passed
- Svelte/TypeScript checks — 0 errors, 0 warnings
- `npm audit` — 0 vulnerabilities
- `npm audit --omit=dev` — 0 vulnerabilities
- Playwright — 68 passed, 1 intentional documentation screenshot skip
- Python sdist/wheel build and metadata checks — passed
- installed-wheel smoke — passed
- documentation tests — 4 passed
- `git diff --check` — clean

## Release boundary

This PR does not bump the project version, create the `v1.11.0` tag, or publish
the release. Those remain release-seal actions after merge.

Closes #152