### PR TITLE
fix: submit Browse filters with Enter

### DIFF
--- a/frontend/e2e/browse-form.spec.ts
+++ b/frontend/e2e/browse-form.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test, type Page } from '@playwright/test'
+
+interface SearchRequest {
+  q: string | null
+  topic_in: string[] | null
+  source_in: string[] | null
+  importance_gte: number | null
+  importance_lte: number | null
+  limit: number
+  include_frontmatter: boolean
+}
+
+async function watchSearchRequests(page: Page): Promise<SearchRequest[]> {
+  const requests: SearchRequest[] = []
+
+  await page.route('**/lessons/search', async (route) => {
+    requests.push(route.request().postDataJSON() as SearchRequest)
+    await route.fulfill({
+      contentType: 'application/json',
+      body: '[]',
+    })
+  })
+
+  return requests
+}
+
+async function openBrowse(page: Page): Promise<SearchRequest[]> {
+  const requests = await watchSearchRequests(page)
+  await page.goto('/app/#/browse')
+  await expect.poll(() => requests.length).toBe(1)
+  await expect(
+    page.getByRole('button', { name: 'Search', exact: true }),
+  ).toBeEnabled()
+  return requests
+}
+
+async function expectOneSearchAfterEnter(
+  page: Page,
+  requests: SearchRequest[],
+  label: string,
+  value: string,
+  expected: Partial<SearchRequest>,
+): Promise<void> {
+  const requestCount = requests.length
+  await page.getByLabel(label).fill(value)
+  await page.getByLabel(label).press('Enter')
+
+  await expect.poll(() => requests.length).toBe(requestCount + 1)
+  expect(requests[requestCount]).toMatchObject(expected)
+  expect(requests).toHaveLength(requestCount + 1)
+}
+
+test.describe('Browse filter form', () => {
+  test('submits Search once with Enter and with the Search button', async ({
+    page,
+  }) => {
+    const requests = await openBrowse(page)
+
+    await expectOneSearchAfterEnter(page, requests, 'Query', 'pytest', {
+      q: 'pytest',
+    })
+
+    await page.getByLabel('Query').fill('pandas')
+    await page.getByRole('button', { name: 'Search', exact: true }).click()
+
+    await expect.poll(() => requests.length).toBe(3)
+    expect(requests[2]).toMatchObject({ q: 'pandas' })
+  })
+
+  test('submits Topic and Source with Enter', async ({ page }) => {
+    const requests = await openBrowse(page)
+
+    await expectOneSearchAfterEnter(page, requests, 'Topic', 'python', {
+      topic_in: ['python'],
+    })
+
+    await expectOneSearchAfterEnter(page, requests, 'Source', 'note', {
+      source_in: ['note'],
+    })
+  })
+
+  test('submits numeric filters with Enter', async ({ page }) => {
+    const requests = await openBrowse(page)
+
+    await expectOneSearchAfterEnter(page, requests, 'Importance ≥', '3', {
+      importance_gte: 3,
+    })
+    await expectOneSearchAfterEnter(page, requests, 'Importance ≤', '4', {
+      importance_lte: 4,
+    })
+    await expectOneSearchAfterEnter(page, requests, 'Limit', '10', {
+      limit: 10,
+    })
+  })
+
+  test('keeps secondary Browse actions out of form submission', async ({
+    page,
+  }) => {
+    const requests = await openBrowse(page)
+    const form = page.locator('.filters form')
+
+    await expect(form).toHaveCount(1)
+    await expect(
+      page.getByRole('button', { name: 'Search', exact: true }),
+    ).toHaveAttribute('type', 'submit')
+
+    for (const name of ['List all', 'Export .md', 'Reset']) {
+      await expect(
+        page.getByRole('button', { name, exact: true }),
+      ).toHaveAttribute('type', 'button')
+    }
+
+    await page.getByLabel('Query').fill('to reset')
+    await page.getByRole('button', { name: 'Reset', exact: true }).click()
+
+    expect(requests).toHaveLength(1)
+    await expect(page.getByLabel('Query')).toHaveValue('')
+
+    const listRequest = page.waitForRequest((request) =>
+      request.method() === 'GET' &&
+      new URL(request.url()).pathname === '/lessons',
+    )
+    await page.getByRole('button', { name: 'List all', exact: true }).click()
+    await listRequest
+    expect(requests).toHaveLength(1)
+  })
+})

--- a/frontend/src/routes/Browse.svelte
+++ b/frontend/src/routes/Browse.svelte
@@ -111,6 +111,11 @@
     importanceLte = ''
   }
 
+  function submitSearch(event: SubmitEvent) {
+    event.preventDefault()
+    runSearch()
+  }
+
   onMount(() => {
     runSearch()
   })
@@ -118,72 +123,77 @@
 
 <div class="browse">
   <Panel title={$messages.routeBrowseTitle} class="filters">
