### PR TITLE
Release v1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ The format is based on **Keep a Changelog**.
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-08-09
+
+### Fixed
+- Native launcher shutdown now treats `Ctrl+C` as an intentional clean exit
+  after Uvicorn completes its shutdown, preventing the packaged PyInstaller
+  application from printing an unhandled `KeyboardInterrupt` traceback.
+
+### Compatibility
+- No intentional breaking changes are introduced in the public API, CLI,
+  Markdown vault authority, persistent local data or native package layout.
+
 ## [1.11.0] - 2026-08-08
 
 ### Added
@@ -313,7 +324,8 @@ _See [1.2.0] — same commit tag point; version marker for milestone tracking._
 - Date parsing (YAML → JSON).
 - NaN/NaT handling in the API layer.
 
-[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/gcomneno/lele-manager/compare/v1.11.1...HEAD
+[1.11.1]: https://github.com/gcomneno/lele-manager/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/gcomneno/lele-manager/compare/v1.10.1...v1.11.0
 [1.10.1]: https://github.com/gcomneno/lele-manager/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/gcomneno/lele-manager/compare/v1.9.0...v1.10.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,42 @@
+## v1.11.1 — Graceful native launcher shutdown
+
+LeLe Manager v1.11.1 is a focused patch release fixing the shutdown behavior
+of the packaged native application.
+
+### Fixed
+
+When the native launcher was stopped with `Ctrl+C`, Uvicorn completed its
+shutdown correctly but the resulting `KeyboardInterrupt` propagated to the
+PyInstaller bootstrap. The application therefore printed a traceback and
+reported an unhandled exception even though shutdown had completed.
+
+The launcher now treats that user-requested interrupt as a clean shutdown and
+returns exit code 0. Other exceptions are not suppressed.
+
+### Verification
+
+The fix was reproduced and verified through the complete engineering loop:
+
+- regression test reproducing the v1.11.0 behavior;
+- Ruff passed;
+- mypy passed for 59 source files;
+- full Python suite: 596 passed, 7 skipped;
+- native Linux build passed;
+- native Linux packaging passed;
+- published-style native archive smoke passed;
+- the extracted packaged executable was started from an isolated temporary
+  runtime, received a real `SIGINT`, completed Uvicorn shutdown and exited 0;
+- no `Traceback`, unhandled `KeyboardInterrupt` or PyInstaller
+  `Failed to execute script` error remained.
+
+### Upgrade compatibility
+
+No intentional breaking changes are introduced. Persistent user data remains
+outside the native installation directory, so upgrading from v1.11.0 does not
+require moving the vault or application state.
+
+---
+
 ## v1.11.0 — Commercial-grade local-first product experience
 
 LeLe Manager v1.11.0 completes the first commercial-grade product-experience

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lele-manager"
-version = "1.11.0"
+version = "1.11.1"
 description = "Lesson Learned Manager: archivio intelligente di lesson learned testuali."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepare LeLe Manager v1.11.1 as a focused patch release for the native launcher Ctrl+C shutdown fix merged in #173.

## Release scope

- bump package version from 1.11.0 to 1.11.1;
- add v1.11.1 changelog entry;
- add cumulative v1.11.1 release notes;
- no additional application-code changes.

## Validation

- Ruff passed;
- mypy passed for 59 source files;
- full Python suite: 596 passed, 7 skipped;
- release packaging tests: 10 passed;
- documentation tests: 4 passed;
- sdist and wheel built successfully;
- twine metadata checks passed;
- installed-wheel smoke passed from an isolated virtual environment;
- Linux native PyInstaller build passed;
- Linux native release packaging passed;
- published-style native archive smoke passed;
- extracted final archive received a real SIGINT and:
  - completed Uvicorn shutdown;
  - exited with code 0;
  - emitted no traceback;
  - emitted no unhandled KeyboardInterrupt;
  - emitted no PyInstaller "Failed to execute script" error.

The release tag is intentionally not created by this PR. It will be applied only after merge and final version/tag invariant verification.