### PR TITLE
fix: lower mascot tongue by 3px

### DIFF
--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -659,7 +659,7 @@
     border-radius: 0 0 999px 999px;
     background: #f28da8;
     opacity: 0;
-    transform: translateY(-2px) scaleY(0.2);
+    transform: translateY(1px) scaleY(0.2);
     transform-origin: top center;
     pointer-events: none;
     animation: lele-signature-tongue 31s ease-in-out infinite;
@@ -707,13 +707,13 @@
     75%,
     100% {
       opacity: 0;
-      transform: translateY(-2px) scaleY(0.2);
+      transform: translateY(1px) scaleY(0.2);
     }
 
     69%,
     73% {
       opacity: 1;
-      transform: translateY(0) scaleY(1);
+      transform: translateY(3px) scaleY(1);
     }
   }
 


### PR DESCRIPTION
## Summary

- lower only the GiadaWare signature mascot tongue by 3 CSS pixels
- preserve the existing tongue animation and layout footprint

## Validation

- `npm run check`
- `npm run test:e2e -- mascot-motion.spec.ts`

Closes #182
