### PR TITLE
feat: install Linux desktop integration

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -89,9 +89,16 @@ all'aggiornamento della cartella applicativa estratta.
 Su Linux l'archive include anche `./install.sh` per un'installazione locale
 utente esplicita. L'installer colloca l'app nativa in
 `${XDG_DATA_HOME:-~/.local/share}/lele-manager/install/app` e crea il launcher
-stabile `~/.local/bin/lele-manager`. La directory `lele-manager` resta lo
-spazio dei dati runtime persistenti; solo `install/` e' gestita e sostituibile
-dall'installer. L'archive estratto resta utilizzabile in modo portabile.
+stabile `~/.local/bin/lele-manager`, la voce del menu applicazioni in
+`${XDG_DATA_HOME:-~/.local/share}/applications/lele-manager.desktop` e l'icona
+ufficiale in `${XDG_DATA_HOME:-~/.local/share}/icons/hicolor/scalable/apps/lele-manager.svg`.
+La voce menu avvia sempre il launcher stabile, quindi e' adatta a preferiti e
+dock e resta valida dopo gli aggiornamenti. La directory `lele-manager` resta
+lo spazio dei dati runtime persistenti; solo `install/` e' gestita e sostituibile
+dall'installer. L'archive estratto resta utilizzabile in modo portabile e non
+registra risorse desktop.
+I percorsi del launcher con spazi sono supportati; i caratteri newline sono
+rifiutati perche' non rappresentabili nel comando di una voce desktop.
 
 Ogni archive nativo include `LEGGIMI_PRIMA.txt` con istruzioni di primo avvio
 specifiche per la piattaforma.

--- a/README.md
+++ b/README.md
@@ -91,16 +91,23 @@ root, run:
 
 This copies the native bundle to
 `${XDG_DATA_HOME:-~/.local/share}/lele-manager/install/app` and creates the stable
-`~/.local/bin/lele-manager` launcher. The latter is intended for a user whose
-`~/.local/bin` is on `PATH`; the installer prints the exact path when it is
-not. Advanced users and automated environments may choose another absolute
-launcher directory with `LELE_MANAGER_INSTALL_BIN_DIR`.
+`~/.local/bin/lele-manager` launcher, an application-menu entry at
+`${XDG_DATA_HOME:-~/.local/share}/applications/lele-manager.desktop`, and the
+official icon at `${XDG_DATA_HOME:-~/.local/share}/icons/hicolor/scalable/apps/lele-manager.svg`.
+The menu entry always launches the stable launcher, so it is suitable for normal
+favorites or dock pinning and survives application upgrades. The launcher is
+intended for a user whose `~/.local/bin` is on `PATH`; the installer prints the
+exact path when it is not. Advanced users and automated environments may choose
+another absolute launcher directory with `LELE_MANAGER_INSTALL_BIN_DIR`.
+Launcher paths containing spaces are supported; newline characters are rejected
+because they cannot be represented in a desktop-entry command line.
 
 `${XDG_DATA_HOME:-~/.local/share}/lele-manager/` is the persistent runtime-data
 namespace; only its `install/` subtree is installer-owned and replaceable.
 Re-running `./install.sh` from a newer extracted Linux release replaces only
-the stable `install/app/` bundle. It does not remove the existing data, vault,
-or model paths. This does not yet create a desktop-menu entry or install icons.
+the stable `install/app/` bundle and refreshes its product-owned desktop entry
+and icon. It does not remove the existing data, vault, or model paths. Portable
+extract-and-run mode does not register any desktop resources.
 
 On first launch, LeLe Manager prepares its local application directories and
 default Markdown vault outside the installation directory, starts the local

--- a/packaging/guides/LEGGIMI_PRIMA-Linux.txt
+++ b/packaging/guides/LEGGIMI_PRIMA-Linux.txt
@@ -23,7 +23,8 @@ L'installazione non richiede privilegi di amministratore. Copia l'applicazione
 in ${XDG_DATA_HOME:-~/.local/share}/lele-manager/install/app e crea il launcher
 ~/.local/bin/lele-manager. Se ~/.local/bin non e' nel PATH, aggiungilo alla
 configurazione della shell oppure esegui il percorso indicato dal programma di
-installazione.
+installazione. Aggiunge inoltre LeLe Manager al menu delle applicazioni con
+l'icona ufficiale; puoi quindi cercarlo o aggiungerlo ai preferiti/dock.
 
 Per aggiornare, estrai una nuova release ed esegui di nuovo ./install.sh. Il
 launcher lele-manager mantiene lo stesso percorso. La directory
@@ -33,10 +34,7 @@ vault e i modelli personali restano fuori dalla directory app installata.
 
 Per uso automatizzato o per scegliere intenzionalmente una directory bin
 diversa, puoi impostare LELE_MANAGER_INSTALL_BIN_DIR a un percorso assoluto
-prima di eseguire l'installer.
-
-L'installazione non aggiunge ancora voci al menu delle applicazioni o icone del
-desktop.
+prima di eseguire l'installer. La voce del menu usera' quel percorso stabile.
 
 Quando il programma è aperto puoi usare normalmente:
 - Esplora

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 APP_NAME="LeLe-Manager"
 PRODUCT_NAME="lele-manager"
