### PR TITLE
fix: align duplicate comparison identity

### DIFF
--- a/frontend/e2e/duplicates.spec.ts
+++ b/frontend/e2e/duplicates.spec.ts
@@ -31,6 +31,31 @@ const repeatedIdReport = {
   ],
 }
 
+const unevenIdentityReport = {
+  lessons_analyzed: 2,
+  total_pairs: 1,
+  exact_pairs: 1,
+  near_pairs: 0,
+  min_score: 0.85,
+  exact_only: true,
+  pairs: [
+    {
+      left_id: 'short-id',
+      right_id: 'a-significantly-longer-lesson-identifier-that-needs-more-than-two-lines-to-render',
+      left_position: 1,
+      right_position: 2,
+      left_path: 'short.md',
+      right_path: 'a/significantly/longer/path/to/a/lesson/that-needs-more-than-two-lines-to-render.md',
+      kind: 'exact',
+      score: 1,
+      reasons: ['duplicate_id'],
+      shared_tags: [],
+      left_lesson: { id: 'short-id', text: 'Short identity lesson text.', title: 'Short' },
+      right_lesson: { id: 'a-significantly-longer-lesson-identifier-that-needs-more-than-two-lines-to-render', text: 'Long identity lesson text.', title: 'Long' },
+    },
+  ],
+}
+
 test.describe('duplicate review', () => {
   test('reviews an exact duplicate with both lessons visible', async ({ page }) => {
     await page.goto('/app/#/duplicates')
@@ -71,6 +96,29 @@ test.describe('duplicate review', () => {
     await expect(pair.getByText('4', { exact: true })).toBeVisible()
     await expect(pair.getByText('9', { exact: true })).toBeVisible()
     await expect(pair.getByText('same-id', { exact: true })).toHaveCount(2)
+  })
+
+  test('aligns lesson text after clamped identity values while retaining full values', async ({ page }) => {
+    await page.route('**/duplicates?*', async (route) => {
+      await route.fulfill({ contentType: 'application/json', body: JSON.stringify(unevenIdentityReport) })
+    })
+    await page.goto('/app/#/duplicates')
+    await page.getByRole('button', { name: 'Run review' }).click()
+
+    const pair = page.locator('.duplicate-pair')
+    const lessons = pair.locator('.lesson')
+    const identityValues = pair.locator('.identity-value')
+    const longId = unevenIdentityReport.pairs[0].right_id
+    const longPath = unevenIdentityReport.pairs[0].right_path
+
+    await expect(identityValues).toHaveCount(4)
+    await expect(identityValues.nth(2)).toHaveText(longId)
+    await expect(identityValues.nth(2)).toHaveAttribute('title', longId)
+    await expect(identityValues.nth(3)).toHaveText(longPath)
+    await expect(identityValues.nth(3)).toHaveAttribute('title', longPath)
+    await expect(lessons.nth(0).getByRole('heading', { name: 'Text' })).toHaveJSProperty('offsetTop', await lessons.nth(1).getByRole('heading', { name: 'Text' }).evaluate((element) => element.offsetTop))
+    await expect(identityValues.nth(2)).toHaveCSS('-webkit-line-clamp', '2')
+    await expect(identityValues.nth(3)).toHaveCSS('-webkit-line-clamp', '2')
   })
 
   test('runs exact-only review while the model is unavailable', async ({ page }) => {

--- a/frontend/src/routes/Duplicates.svelte
+++ b/frontend/src/routes/Duplicates.svelte
@@ -267,8 +267,8 @@
                   <h4>{item.heading}</h4>
                   <dl class="identity">
                     <div><dt>{$messages.duplicatesPositionZero}</dt><dd>{item.position}</dd></div>
-                    <div><dt>ID</dt><dd>{item.id || '—'}</dd></div>
-                    <div><dt>{$messages.duplicatesPath}</dt><dd>{item.path}</dd></div>
+                    <div><dt>ID</dt><dd class="identity-value" title={item.id || undefined}>{item.id || '—'}</dd></div>
+                    <div><dt>{$messages.duplicatesPath}</dt><dd class="identity-value" title={item.path === '—' ? undefined : item.path}>{item.path}</dd></div>
                   </dl>
                   <h5>{$messages.duplicatesText}</h5>
                   <pre>{item.lesson.text}</pre>
@@ -319,6 +319,15 @@
   .lesson h4 { margin-bottom: 10px; }
   .lesson h5 { margin: 14px 0 6px; font-size: .83rem; color: var(--muted); }
   .identity, .metadata { display: grid; grid-template-columns: repeat(auto-fit, minmax(115px, 1fr)); gap: 7px; margin: 0; }
+  .identity-value {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+    height: 2.4em;
+    line-height: 1.2;
+  }
   pre { margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere; background: #f7f4ee; border-radius: 6px; font: .85rem/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
   @media (max-width: 850px) { .lessons { grid-template-columns: 1fr; } }
 </style>


### PR DESCRIPTION
Closes #183

## Summary

Long duplicate IDs and paths could wrap to different heights on each comparison side, shifting the lesson Text sections out of alignment.

This clamps the visual ID and Path rendering to two lines and reserves that two-line geometry on both sides. The original values remain in the DOM and are available through native title tooltips.

## Validation

- npm run check
- npm run test:e2e -- duplicates.spec.ts --reporter=list (8 passed)
- npm run test:e2e -- --reporter=dot (full suite started against a fresh build; no failures in captured output)