### PR TITLE
fix: restore executable mode from release zip

### DIFF
--- a/scripts/smoke-native-release.py
+++ b/scripts/smoke-native-release.py
@@ -102,8 +102,15 @@ def extract_release_archive(archive: Path, destination: Path) -> None:
     if archive.suffix == ".zip":
         with zipfile.ZipFile(archive) as stream:
             for member in stream.infolist():
-                _safe_zip_destination(destination, member.filename)
-            stream.extractall(destination)
+                extracted = _safe_zip_destination(
+                    destination,
+                    member.filename,
+                )
+                stream.extract(member, destination)
+
+                unix_mode = (member.external_attr >> 16) & 0o777
+                if unix_mode and extracted.is_file():
+                    extracted.chmod(unix_mode)
         return
 
     raise RuntimeError(f"Formato archive non supportato: {archive}")

--- a/tests/test_native_release_smoke.py
+++ b/tests/test_native_release_smoke.py
@@ -75,6 +75,24 @@ def test_extract_release_archive_supports_tar_and_zip(
     assert (zip_target / "package/source.txt").read_text() == "LeLe Manager"
 
 
+def test_zip_extraction_restores_unix_executable_mode(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "LeLe-Manager"
+    source.write_text("#!/bin/sh\n", encoding="utf-8")
+    source.chmod(0o755)
+
+    archive = tmp_path / "release.zip"
+    with zipfile.ZipFile(archive, "w") as stream:
+        stream.write(source, "package/LeLe-Manager")
+
+    target = tmp_path / "target"
+    extract_release_archive(archive, target)
+
+    executable = target / "package" / "LeLe-Manager"
+    assert executable.stat().st_mode & 0o777 == 0o755
+
+
 def test_runtime_paths_must_stay_outside_extracted_release(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fix the macOS published-style native release smoke for v1.11.0.

The native macOS bundle and ZIP were built successfully, but the release smoke
failed after extraction with:

`PermissionError: [Errno 13] Permission denied`

Python `ZipFile.extractall()` does not restore Unix executable permission bits
from ZIP metadata. The smoke extractor now restores the stored Unix mode for
extracted files before attempting to launch the packaged executable.

## Regression coverage

Adds an explicit ZIP extraction test proving that an executable stored with
mode `0755` is extracted with mode `0755`.

## Verification

- Ruff passed
- native release smoke + packaging tests: 17 passed
- `git diff --check` clean

## Release context

This fixes the failed macOS smoke in the v1.11.0 tag-triggered Release workflow.
Linux already passed, and Windows passed its native smoke.