+ICON_NAME="lele-manager.svg"
 
 fail() {
     printf 'ERRORE: %s\n' "$*" >&2
@@ -21,6 +22,15 @@ require_absolute_path() {
 require_safe_directory() {
     local path="$1"
     local label="$2"
+    local ancestor="$path"
+
+    while [ "$ancestor" != "/" ]; do
+        if [ -L "$ancestor" ]; then
+            fail "$label non deve attraversare link simbolici: $ancestor"
+        fi
+        ancestor="${ancestor%/*}"
+        [ -n "$ancestor" ] || ancestor="/"
+    done
 
     if [ -L "$path" ]; then
         fail "$label non deve essere un link simbolico: $path"
@@ -36,13 +46,49 @@ require_safe_directory() {
     fi
 }
 
+desktop_escape_argument() {
+    local value="$1"
+
+    case "$value" in
+        *$'\n'*|*$'\r'*) fail "il percorso del launcher non puo' contenere newline" ;;
+    esac
+
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//\`/\\\`}"
+    value="${value//\$/\\\$}"
+    printf '"%s"' "$value"
+}
+
+desktop_file_is_owned() {
+    local path="$1"
+    local launcher="$2"
+
+    [ ! -L "$path" ] || return 1
+    [ -f "$path" ] || return 1
+    grep -Fqx 'X-LeLe-Manager-Installer=true' "$path" && return 0
+
+    # Adopt the narrowly recognizable pre-#178 manual workaround only.
+    grep -Fqx '[Desktop Entry]' "$path" &&
+        grep -Fqx 'Type=Application' "$path" &&
+        grep -Fqx 'Name=LeLe Manager' "$path" &&
+        grep -Fqx "Exec=$launcher" "$path" &&
+        grep -Fqx "TryExec=$launcher" "$path" &&
+        grep -Fqx 'Icon=lele-manager' "$path" &&
+        grep -Fqx 'Terminal=false' "$path" &&
+        grep -Fqx 'Categories=Development;' "$path" &&
+        grep -Fqx 'StartupNotify=true' "$path"
+}
+
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 SOURCE_BUNDLE="$SCRIPT_DIR/$APP_NAME"
 SOURCE_EXECUTABLE="$SOURCE_BUNDLE/$APP_NAME"
+SOURCE_ICON="$SCRIPT_DIR/$ICON_NAME"
 
 [ -d "$SOURCE_BUNDLE" ] || fail "bundle nativo assente: $SOURCE_BUNDLE"
 [ -f "$SOURCE_EXECUTABLE" ] || fail "eseguibile nativo assente: $SOURCE_EXECUTABLE"
 [ -x "$SOURCE_EXECUTABLE" ] || fail "eseguibile nativo non eseguibile: $SOURCE_EXECUTABLE"
+[ -f "$SOURCE_ICON" ] || fail "icona Linux assente: $SOURCE_ICON"
 
 if [ -n "${XDG_DATA_HOME:-}" ]; then
     DATA_HOME="$XDG_DATA_HOME"
@@ -65,9 +111,20 @@ INSTALL_ROOT="$PRODUCT_ROOT/install"
 APP_DIR="$INSTALL_ROOT/app"
 APP_EXECUTABLE="$APP_DIR/$APP_NAME"
 LAUNCHER="$BIN_DIR/$PRODUCT_NAME"
+APPLICATIONS_DIR="$DATA_HOME/applications"
+ICON_DIR="$DATA_HOME/icons/hicolor/scalable/apps"
+DESKTOP_ENTRY="$APPLICATIONS_DIR/$PRODUCT_NAME.desktop"
+INSTALLED_ICON="$ICON_DIR/$ICON_NAME"
 
+require_safe_directory "$DATA_HOME" "la directory dati XDG"
+require_safe_directory "$PRODUCT_ROOT" "la radice del prodotto"
 require_safe_directory "$INSTALL_ROOT" "la radice di installazione"
 require_safe_directory "$BIN_DIR" "la directory bin di installazione"
+require_safe_directory "$APPLICATIONS_DIR" "la directory delle applicazioni XDG"
+require_safe_directory "$DATA_HOME/icons" "la directory icone XDG"
+require_safe_directory "$DATA_HOME/icons/hicolor" "il tema icone hicolor"
+require_safe_directory "$DATA_HOME/icons/hicolor/scalable" "la directory icone scalabili"
+require_safe_directory "$ICON_DIR" "la directory icone delle applicazioni"
 
 if [ -L "$APP_DIR" ]; then
     fail "la directory app installata non deve essere un link simbolico: $APP_DIR"
@@ -84,13 +141,30 @@ elif [ -e "$LAUNCHER" ]; then
     fail "il launcher esistente non appartiene a LeLe Manager: $LAUNCHER"
 fi
 
+if [ -L "$DESKTOP_ENTRY" ]; then
+    fail "la voce desktop installata non deve essere un link simbolico: $DESKTOP_ENTRY"
+fi
+if [ -e "$DESKTOP_ENTRY" ] && ! desktop_file_is_owned "$DESKTOP_ENTRY" "$LAUNCHER"; then
+    fail "la voce desktop esistente non appartiene a LeLe Manager: $DESKTOP_ENTRY"
+fi
+if [ -L "$INSTALLED_ICON" ]; then
+    fail "l'icona installata non deve essere un link simbolico: $INSTALLED_ICON"
+fi
+if [ -e "$INSTALLED_ICON" ] && [ ! -f "$INSTALLED_ICON" ]; then
+    fail "l'icona installata non e' un file regolare: $INSTALLED_ICON"
+fi
+
 STAGING_DIR="$(mktemp -d "$INSTALL_ROOT/.app-staging.XXXXXX")"
 BACKUP_DIR=""
+ICON_TMP="$(mktemp "$ICON_DIR/.lele-manager-icon.XXXXXX")"
+DESKTOP_TMP="$(mktemp "$APPLICATIONS_DIR/.lele-manager-desktop.XXXXXX")"
 cleanup() {
     local status=$?
     if [ -n "${STAGING_DIR:-}" ] && [ -d "$STAGING_DIR" ]; then
         rm -rf "$STAGING_DIR"
     fi
+    [ -z "${ICON_TMP:-}" ] || rm -f "$ICON_TMP"
+    [ -z "${DESKTOP_TMP:-}" ] || rm -f "$DESKTOP_TMP"
     exit "$status"
 }
 trap cleanup EXIT
@@ -99,6 +173,22 @@ cp -a "$SOURCE_BUNDLE" "$STAGING_DIR/app"
 STAGED_EXECUTABLE="$STAGING_DIR/app/$APP_NAME"
 [ -f "$STAGED_EXECUTABLE" ] || fail "copia staged senza eseguibile nativo"
 [ -x "$STAGED_EXECUTABLE" ] || fail "copia staged senza eseguibile nativo eseguibile"
+
+cp "$SOURCE_ICON" "$ICON_TMP"
+[ -s "$ICON_TMP" ] || fail "copia staged senza icona Linux"
+LAUNCHER_EXEC="$(desktop_escape_argument "$LAUNCHER")"
+cat > "$DESKTOP_TMP" <<EOF
+[Desktop Entry]
+Type=Application
+Name=LeLe Manager
+Exec=$LAUNCHER_EXEC
+TryExec=$LAUNCHER_EXEC
+Icon=lele-manager
+Terminal=false
+Categories=Development;
+StartupNotify=true
+X-LeLe-Manager-Installer=true
+EOF
 
 if [ -d "$APP_DIR" ]; then
     BACKUP_DIR="$(mktemp -d "$INSTALL_ROOT/.app-backup.XXXXXX")"
@@ -124,6 +214,13 @@ if [ ! -L "$LAUNCHER" ]; then
     mv "$LAUNCHER_TMP" "$LAUNCHER"
 fi
 
+mv "$ICON_TMP" "$INSTALLED_ICON"
+ICON_TMP=""
+mv "$DESKTOP_TMP" "$DESKTOP_ENTRY"
+DESKTOP_TMP=""
+
 printf 'LeLe Manager installato in: %s\n' "$APP_DIR"
 printf 'Launcher stabile: %s\n' "$LAUNCHER"
+printf 'Voce menu applicazioni: %s\n' "$DESKTOP_ENTRY"
+printf 'Icona applicazione: %s\n' "$INSTALLED_ICON"
 printf 'Aggiungi %s al PATH se necessario, poi esegui: lele-manager\n' "$BIN_DIR"

--- a/packaging/linux/install.sh
+++ b/packaging/linux/install.sh
@@ -46,18 +46,48 @@ require_safe_directory() {
     fi
 }
 
-desktop_escape_argument() {
+reject_invalid_desktop_path() {
     local value="$1"
 
     case "$value" in
         *$'\n'*|*$'\r'*) fail "il percorso del launcher non puo' contenere newline" ;;
+        *[[:cntrl:]]*) fail "il percorso del launcher non puo' contenere caratteri di controllo" ;;
+    esac
+}
+
+desktop_escape_exec_program() {
+    local value="$1"
+
+    reject_invalid_desktop_path "$value"
+    case "$value" in
+        *'='*) fail "il percorso del launcher non puo' contenere '=' per Exec" ;;
     esac
 
+    # Exec is a command line. Escape its quoted executable token first, then
+    # escape resulting backslashes for the desktop-entry string layer.
     value="${value//\\/\\\\}"
     value="${value//\"/\\\"}"
     value="${value//\`/\\\`}"
     value="${value//\$/\\\$}"
+    value="${value//%/%%}"
+    value="${value//\\/\\\\}"
     printf '"%s"' "$value"
+}
+
+desktop_escape_string_path() {
+    local value="$1"
+
+    reject_invalid_desktop_path "$value"
+    # TryExec is a desktop-entry string path, not an Exec command line.
+    value="${value//\\/\\\\}"
+    printf '%s' "$value"
+}
+
+desktop_path_is_simple_legacy_path() {
+    case "$1" in
+        *' '*|*'\\'*|*'"'*|*'$'*|*'`'*|*'%'*) return 1 ;;
+    esac
+    return 0
 }
 
 desktop_file_is_owned() {
@@ -69,6 +99,7 @@ desktop_file_is_owned() {
     grep -Fqx 'X-LeLe-Manager-Installer=true' "$path" && return 0
 
     # Adopt the narrowly recognizable pre-#178 manual workaround only.
+    desktop_path_is_simple_legacy_path "$launcher" || return 1
     grep -Fqx '[Desktop Entry]' "$path" &&
         grep -Fqx 'Type=Application' "$path" &&
         grep -Fqx 'Name=LeLe Manager' "$path" &&
@@ -115,6 +146,10 @@ APPLICATIONS_DIR="$DATA_HOME/applications"
 ICON_DIR="$DATA_HOME/icons/hicolor/scalable/apps"
 DESKTOP_ENTRY="$APPLICATIONS_DIR/$PRODUCT_NAME.desktop"
 INSTALLED_ICON="$ICON_DIR/$ICON_NAME"
+
+# Validate and serialize before altering any installed resources.
+LAUNCHER_EXEC="$(desktop_escape_exec_program "$LAUNCHER")"
+LAUNCHER_TRY_EXEC="$(desktop_escape_string_path "$LAUNCHER")"
 
 require_safe_directory "$DATA_HOME" "la directory dati XDG"
 require_safe_directory "$PRODUCT_ROOT" "la radice del prodotto"
@@ -176,13 +211,12 @@ STAGED_EXECUTABLE="$STAGING_DIR/app/$APP_NAME"
 
 cp "$SOURCE_ICON" "$ICON_TMP"
 [ -s "$ICON_TMP" ] || fail "copia staged senza icona Linux"
-LAUNCHER_EXEC="$(desktop_escape_argument "$LAUNCHER")"
 cat > "$DESKTOP_TMP" <<EOF
 [Desktop Entry]
 Type=Application
 Name=LeLe Manager
 Exec=$LAUNCHER_EXEC
-TryExec=$LAUNCHER_EXEC
+TryExec=$LAUNCHER_TRY_EXEC
 Icon=lele-manager
 Terminal=false
 Categories=Development;

--- a/scripts/package-native-release.py
+++ b/scripts/package-native-release.py
@@ -17,6 +17,7 @@ DIST_NATIVE = ROOT / "dist" / "native"
 RELEASE_DIR = ROOT / "dist" / "release"
 APP_NAME = "LeLe-Manager"
 LINUX_INSTALLER = ROOT / "packaging" / "linux" / "install.sh"
+LINUX_ICON = ROOT / "frontend" / "public" / "favicon.svg"
 
 
 def project_version() -> str:
@@ -105,6 +106,8 @@ def main() -> int:
             raise SystemExit(
                 f"ERRORE: installer Linux non eseguibile: {LINUX_INSTALLER}"
             )
+        if not LINUX_ICON.is_file():
+            raise SystemExit(f"ERRORE: icona Linux assente: {LINUX_ICON}")
 
     RELEASE_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -124,6 +127,7 @@ def main() -> int:
     shutil.copy2(guide, staging / "LEGGIMI_PRIMA.txt")
     if os_label == "Linux":
         shutil.copy2(LINUX_INSTALLER, staging / "install.sh")
+        shutil.copy2(LINUX_ICON, staging / "lele-manager.svg")
 
     if archive_format == "tar.gz":
         create_tar_gz(staging, archive, package_name)

--- a/scripts/smoke-native-release.py
+++ b/scripts/smoke-native-release.py
@@ -177,6 +177,63 @@ def find_linux_icon(extraction_root: Path, version: str) -> Path:
     return candidates[0]
 
 
+def desktop_entry_value(desktop_entry: Path, key: str) -> str:
+    prefix = f"{key}="
+    for line in desktop_entry.read_text(encoding="utf-8").splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix) :]
+    raise RuntimeError(f"Voce desktop Linux priva di {key}.")
+
+
+def decode_desktop_string(value: str) -> str:
+    escapes = {"s": " ", "n": "\n", "t": "\t", "r": "\r", "\\": "\\"}
+    decoded: list[str] = []
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if char != "\\":
+            decoded.append(char)
+            index += 1
+            continue
+        if index + 1 == len(value) or value[index + 1] not in escapes:
+            raise RuntimeError(f"Escape desktop non supportato: {value!r}")
+        decoded.append(escapes[value[index + 1]])
+        index += 2
+    return "".join(decoded)
+
+
+def decode_exec_program(value: str) -> str:
+    command_line = decode_desktop_string(value)
+    if len(command_line) < 2 or not (
+        command_line.startswith('"') and command_line.endswith('"')
+    ):
+        raise RuntimeError(f"Exec non e' un singolo token quotato: {value!r}")
+
+    decoded: list[str] = []
+    index = 1
+    while index < len(command_line) - 1:
+        char = command_line[index]
+        if char == "\\":
+            if (
+                index + 1 >= len(command_line) - 1
+                or command_line[index + 1] not in {'"', "`", "$", "\\"}
+            ):
+                raise RuntimeError(f"Escape Exec non valido: {value!r}")
+            decoded.append(command_line[index + 1])
+            index += 2
+        elif char == "%":
+            if index + 1 >= len(command_line) - 1 or command_line[index + 1] != "%":
+                raise RuntimeError(f"Field code Exec inatteso: {value!r}")
+            decoded.append("%")
+            index += 2
+        elif char == '"':
+            raise RuntimeError(f"Virgolette Exec non escaped: {value!r}")
+        else:
+            decoded.append(char)
+            index += 1
+    return "".join(decoded)
+
+
 def choose_free_loopback_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -412,11 +469,21 @@ def run_linux_installed_smoke(
         "Icon=lele-manager",
         "Categories=Development;",
         "StartupNotify=true",
-        f'Exec="{launcher}"',
-        f'TryExec="{launcher}"',
     ):
         if entry not in desktop:
             raise RuntimeError(f"Voce desktop Linux non valida, manca: {entry}")
