### PR TITLE
Add manual PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,101 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: "Existing release tag to publish, for example v1.11.1"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Python artifacts from tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout requested release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version_tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Verify requested tag and package version
+        env:
+          VERSION_TAG: ${{ inputs.version_tag }}
+        run: |
+          python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          tag = os.environ["VERSION_TAG"].strip()
+
+          if not tag.startswith("v") or len(tag) == 1:
+              raise SystemExit(f"Invalid release tag: {tag!r}")
+
+          project = tomllib.loads(
+              Path("pyproject.toml").read_text(encoding="utf-8")
+          )
+          package_version = project["project"]["version"]
+          tag_version = tag[1:]
+
+          if package_version != tag_version:
+              raise SystemExit(
+                  "Tag/package version mismatch: "
+                  f"tag={tag!r}, package={package_version!r}"
+              )
+
+          print(f"OK: {tag} matches package version {package_version}.")
+          PY
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build twine
+
+      - name: Build release artifacts
+        run: ./scripts/build-release-artifacts.sh
+
+      - name: Upload Python distributions
+        uses: actions/upload-artifact@v6
+        with:
+          name: pypi-dist-${{ inputs.version_tag }}
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v7
+        with:
+          name: pypi-dist-${{ inputs.version_tag }}
+          path: dist
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,6 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
-    inputs:
-      publish_pypi:
-        description: "Publish Python artifacts to PyPI"
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -133,23 +127,3 @@ jobs:
             --verify-tag \
             --generate-notes \
             --title "LeLe Manager ${GITHUB_REF_NAME}"
-
-
-  publish:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_pypi && vars.PYPI_ENABLED == 'true' }}
-    name: Publish to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: dist
-          path: dist
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -101,3 +101,19 @@ def test_native_build_rejects_stale_installed_version() -> None:
     assert 'version("lele-manager")' in script
     assert '"project"]["version"]' in script
     assert "metadata lele-manager non allineata" in script
+
+def test_pypi_publication_uses_dedicated_manual_trusted_workflow() -> None:
+    release = read(".github/workflows/release.yml")
+    pypi = read(".github/workflows/publish-pypi.yml")
+
+    assert "Publish to PyPI" not in release
+    assert "publish_pypi:" not in release
+
+    assert "workflow_dispatch:" in pypi
+    assert "version_tag:" in pypi
+    assert "push:" not in pypi
+
+    assert BUILD_COMMAND in pypi
+    assert "environment: pypi" in pypi
+    assert "id-token: write" in pypi
+    assert "pypa/gh-action-pypi-publish@release/v1" in pypi


### PR DESCRIPTION
## Summary

Add a dedicated, explicitly triggered PyPI publishing workflow using GitHub Actions OIDC / PyPI Trusted Publishing.

## Design

- keep native GitHub Releases and PyPI publishing as separate distribution channels;
- keep native release publication unchanged;
- remove the old optional PyPI job from `release.yml`;
- add a dedicated `publish-pypi.yml` workflow;
- require an explicit existing release tag such as `v1.11.1`;
- check out that exact tag before building;
- verify that the tag version matches `pyproject.toml`;
- reuse the canonical `./scripts/build-release-artifacts.sh` entrypoint;
- use the dedicated GitHub Environment `pypi`;
- grant `id-token: write` only to the publish job;
- publish through `pypa/gh-action-pypi-publish@release/v1`;
- never publish automatically on tag push.

## Validation

- RED contract reproduced before implementation;
- dedicated PyPI publishing contract: passed;
- full release packaging suite: 11 passed;
- `git diff --check`: passed.

## Important

This PR does **not** publish anything to PyPI.

After merge, the external PyPI Trusted Publisher and GitHub `pypi` environment will be configured separately. The already released `v1.11.1` can then be published manually without creating another native release.

Closes #175