### PR TITLE
Document PyPI installation with pipx

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -89,6 +89,17 @@ all'aggiornamento della cartella applicativa estratta.
 Ogni archive nativo include `LEGGIMI_PRIMA.txt` con istruzioni di primo avvio
 specifiche per la piattaforma.
 
+Per utenti Python e power user, LeLe Manager è pubblicato anche su PyPI. È
+consigliata l'installazione come applicazione isolata tramite `pipx`:
+
+```bash
+pipx install lele-manager
+```
+
+Il pacchetto PyPI espone sia `lele-manager` per avviare l'applicazione locale,
+sia `lele` per la CLI. I pacchetti nativi delle GitHub Release restano il
+percorso di installazione consigliato per il normale utilizzo utente.
+
 Per lo sviluppo dai sorgenti, clonare il repository e creare un ambiente
 virtuale:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ the extracted application package.
 Each native archive includes `LEGGIMI_PRIMA.txt` with platform-specific
 first-run instructions.
 
+For Python and power users, LeLe Manager is also published on PyPI. Install it
+as an isolated application with `pipx`:
+
+```bash
+pipx install lele-manager
+```
+
+The PyPI package exposes both `lele-manager` for the local application launcher
+and `lele` for the CLI. Native GitHub Release packages remain the recommended
+installation path for normal end-user use.
+
 For development from source, clone the repository and create a virtual
 environment:
 


### PR DESCRIPTION
## Summary

Document PyPI as an additional installation channel for Python and power users.

## Changes

- add `pipx install lele-manager` to the English README;
- add the equivalent installation guidance to the Italian README;
- keep native GitHub Release packages as the recommended path for normal end-user use;
- document the `lele-manager` launcher and `lele` CLI entry points.

## Validation

- documentation tests: 4 passed;
- Markdown fences verified explicitly;
- `git diff --check`: passed.

## PyPI publication status

LeLe Manager 1.11.1 has already been published successfully on PyPI through GitHub Actions OIDC / Trusted Publishing.

The published wheel and sdist were verified through the public PyPI API, and an isolated install directly from PyPI passed the existing package smoke test and CLI smoke test.

Closes #175