+    exec_program = decode_exec_program(desktop_entry_value(desktop_entry, "Exec"))
+    if exec_program != str(launcher):
+        raise RuntimeError(
+            "Exec desktop Linux non risolve al launcher stabile: "
+            f"{exec_program!r} != {str(launcher)!r}"
+        )
+    try_exec = decode_desktop_string(desktop_entry_value(desktop_entry, "TryExec"))
+    if try_exec != str(launcher):
+        raise RuntimeError(
+            "TryExec desktop Linux non rappresenta il launcher stabile: "
+            f"{try_exec!r} != {str(launcher)!r}"
+        )
 
     port = choose_free_loopback_port()
     base_url = f"http://127.0.0.1:{port}"

--- a/scripts/smoke-native-release.py
+++ b/scripts/smoke-native-release.py
@@ -163,6 +163,20 @@ def find_linux_installer(extraction_root: Path, version: str) -> Path:
     return candidates[0]
 
 
+def find_linux_icon(extraction_root: Path, version: str) -> Path:
+    candidates = sorted(
+        extraction_root.glob(
+            f"{APP_NAME}-v{version}-Linux-*/lele-manager.svg"
+        )
+    )
+    if len(candidates) != 1 or not candidates[0].is_file():
+        raise RuntimeError(
+            "Icona Linux packaged non trovata in modo univoco: "
+            f"{candidates}"
+        )
+    return candidates[0]
+
+
 def choose_free_loopback_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -333,6 +347,7 @@ def validate_running_release(
 
 def run_linux_installed_smoke(
     installer: Path,
+    packaged_icon: Path,
     version: str,
     temporary_root: Path,
     environment: dict[str, str],
@@ -380,6 +395,28 @@ def run_linux_installed_smoke(
             "Bundle Linux installato assente: "
             f"{installed_executable}"
         )
+    desktop_entry = install_data_home / "applications" / "lele-manager.desktop"
+    installed_icon = (
+        install_data_home / "icons/hicolor/scalable/apps/lele-manager.svg"
+    )
+    if not desktop_entry.is_file():
+        raise RuntimeError(f"Voce desktop Linux installata assente: {desktop_entry}")
+    if not installed_icon.is_file() or installed_icon.read_bytes() != packaged_icon.read_bytes():
+        raise RuntimeError("Icona Linux installata assente o diversa da quella packaged.")
+    desktop = desktop_entry.read_text(encoding="utf-8")
+    for entry in (
+        "[Desktop Entry]",
+        "Type=Application",
+        "Name=LeLe Manager",
+        "Terminal=false",
+        "Icon=lele-manager",
+        "Categories=Development;",
+        "StartupNotify=true",
+        f'Exec="{launcher}"',
+        f'TryExec="{launcher}"',
+    ):
+        if entry not in desktop:
+            raise RuntimeError(f"Voce desktop Linux non valida, manca: {entry}")
 
     port = choose_free_loopback_port()
     base_url = f"http://127.0.0.1:{port}"
@@ -406,7 +443,7 @@ def run_linux_installed_smoke(
         finally:
             terminate_process(process)
 
-    print("OK: installer Linux e launcher stabile verificati.")
+    print("OK: installer Linux, launcher stabile e integrazione desktop verificati.")
 
 
 def main() -> int:
@@ -439,6 +476,7 @@ def main() -> int:
         )
         if os_label == "Linux":
             installer = find_linux_installer(extraction_root, version)
+            packaged_icon = find_linux_icon(extraction_root, version)
             print(f"Installer:    {installer}")
 
         port = choose_free_loopback_port()
@@ -483,6 +521,7 @@ def main() -> int:
         if os_label == "Linux":
             run_linux_installed_smoke(
                 installer,
+                packaged_icon,
                 version,
                 temp_root,
                 environment,

--- a/tests/test_linux_install_contract.py
+++ b/tests/test_linux_install_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER_SOURCE = ROOT / "packaging" / "linux" / "install.sh"
+CANONICAL_ICON = ROOT / "frontend" / "public" / "favicon.svg"
 
 
 def create_extracted_release(
@@ -20,6 +21,7 @@ def create_extracted_release(
     release.mkdir()
     installer = release / "install.sh"
     shutil.copy2(INSTALLER_SOURCE, installer)
+    shutil.copy2(CANONICAL_ICON, release / "lele-manager.svg")
 
     bundle = release / "LeLe-Manager"
     bundle.mkdir()
@@ -94,6 +96,26 @@ def test_clean_install_honors_xdg_data_home_and_creates_stable_launcher(
     assert subprocess.run(
         [str(launcher)], text=True, capture_output=True, check=True
     ).stdout == "payload-a\n"
+    desktop_entry = data_home / "applications" / "lele-manager.desktop"
+    icon = data_home / "icons/hicolor/scalable/apps/lele-manager.svg"
+    assert desktop_entry.is_file()
+    assert icon.read_bytes() == CANONICAL_ICON.read_bytes()
+    desktop = desktop_entry.read_text(encoding="utf-8")
+    assert "[Desktop Entry]" in desktop
+    assert "Type=Application" in desktop
+    assert "Name=LeLe Manager" in desktop
+    assert "Terminal=false" in desktop
+    assert "Icon=lele-manager" in desktop
+    assert "Categories=Development;" in desktop
+    assert "StartupNotify=true" in desktop
+    assert f'Exec="{launcher}"' in desktop
+    assert f'TryExec="{launcher}"' in desktop
+    assert "~" not in desktop
+    assert "$HOME" not in desktop
+    assert "/home/baltimora" not in desktop
+    assert "1.2.3" not in desktop
+    assert str(release) not in desktop
+    assert str(app) not in desktop
 
 
 def test_default_paths_use_home_local_conventions_without_real_home_writes(
@@ -131,6 +153,9 @@ def test_reinstall_is_idempotent_and_preserves_launcher_identity(
     assert launcher.lstat().st_ino == original_inode
     assert list((data_home / "lele-manager").iterdir()) == [
         data_home / "lele-manager" / "install"
+    ]
+    assert list((data_home / "applications").glob("lele-manager.desktop")) == [
+        data_home / "applications" / "lele-manager.desktop"
     ]
 
 
@@ -179,6 +204,12 @@ def test_upgrade_replaces_only_stable_app_payload_and_preserves_user_state(
         "1.2." in str(path)
         for path in (data_home / "lele-manager").rglob("*")
     )
+    desktop = (data_home / "applications/lele-manager.desktop").read_text(
+        encoding="utf-8"
+    )
+    assert f'Exec="{launcher}"' in desktop
+    assert f'TryExec="{launcher}"' in desktop
+    assert (data_home / "icons/hicolor/scalable/apps/lele-manager.svg").is_file()
 
 
 def test_invalid_source_fails_before_replacing_existing_installation(
@@ -208,6 +239,35 @@ def test_invalid_source_fails_before_replacing_existing_installation(
     ).stdout == "payload-a\n"
 
 
+def test_missing_icon_fails_before_replacing_desktop_resources(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    data_home = tmp_path / "data"
+    bin_dir = tmp_path / "bin"
+    good_release = create_extracted_release(tmp_path, "good", "payload-a")
+    invalid_release = create_extracted_release(tmp_path, "invalid", "payload-b")
+    (invalid_release / "lele-manager.svg").unlink()
+
+    good = install(good_release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+    desktop = data_home / "applications/lele-manager.desktop"
+    icon = data_home / "icons/hicolor/scalable/apps/lele-manager.svg"
+    old_desktop = desktop.read_bytes()
+    old_icon = icon.read_bytes()
+    failed = install(
+        invalid_release, home, xdg_data_home=data_home, bin_dir=bin_dir
+    )
+
+    assert good.returncode == 0, good.stderr
+    assert failed.returncode != 0
+    assert "icona Linux assente" in failed.stderr
+    assert desktop.read_bytes() == old_desktop
+    assert icon.read_bytes() == old_icon
+    assert subprocess.run(
+        [str(bin_dir / "lele-manager")], text=True, capture_output=True, check=True
+    ).stdout == "payload-a\n"
+
+
 def test_existing_unowned_launcher_is_not_overwritten(tmp_path: Path) -> None:
     home = tmp_path / "home"
     data_home = tmp_path / "data"
@@ -223,6 +283,92 @@ def test_existing_unowned_launcher_is_not_overwritten(tmp_path: Path) -> None:
     assert "non appartiene a LeLe Manager" in result.stderr
     assert foreign.read_text(encoding="utf-8") == "do not replace\n"
     assert not (data_home / "lele-manager" / "install" / "app").exists()
+
+
+def test_existing_unrelated_desktop_entry_is_not_overwritten(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    data_home = tmp_path / "data"
+    bin_dir = tmp_path / "bin"
+    foreign = data_home / "applications/lele-manager.desktop"
+    foreign.parent.mkdir(parents=True)
+    foreign.write_text("[Desktop Entry]\nName=Other App\n", encoding="utf-8")
+    release = create_extracted_release(tmp_path, "release", "payload-a")
+
+    result = install(release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+
+    assert result.returncode != 0
+    assert "voce desktop esistente non appartiene" in result.stderr
+    assert foreign.read_text(encoding="utf-8") == "[Desktop Entry]\nName=Other App\n"
+    assert not (data_home / "lele-manager" / "install" / "app").exists()
+
+
+def test_existing_desktop_entry_symlink_is_rejected(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    data_home = tmp_path / "data"
+    bin_dir = tmp_path / "bin"
+    foreign = tmp_path / "foreign.desktop"
+    foreign.write_text("[Desktop Entry]\n", encoding="utf-8")
+    desktop = data_home / "applications/lele-manager.desktop"
+    desktop.parent.mkdir(parents=True)
+    desktop.symlink_to(foreign)
+    release = create_extracted_release(tmp_path, "release", "payload-a")
+
+    result = install(release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+
+    assert result.returncode != 0
+    assert "non deve essere un link simbolico" in result.stderr
+    assert desktop.is_symlink()
+
+
+def test_custom_launcher_path_with_spaces_is_desktop_entry_escaped(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home with spaces"
+    data_home = tmp_path / "data with spaces"
+    bin_dir = tmp_path / "bin with spaces"
+    release = create_extracted_release(tmp_path, "release with spaces", "payload-a")
+
+    result = install(release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    launcher = bin_dir / "lele-manager"
+    desktop = (data_home / "applications/lele-manager.desktop").read_text(
+        encoding="utf-8"
+    )
+    assert f'Exec="{launcher}"' in desktop
+    assert f'TryExec="{launcher}"' in desktop
+    validator = shutil.which("desktop-file-validate")
+    if validator:
+        validation = subprocess.run(
+            [validator, str(data_home / "applications/lele-manager.desktop")],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert validation.returncode == 0, validation.stderr
+
+
+def test_recognizable_manual_desktop_entry_is_adopted(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    data_home = tmp_path / "data"
+    bin_dir = tmp_path / "bin"
+    launcher = bin_dir / "lele-manager"
+    desktop = data_home / "applications/lele-manager.desktop"
+    desktop.parent.mkdir(parents=True)
+    desktop.write_text(
+        "[Desktop Entry]\nType=Application\nName=LeLe Manager\n"
+        f"Exec={launcher}\nTryExec={launcher}\nIcon=lele-manager\n"
+        "Terminal=false\nCategories=Development;\nStartupNotify=true\n",
+        encoding="utf-8",
+    )
+    release = create_extracted_release(tmp_path, "release", "payload-a")
+
+    result = install(release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert "X-LeLe-Manager-Installer=true" in desktop.read_text(encoding="utf-8")
 
 
 def test_distributed_installer_has_no_developer_home_or_release_version() -> None:

--- a/tests/test_linux_install_contract.py
+++ b/tests/test_linux_install_contract.py
@@ -5,9 +5,77 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER_SOURCE = ROOT / "packaging" / "linux" / "install.sh"
 CANONICAL_ICON = ROOT / "frontend" / "public" / "favicon.svg"
+
+
+def desktop_entry_values(desktop_entry: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in desktop_entry.read_text(encoding="utf-8").splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key] = value
+    return values
+
+
+def decode_desktop_string(value: str) -> str:
+    escapes = {"s": " ", "n": "\n", "t": "\t", "r": "\r", "\\": "\\"}
+    decoded: list[str] = []
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if char != "\\":
+            decoded.append(char)
+            index += 1
+            continue
+        if index + 1 == len(value) or value[index + 1] not in escapes:
+            raise AssertionError(f"unsupported desktop string escape: {value!r}")
+        decoded.append(escapes[value[index + 1]])
+        index += 2
+    return "".join(decoded)
+
+
+def decode_exec_program(value: str) -> str:
+    command_line = decode_desktop_string(value)
+    if len(command_line) < 2 or not (
+        command_line.startswith('"') and command_line.endswith('"')
+    ):
+        raise AssertionError(f"Exec program is not one quoted token: {value!r}")
+
+    decoded: list[str] = []
+    index = 1
+    while index < len(command_line) - 1:
+        char = command_line[index]
+        if char == "\\":
+            if (
+                index + 1 >= len(command_line) - 1
+                or command_line[index + 1] not in {'"', "`", "$", "\\"}
+            ):
+                raise AssertionError(f"invalid Exec quote escape: {value!r}")
+            decoded.append(command_line[index + 1])
+            index += 2
+        elif char == "%":
+            if index + 1 >= len(command_line) - 1 or command_line[index + 1] != "%":
+                raise AssertionError(f"unexpected Exec field code: {value!r}")
+            decoded.append("%")
+            index += 2
+        elif char == '"':
+            raise AssertionError(f"unescaped quote inside Exec token: {value!r}")
+        else:
+            decoded.append(char)
+            index += 1
+    return "".join(decoded)
+
+
+def assert_desktop_launcher_contract(desktop_entry: Path, launcher: Path) -> None:
+    values = desktop_entry_values(desktop_entry)
+    assert decode_exec_program(values["Exec"]) == str(launcher)
+    assert decode_desktop_string(values["TryExec"]) == str(launcher)
+    assert not values["TryExec"].startswith('"')
+    assert not values["TryExec"].endswith('"')
 
 
 def create_extracted_release(
@@ -108,8 +176,7 @@ def test_clean_install_honors_xdg_data_home_and_creates_stable_launcher(
     assert "Icon=lele-manager" in desktop
     assert "Categories=Development;" in desktop
     assert "StartupNotify=true" in desktop
-    assert f'Exec="{launcher}"' in desktop
-    assert f'TryExec="{launcher}"' in desktop
+    assert_desktop_launcher_contract(desktop_entry, launcher)
     assert "~" not in desktop
     assert "$HOME" not in desktop
     assert "/home/baltimora" not in desktop
@@ -204,11 +271,10 @@ def test_upgrade_replaces_only_stable_app_payload_and_preserves_user_state(
         "1.2." in str(path)
         for path in (data_home / "lele-manager").rglob("*")
     )
-    desktop = (data_home / "applications/lele-manager.desktop").read_text(
-        encoding="utf-8"
+    assert_desktop_launcher_contract(
+        data_home / "applications/lele-manager.desktop",
+        launcher,
     )
-    assert f'Exec="{launcher}"' in desktop
-    assert f'TryExec="{launcher}"' in desktop
     assert (data_home / "icons/hicolor/scalable/apps/lele-manager.svg").is_file()
 
 
@@ -322,7 +388,7 @@ def test_existing_desktop_entry_symlink_is_rejected(tmp_path: Path) -> None:
     assert desktop.is_symlink()
 
 
-def test_custom_launcher_path_with_spaces_is_desktop_entry_escaped(
+def test_custom_launcher_path_with_spaces_preserves_both_desktop_contracts(
     tmp_path: Path,
 ) -> None:
     home = tmp_path / "home with spaces"
@@ -334,11 +400,10 @@ def test_custom_launcher_path_with_spaces_is_desktop_entry_escaped(
 
     assert result.returncode == 0, result.stderr
     launcher = bin_dir / "lele-manager"
-    desktop = (data_home / "applications/lele-manager.desktop").read_text(
-        encoding="utf-8"
-    )
-    assert f'Exec="{launcher}"' in desktop
-    assert f'TryExec="{launcher}"' in desktop
+    desktop_entry = data_home / "applications/lele-manager.desktop"
+    values = desktop_entry_values(desktop_entry)
+    assert_desktop_launcher_contract(desktop_entry, launcher)
+    assert values["TryExec"] == str(launcher)
     validator = shutil.which("desktop-file-validate")
     if validator:
         validation = subprocess.run(
@@ -348,6 +413,103 @@ def test_custom_launcher_path_with_spaces_is_desktop_entry_escaped(
             check=False,
         )
         assert validation.returncode == 0, validation.stderr
+
+
+@pytest.mark.parametrize(
+    ("directory_name", "expected_exec_fragment", "expected_try_exec_fragment"),
+    [
+        ("bin%percent", "%%", "%"),
+        (r"bin\backslash", "\\\\\\\\", "\\\\"),
+        ("bin$dollar", r"\\$", "$"),
+        ("bin`backtick", r"\\`", "`"),
+        ('bin"quote', r'\\"', '"'),
+    ],
+)
+def test_special_launcher_paths_round_trip_through_distinct_desktop_layers(
+    tmp_path: Path,
+    directory_name: str,
+    expected_exec_fragment: str,
+    expected_try_exec_fragment: str,
+) -> None:
+    home = tmp_path / "home"
+    data_home = tmp_path / "data"
+    bin_dir = tmp_path / directory_name
+    release = create_extracted_release(tmp_path, "release", "payload-a")
+
+    result = install(release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    launcher = bin_dir / "lele-manager"
+    desktop_entry = data_home / "applications/lele-manager.desktop"
+    values = desktop_entry_values(desktop_entry)
+    assert_desktop_launcher_contract(desktop_entry, launcher)
+    assert expected_exec_fragment in values["Exec"]
+    assert expected_try_exec_fragment in values["TryExec"]
+
+
+def test_equal_in_launcher_path_fails_before_replacing_desktop_resources(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    data_home = tmp_path / "data"
+    bin_dir = tmp_path / "bin"
+    good_release = create_extracted_release(tmp_path, "good", "payload-a")
+    invalid_release = create_extracted_release(tmp_path, "invalid", "payload-b")
+
+    good = install(good_release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+    desktop = data_home / "applications/lele-manager.desktop"
+    icon = data_home / "icons/hicolor/scalable/apps/lele-manager.svg"
+    old_desktop = desktop.read_bytes()
+    old_icon = icon.read_bytes()
+    failed = install(
+        invalid_release,
+        home,
+        xdg_data_home=data_home,
+        bin_dir=tmp_path / "bin=invalid",
+    )
+
+    assert good.returncode == 0, good.stderr
+    assert failed.returncode != 0
+    assert "non puo' contenere '=' per Exec" in failed.stderr
+    assert desktop.read_bytes() == old_desktop
+    assert icon.read_bytes() == old_icon
+    assert subprocess.run(
+        [str(bin_dir / "lele-manager")], text=True, capture_output=True, check=True
+    ).stdout == "payload-a\n"
+
+
+@pytest.mark.parametrize(
+    ("invalid_character", "expected_error"),
+    [("\n", "non puo' contenere newline"), ("\r", "non puo' contenere newline"), ("\x1f", "caratteri di controllo")],
+)
+def test_control_character_launcher_paths_are_rejected(
+    tmp_path: Path,
+    invalid_character: str,
+    expected_error: str,
+) -> None:
+    home = tmp_path / "home"
+    data_home = tmp_path / "data"
+    bin_dir = tmp_path / "bin"
+    good_release = create_extracted_release(tmp_path, "good", "payload-a")
+    invalid_release = create_extracted_release(tmp_path, "invalid", "payload-b")
+
+    good = install(good_release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+    desktop = data_home / "applications/lele-manager.desktop"
+    icon = data_home / "icons/hicolor/scalable/apps/lele-manager.svg"
+    old_desktop = desktop.read_bytes()
+    old_icon = icon.read_bytes()
+    failed = install(
+        invalid_release,
+        home,
+        xdg_data_home=data_home,
+        bin_dir=tmp_path / f"bin{invalid_character}invalid",
+    )
+
+    assert good.returncode == 0, good.stderr
+    assert failed.returncode != 0
+    assert expected_error in failed.stderr
+    assert desktop.read_bytes() == old_desktop
+    assert icon.read_bytes() == old_icon
 
 
 def test_recognizable_manual_desktop_entry_is_adopted(tmp_path: Path) -> None:
@@ -369,6 +531,30 @@ def test_recognizable_manual_desktop_entry_is_adopted(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     assert "X-LeLe-Manager-Installer=true" in desktop.read_text(encoding="utf-8")
+
+
+def test_manual_desktop_entry_with_escaping_sensitive_path_is_not_adopted(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    data_home = tmp_path / "data"
+    bin_dir = tmp_path / "bin with spaces"
+    launcher = bin_dir / "lele-manager"
+    desktop = data_home / "applications/lele-manager.desktop"
+    desktop.parent.mkdir(parents=True)
+    legacy_entry = (
+        "[Desktop Entry]\nType=Application\nName=LeLe Manager\n"
+        f"Exec={launcher}\nTryExec={launcher}\nIcon=lele-manager\n"
+        "Terminal=false\nCategories=Development;\nStartupNotify=true\n"
+    )
+    desktop.write_text(legacy_entry, encoding="utf-8")
+    release = create_extracted_release(tmp_path, "release", "payload-a")
+
+    result = install(release, home, xdg_data_home=data_home, bin_dir=bin_dir)
+
+    assert result.returncode != 0
+    assert "voce desktop esistente non appartiene" in result.stderr
+    assert desktop.read_text(encoding="utf-8") == legacy_entry
 
 
 def test_distributed_installer_has_no_developer_home_or_release_version() -> None:

--- a/tests/test_native_release_smoke.py
+++ b/tests/test_native_release_smoke.py
@@ -14,6 +14,7 @@ find_release_archive = SMOKE["find_release_archive"]
 extract_release_archive = SMOKE["extract_release_archive"]
 assert_isolated_runtime_paths = SMOKE["assert_isolated_runtime_paths"]
 find_linux_installer = SMOKE["find_linux_installer"]
+find_linux_icon = SMOKE["find_linux_icon"]
 run_linux_installed_smoke = SMOKE["run_linux_installed_smoke"]
 
 
@@ -105,6 +106,17 @@ def test_find_linux_installer_requires_an_executable_at_archive_root(
     installer.chmod(0o755)
 
     assert find_linux_installer(tmp_path, "1.2.3") == installer
+
+
+def test_find_linux_icon_requires_the_packaged_installation_resource(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "LeLe-Manager-v1.2.3-Linux-x86_64"
+    root.mkdir()
+    icon = root / "lele-manager.svg"
+    icon.write_text("<svg/>", encoding="utf-8")
+
+    assert find_linux_icon(tmp_path, "1.2.3") == icon
 
 
 def test_linux_installed_smoke_is_part_of_the_published_archive_contract() -> None:

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -111,6 +111,8 @@ def test_linux_native_release_ships_the_user_local_installer() -> None:
     assert installer.stat().st_mode & 0o111
     assert 'LINUX_INSTALLER = ROOT / "packaging" / "linux" / "install.sh"' in script
     assert 'shutil.copy2(LINUX_INSTALLER, staging / "install.sh")' in script
+    assert 'LINUX_ICON = ROOT / "frontend" / "public" / "favicon.svg"' in script
+    assert 'shutil.copy2(LINUX_ICON, staging / "lele-manager.svg")' in script
 
 def test_pypi_publication_uses_dedicated_manual_trusted_workflow() -> None:
     release = read(".github/workflows/release.yml")


### PR DESCRIPTION
Closes #178

## Summary

#200 established the stable user-local Linux installation contract that this change extends. `install.sh` now installs the product-owned desktop entry at `${XDG_DATA_HOME:-$HOME/.local/share}/applications/lele-manager.desktop` and the canonical icon at `${XDG_DATA_HOME:-$HOME/.local/share}/icons/hicolor/scalable/apps/lele-manager.svg`.

The entry renders the stable absolute `Exec` launcher as one command-line executable token: it applies Exec token quoting and then desktop-entry string escaping. `TryExec` is rendered separately as a desktop-entry string path, with only string-layer escaping and never Exec wrapper quotes. This covers custom absolute `LELE_MANAGER_INSTALL_BIN_DIR` paths; `Exec` rejects a launcher path containing `=`. The launcher, desktop path, and icon lookup name remain stable across reinstall and upgrade.

The release archive ships `frontend/public/favicon.svg` as `lele-manager.svg`, so installation needs no checkout or network access. Portable execution still does not register desktop resources. Reinstalls adopt a narrowly recognizable previous manual workaround, replace marked product resources atomically, and reject unrelated or symlink desktop collisions.

## Validation

- Focused Linux installation, packaging, and smoke tests
- `ruff check .`
- `mypy src/lele_manager`
- Full pytest
- Native Linux PyInstaller build, archive inspection, portable smoke, and installed launcher + desktop integration smoke