### PR TITLE
fix: reuse running launcher instance

### DIFF
--- a/src/lele_manager/launcher.py
+++ b/src/lele_manager/launcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import socket
 import threading
@@ -20,8 +21,22 @@ from lele_manager.core.vault import resolve_vault_dir
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
 HEALTH_TIMEOUT_SECONDS = 30.0
+INSTANCE_PROBE_TIMEOUT_SECONDS = 0.5
+INSTANCE_PROBE_MAX_BODY_BYTES = 16 * 1024
 AUTOMATION_NO_BROWSER_ENV = "LELE_MANAGER_NO_BROWSER"
 AUTOMATION_PORT_ENV = "LELE_MANAGER_PORT"
+PRODUCT_NAME = "LeLe Manager"
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject redirects while probing an untrusted local port occupant."""
+
+    def redirect_request(
+        self,
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        return None
 
 
 def resolve_automation_port(
@@ -68,6 +83,64 @@ def find_available_port(
         except OSError:
             sock.bind((host, 0))
         return int(sock.getsockname()[1])
+
+
+def is_running_lele_manager(
+    port: int,
+    *,
+    timeout: float = INSTANCE_PROBE_TIMEOUT_SECONDS,
+) -> bool:
+    """Return whether a loopback port exposes LeLe Manager's product identity."""
+    about_url = f"http://{DEFAULT_HOST}:{port}/about"
+    request = urllib.request.Request(
+        about_url,
+        headers={"Accept": "application/json"},
+    )
+    opener = urllib.request.build_opener(_NoRedirectHandler())
+
+    try:
+        # The URL is constructed from the fixed loopback host and supplied port.
+        with opener.open(request, timeout=timeout) as response:  # nosec B310
+            if not 200 <= response.status < 300:
+                return False
+            if response.headers.get_content_type() != "application/json":
+                return False
+
+            payload_bytes = response.read(INSTANCE_PROBE_MAX_BODY_BYTES + 1)
+            if len(payload_bytes) > INSTANCE_PROBE_MAX_BODY_BYTES:
+                return False
+
+        payload = json.loads(payload_bytes.decode("utf-8"))
+    except (
+        urllib.error.URLError,
+        OSError,
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+    ):
+        return False
+
+    return (
+        isinstance(payload, dict)
+        and payload.get("product_name") == PRODUCT_NAME
+    )
+
+
+def resolve_launch_target(
+    automation_port: int | None,
+) -> tuple[int, bool]:
+    """Choose the server port and whether an existing server can be reused.
+
+    The release-smoke port override deliberately retains its fixed-port
+    semantics. Normal launches reuse only a healthy local process that
+    explicitly identifies itself through LeLe Manager's ``/about`` contract.
+    """
+    if automation_port is not None:
+        return automation_port, False
+
+    if is_running_lele_manager(DEFAULT_PORT):
+        return DEFAULT_PORT, True
+
+    return find_available_port(), False
 
 
 def prepare_runtime() -> tuple[Path, Path, Path]:
@@ -126,14 +199,15 @@ def main() -> int:
     except ValueError as exc:
         raise SystemExit(f"ERRORE: {exc}") from exc
 
-    port = (
-        automation_port
-        if automation_port is not None
-        else find_available_port()
-    )
+    port, reuses_existing_instance = resolve_launch_target(automation_port)
     base_url = f"http://{DEFAULT_HOST}:{port}"
     health_url = f"{base_url}/health"
     app_url = f"{base_url}/app/"