-    <div class="grid browse-filter-grid" data-testid="browse-filter-grid">
-      <label>
-        <FieldLabel label={$messages.fieldQuery} />
-        <input bind:value={q} placeholder="pytest, git, pandas…" onkeydown={(e) => e.key === 'Enter' && runSearch()} />
-      </label>
-      <label>
-        <FieldLabel label={$messages.fieldTopic} />
-        <input bind:value={topic} placeholder="python" />
-      </label>
-      <label>
-        <FieldLabel label={$messages.fieldSource} />
-        <input bind:value={source} placeholder="note" />
-      </label>
-      <label>
-        <FieldLabel label={$messages.browseImportanceMin} />
-        <input type="number" min="1" max="5" bind:value={importanceGte} />
-      </label>
-      <label>
-        <FieldLabel label={$messages.browseImportanceMax} />
-        <input type="number" min="1" max="5" bind:value={importanceLte} />
-      </label>
-      <label>
-        <FieldLabel label={$messages.browseLimit} />
-        <input type="number" min="1" max="500" bind:value={limit} />
-      </label>
-    </div>
-    <FormActions
-      class="browse-actions"
-      style="--giu-form-actions-gap: var(--space-2); margin-top: var(--space-3)"
-    >
-      <Button
-        size="compact"
-        onclick={runSearch}
-        disabled={loading}
+    <form onsubmit={submitSearch}>
+      <div class="grid browse-filter-grid" data-testid="browse-filter-grid">
+        <label>
+          <FieldLabel label={$messages.fieldQuery} />
+          <input bind:value={q} placeholder="pytest, git, pandas…" />
+        </label>
+        <label>
+          <FieldLabel label={$messages.fieldTopic} />
+          <input bind:value={topic} placeholder="python" />
+        </label>
+        <label>
+          <FieldLabel label={$messages.fieldSource} />
+          <input bind:value={source} placeholder="note" />
+        </label>
+        <label>
+          <FieldLabel label={$messages.browseImportanceMin} />
+          <input type="number" min="1" max="5" bind:value={importanceGte} />
+        </label>
+        <label>
+          <FieldLabel label={$messages.browseImportanceMax} />
+          <input type="number" min="1" max="5" bind:value={importanceLte} />
+        </label>
+        <label>
+          <FieldLabel label={$messages.browseLimit} />
+          <input type="number" min="1" max="500" bind:value={limit} />
+        </label>
+      </div>
+      <FormActions
+        class="browse-actions"
+        style="--giu-form-actions-gap: var(--space-2); margin-top: var(--space-3)"
       >
-        {$messages.browseSearch}
-      </Button>
-      <Button
-        variant="secondary"
-        size="compact"
-        onclick={listAll}
-        disabled={loading}
-        class="lele-secondary-button"
-      >
-        {$messages.browseListAll}
-      </Button>
-      <Button
-        variant="secondary"
-        size="compact"
-        onclick={exportResults}
-        disabled={loading || exporting || lessons.length === 0}
-        class="lele-secondary-button"
-      >
-        {exporting
-          ? $messages.browseExporting
-          : $messages.browseExportMarkdown}
-      </Button>
-      <Button
-        variant="secondary"
-        size="compact"
-        onclick={reset}
-        class="lele-secondary-button"
-      >
-        {$messages.browseReset}
-      </Button>
-    </FormActions>
+        <Button
+          type="submit"
+          size="compact"
+          disabled={loading}
+        >
+          {$messages.browseSearch}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="compact"
+          onclick={listAll}
+          disabled={loading}
+          class="lele-secondary-button"
+        >
+          {$messages.browseListAll}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="compact"
+          onclick={exportResults}
+          disabled={loading || exporting || lessons.length === 0}
+          class="lele-secondary-button"
+        >
+          {exporting
+            ? $messages.browseExporting
+            : $messages.browseExportMarkdown}
+        </Button>
+        <Button
+          type="button"
+          variant="secondary"
+          size="compact"
+          onclick={reset}
+          class="lele-secondary-button"
+        >
+          {$messages.browseReset}
+        </Button>
+      </FormActions>
+    </form>
 
     {#if status}
       <FormStatus


### PR DESCRIPTION
## Summary

Makes the Browse filters a single semantic HTML form so Enter from Search, Topic, Source, importance bounds, or Limit follows the same `runSearch()` workflow as the Search action.

## Root cause

Only the free-text Search input had a custom Enter key handler. The remaining filters were outside a form, so they had no native submission behavior.

## Implementation

- Wrap Browse filters and actions in a native form with one prevented submit handler.
- Make Search a native submit action; make List all, Export, and Reset explicit non-submit actions.
- Add focused Playwright coverage for text/numeric Enter submission, one-request behavior, normal Search clicks, and secondary actions.

Closes #191

## Validation

- `npm run check`
- `CI=1 E2E_PORT=8770 npm run test:e2e -- browse-form.spec.ts` (4 passed)
- `CI=1 E2E_PORT=8769 npm run test:e2e` (73 passed)