### PR TITLE
release: prepare v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on **Keep a Changelog**.
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-08-08
+
 ### Added
 - **Commercial-grade product experience for v1.11.0:** coherent product shell
   and navigation hierarchy, Dashboard and explicit first-run states, read-only
@@ -311,7 +313,8 @@ _See [1.2.0] — same commit tag point; version marker for milestone tracking._
 - Date parsing (YAML → JSON).
 - NaN/NaT handling in the API layer.
 
-[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.10.1...HEAD
+[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/gcomneno/lele-manager/compare/v1.10.1...v1.11.0
 [1.10.1]: https://github.com/gcomneno/lele-manager/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/gcomneno/lele-manager/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/gcomneno/lele-manager/compare/v1.8.0...v1.9.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,5 @@
 ## v1.11.0 — Commercial-grade local-first product experience
 
-> Draft release notes. The v1.11.0 version/tag seal is intentionally not
-> applied by issue #152.
-
 LeLe Manager v1.11.0 completes the first commercial-grade product-experience
 tranche without changing the local-first architecture or the authority of the
 Markdown vault.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lele-manager"
-version = "1.10.1"
+version = "1.11.0"
 description = "Lesson Learned Manager: archivio intelligente di lesson learned testuali."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare the repository for the v1.11.0 release.

- bump `pyproject.toml` from 1.10.1 to 1.11.0;
- move the completed v1.11.0 changelog content out of `Unreleased`;
- add the v1.11.0 compare link and advance `Unreleased` to v1.11.0...HEAD;
- remove the draft marker from the completed v1.11.0 release notes.

## Verification

- installed package metadata aligned to 1.11.0;
- release-packaging and documentation tests passed;
- Ruff checks for native release scripts passed;
- `git diff --check` clean.

## Release process

This PR intentionally does not create or push the `v1.11.0` tag.

After merge and green remote checks, the annotated tag will be created from
the resulting `main` commit. The tag-triggered Release workflow will then build,
smoke-test and publish the Linux, macOS and Windows native artifacts.