+
+    if reuses_existing_instance:
+        if browser_opening_enabled():
+            webbrowser.open(app_url)
+        return 0
 
     if browser_opening_enabled():
         browser_thread = threading.Thread(

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,6 +1,49 @@
+import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
+import pytest
+
 import lele_manager.launcher as launcher
+
+
+@contextmanager
+def local_http_service(
+    *,
+    status: int = 200,
+    content_type: str = "application/json",
+    body: bytes = b'{"product_name": "LeLe Manager"}',
+):
+    """Run a real loopback HTTP service representing a port occupant."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path == "/about":
+                self.send_response(status)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+    server = ThreadingHTTPServer((launcher.DEFAULT_HOST, 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield int(server.server_address[1])
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
 
 
 def test_prepare_runtime_creates_required_directories(
@@ -84,6 +127,61 @@ def test_find_available_port_falls_back_when_preferred_port_is_busy() -> None:
     assert selected != busy_port
     assert selected > 0
 
+
+def test_find_available_port_prefers_a_free_preferred_port() -> None:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as candidate:
+        candidate.bind((launcher.DEFAULT_HOST, 0))
+        preferred_port = int(candidate.getsockname()[1])
+
+    assert (
+        launcher.find_available_port(launcher.DEFAULT_HOST, preferred_port)
+        == preferred_port
+    )
+
+
+def test_instance_probe_recognizes_lele_manager_without_version_matching() -> None:
+    body = json.dumps(
+        {"product_name": "LeLe Manager", "version": "0.9.0"}
+    ).encode()
+
+    with local_http_service(body=body) as port:
+        assert launcher.is_running_lele_manager(port) is True
+
+
+@pytest.mark.parametrize(
+    ("status", "content_type", "body"),
+    [
+        (200, "text/html", b'{"product_name": "LeLe Manager"}'),
+        (200, "application/json", b"not-json"),
+        (200, "application/json", b'{"product_name": "Other app"}'),
+        (503, "application/json", b'{"product_name": "LeLe Manager"}'),
+    ],
+)
+def test_instance_probe_rejects_unexpected_port_occupants(
+    status: int,
+    content_type: str,
+    body: bytes,
+) -> None:
+    with local_http_service(
+        status=status,
+        content_type=content_type,
+        body=body,
+    ) as port:
+        assert launcher.is_running_lele_manager(port) is False
+
+
+def test_instance_probe_handles_unavailable_port() -> None:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((launcher.DEFAULT_HOST, 0))
+        unavailable_port = int(sock.getsockname()[1])
+
+    assert launcher.is_running_lele_manager(unavailable_port) is False
+
+
 def test_release_automation_hooks_are_disabled_by_default() -> None:
     environment: dict[str, str] = {}
 
@@ -99,6 +197,16 @@ def test_release_automation_hooks_accept_explicit_smoke_values() -> None:
 
     assert launcher.resolve_automation_port(environment) == 43210
     assert launcher.browser_opening_enabled(environment) is False
+
+
+def test_automation_port_keeps_fixed_port_semantics(monkeypatch) -> None:
+    monkeypatch.setattr(
+        launcher,
+        "is_running_lele_manager",
+        lambda port: (_ for _ in ()).throw(AssertionError("unexpected probe")),
+    )
+
+    assert launcher.resolve_launch_target(43210) == (43210, False)
 
 
 def test_release_automation_port_rejects_invalid_values() -> None:
@@ -127,6 +235,7 @@ def test_main_treats_keyboard_interrupt_as_clean_shutdown(monkeypatch) -> None:
         lambda: (Path("/tmp/data"), Path("/tmp/model"), Path("/tmp/vault")),
     )
     monkeypatch.setattr(launcher, "resolve_automation_port", lambda: None)
+    monkeypatch.setattr(launcher, "is_running_lele_manager", lambda port: False)
     monkeypatch.setattr(launcher, "find_available_port", lambda: 43210)
     monkeypatch.setattr(launcher, "browser_opening_enabled", lambda: False)
     monkeypatch.setattr(launcher.uvicorn, "Server", InterruptingServer)
@@ -140,3 +249,86 @@ def test_main_treats_keyboard_interrupt_as_clean_shutdown(monkeypatch) -> None:
         ) from None
 
     assert result == 0
+
+
+def test_main_reuses_running_lele_manager_at_preferred_origin(monkeypatch) -> None:
+    opened: list[str] = []
+
+    class UnexpectedServer:
+        def __init__(self, config) -> None:
+            raise AssertionError("a reusable LeLe Manager must not be restarted")
+
+    with local_http_service() as preferred_port:
+        monkeypatch.setattr(launcher, "DEFAULT_PORT", preferred_port)
+        monkeypatch.setattr(
+            launcher,
+            "prepare_runtime",
+            lambda: (Path("/tmp/data"), Path("/tmp/model"), Path("/tmp/vault")),
+        )
+        monkeypatch.setattr(launcher, "resolve_automation_port", lambda: None)
+        monkeypatch.setattr(launcher.webbrowser, "open", opened.append)
+        monkeypatch.setattr(launcher.uvicorn, "Server", UnexpectedServer)
+
+        assert launcher.main() == 0
+
+    assert opened == [f"http://{launcher.DEFAULT_HOST}:{preferred_port}/app/"]
+
+
+def test_main_reuse_respects_browser_disabled_automation(monkeypatch) -> None:
+    class UnexpectedServer:
+        def __init__(self, config) -> None:
+            raise AssertionError("a reusable LeLe Manager must not be restarted")
+
+    with local_http_service() as preferred_port:
+        monkeypatch.setattr(launcher, "DEFAULT_PORT", preferred_port)
+        monkeypatch.setattr(
+            launcher,
+            "prepare_runtime",
+            lambda: (Path("/tmp/data"), Path("/tmp/model"), Path("/tmp/vault")),
+        )
+        monkeypatch.setattr(launcher, "resolve_automation_port", lambda: None)
+        monkeypatch.setattr(launcher, "browser_opening_enabled", lambda: False)
+        monkeypatch.setattr(
+            launcher.webbrowser,
+            "open",
+            lambda url: (_ for _ in ()).throw(AssertionError("browser opened")),
+        )
+        monkeypatch.setattr(launcher.uvicorn, "Server", UnexpectedServer)
+
+        assert launcher.main() == 0
+
+
+def test_main_does_not_attach_to_an_unrelated_preferred_port(monkeypatch) -> None:
+    captured_ports: list[int] = []
+
+    class InterruptingServer:
+        def __init__(self, config) -> None:
+            captured_ports.append(config.port)
+
+        def run(self) -> None:
+            raise KeyboardInterrupt
+
+    unrelated_body = json.dumps(
+        {"product_name": "Another local app", "status": "ok"}
+    ).encode()
+    with local_http_service(body=unrelated_body) as preferred_port:
+        fallback_port = preferred_port + 1
+        monkeypatch.setattr(launcher, "DEFAULT_PORT", preferred_port)
+        monkeypatch.setattr(
+            launcher,
+            "prepare_runtime",
+            lambda: (Path("/tmp/data"), Path("/tmp/model"), Path("/tmp/vault")),
+        )
+        monkeypatch.setattr(launcher, "resolve_automation_port", lambda: None)
+        monkeypatch.setattr(
+            launcher,
+            "find_available_port",
+            lambda: fallback_port,
+        )
+        monkeypatch.setattr(launcher, "browser_opening_enabled", lambda: False)
+        monkeypatch.setattr(launcher.uvicorn, "Server", InterruptingServer)
+
+        assert launcher.main() == 0
+        assert launcher.is_running_lele_manager(preferred_port) is False
+
+    assert captured_ports == [fallback_port]


### PR DESCRIPTION
## Summary

Closes #179

- Reuse the existing preferred loopback origin when its `/about` endpoint identifies a running LeLe Manager instance.
- Keep the existing random-port fallback for unrelated preferred-port occupants.
- Add launcher lifecycle coverage using real local HTTP fixtures.

## Root cause

The launcher previously selected a random port whenever `127.0.0.1:8765` was occupied, including when that port was occupied by a previous LeLe Manager backend. Reopening the browser on that different origin gave the GUI a different `localStorage` namespace, so its persisted locale was not available.

## Instance identification and safety

The launcher makes a bounded loopback-only request to `/about` and reuses a process only for a successful JSON response whose explicit `product_name` is `LeLe Manager`. It does not match TCP reachability, generic `/health`, HTML, or version equality; it rejects malformed, non-2xx, foreign, and unavailable responses and does not follow redirects. An unrelated occupant is never killed or opened, and the launcher retains the prior random-port fallback.

`LELE_MANAGER_PORT` retains its fixed-port release-smoke behavior and `LELE_MANAGER_NO_BROWSER` is respected in both normal and reuse paths.

## Concurrency note

This fixes the deterministic reopen case once the original preferred-port backend is healthy. The pre-existing race between checking a free port and a concurrent first launch is intentionally not expanded into a registry or lock protocol; a conflicting first launch can still take the existing safe random-port fallback.

## Validation

- `.venv/bin/pytest -q tests/test_launcher.py` (19 passed)
- `.venv/bin/ruff check .`
- `.venv/bin/mypy src/lele_manager`
- `.venv/bin/pytest -q` (608 passed, 7 skipped)
- `./scripts/build-release-artifacts.sh` (with the project virtual environment)
- Installed rebuilt wheel smoke (`scripts/smoke-installed-package.py`)

The native PyInstaller smoke was started but this execution environment terminated its build during dependency analysis before an executable was emitted; the fixed-port/no-browser launcher contract remains covered by unit tests and the artifact/wheel checks above.
