### PR TITLE
Fix graceful Ctrl+C shutdown in native launcher

### DIFF
--- a/src/lele_manager/launcher.py
+++ b/src/lele_manager/launcher.py
@@ -150,7 +150,11 @@ def main() -> int:
         log_level="info",
     )
     server = uvicorn.Server(config)
-    server.run()
+
+    try:
+        server.run()
+    except KeyboardInterrupt:
+        return 0
 
     return 0
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -111,3 +111,32 @@ def test_release_automation_port_rejects_invalid_values() -> None:
             assert launcher.AUTOMATION_PORT_ENV in str(exc)
         else:
             raise AssertionError(f"invalid automation port accepted: {raw}")
+
+
+def test_main_treats_keyboard_interrupt_as_clean_shutdown(monkeypatch) -> None:
+    class InterruptingServer:
+        def __init__(self, config) -> None:
+            self.config = config
+
+        def run(self) -> None:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        launcher,
+        "prepare_runtime",
+        lambda: (Path("/tmp/data"), Path("/tmp/model"), Path("/tmp/vault")),
+    )
+    monkeypatch.setattr(launcher, "resolve_automation_port", lambda: None)
+    monkeypatch.setattr(launcher, "find_available_port", lambda: 43210)
+    monkeypatch.setattr(launcher, "browser_opening_enabled", lambda: False)
+    monkeypatch.setattr(launcher.uvicorn, "Server", InterruptingServer)
+
+    try:
+        result = launcher.main()
+    except KeyboardInterrupt:
+        raise AssertionError(
+            "launcher.main() propagated KeyboardInterrupt instead of "
+            "treating Ctrl+C as a clean shutdown"
+        ) from None
+
+    assert result == 0


### PR DESCRIPTION
## Summary

Handle Ctrl+C in the native LeLe Manager launcher as an intentional clean shutdown.

Uvicorn already completed its shutdown correctly, but the resulting `KeyboardInterrupt` propagated through the packaged launcher and caused PyInstaller to print a traceback and report an unhandled exception.

The launcher now absorbs only `KeyboardInterrupt` around `uvicorn.Server.run()` and returns exit code 0. Other exceptions continue to propagate normally.

Closes #172.

## Regression coverage

Added a launcher regression test that reproduces the v1.11.0 behavior by making `uvicorn.Server.run()` raise `KeyboardInterrupt`.

The test fails against the v1.11.0 baseline and passes with the fix.

## Validation

- `ruff check .` — passed
- `mypy src/lele_manager` — passed
- full pytest suite — `596 passed, 7 skipped`
- native Linux build — passed
- native Linux packaging — passed
- published-style native release smoke — passed
- extracted release artifact started successfully from a clean temporary HOME
- `/health` returned successfully
- real `SIGINT` sent to the packaged executable
- Uvicorn completed application shutdown
- process exit code: `0`
- no `Traceback`
- no unhandled `KeyboardInterrupt`
- no `Failed to execute script` PyInstaller error

## Commits

- `test: reproduce launcher Ctrl+C shutdown bug`
- `fix: handle launcher Ctrl+C shutdown cleanly`
