### PR TITLE
ux: differentiate sidebar icons

### DIFF
--- a/frontend/e2e/product-shell.spec.ts
+++ b/frontend/e2e/product-shell.spec.ts
@@ -64,6 +64,76 @@ test.describe('product shell hierarchy', () => {
     }
   })
 
+  test('maps every navigation destination to its distinct semantic icon', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/browse')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+    const expectedIcons = [
+      ['Dashboard', 'dashboard'],
+      ['Browse', 'browse'],
+      ['Timeline', 'timeline'],
+      ['Statistics', 'stats'],
+      ['New LeLe', 'new'],
+      ['Collection', 'collection'],
+      ['Vault', 'vault'],
+      ['Duplicates', 'duplicates'],
+      ['System', 'system'],
+      ['Diagnostics', 'diagnostics'],
+      ['About', 'about'],
+    ] as const
+
+    for (const [label, icon] of expectedIcons) {
+      const link = navigation.getByRole('link', {
+        name: label,
+        exact: true,
+      })
+      const svg = link.locator('svg')
+
+      await expect(svg).toHaveAttribute('data-icon', icon)
+      await expect(svg).toHaveAttribute('aria-hidden', 'true')
+    }
+
+    expect(new Set(expectedIcons.map(([, icon]) => icon)).size).toBe(
+      expectedIcons.length,
+    )
+    await expect(
+      navigation.getByRole('link', { name: 'Browse', exact: true }),
+    ).toHaveAttribute('aria-current', 'page')
+    await expect(
+      navigation.getByRole('link', { name: 'System', exact: true }),
+    ).not.toHaveAttribute('aria-current')
+    await expect(
+      navigation.locator('a[aria-current="page"]'),
+    ).toHaveCount(1)
+  })
+
+  test('keeps semantic icon identities stable when localized', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/')
+
+    await page.getByLabel('Language').selectOption('it')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+    const expectedIcons = [
+      ['Sistema', 'system'],
+      ['Diagnostica', 'diagnostics'],
+      ['Informazioni', 'about'],
+    ] as const
+
+    for (const [label, icon] of expectedIcons) {
+      await expect(
+        navigation.getByRole('link', { name: label, exact: true }).locator('svg'),
+      ).toHaveAttribute('data-icon', icon)
+    }
+  })
+
   test('shows bounded runtime and workspace context', async ({
     page,
   }) => {

--- a/frontend/src/components/NavIcon.svelte
+++ b/frontend/src/components/NavIcon.svelte
@@ -10,6 +10,7 @@
     | 'duplicates'
     | 'system'
     | 'diagnostics'
+    | 'about'
 
   interface Props {
     name: IconName
@@ -28,6 +29,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
   aria-hidden="true"
+  data-icon={name}
 >
   {#if name === 'dashboard'}
     <rect x="4" y="4" width="6" height="6" rx="1" />
@@ -56,13 +58,17 @@
   {:else if name === 'duplicates'}
     <rect x="4" y="4" width="11" height="11" rx="2" />
     <rect x="9" y="9" width="11" height="11" rx="2" />
+  {:else if name === 'system'}
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12 3v2M12 19v2M3 12h2M19 12h2" />
+    <path d="m5.6 5.6 1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4" />
   {:else if name === 'diagnostics'}
     <circle cx="11" cy="11" r="6" />
     <path d="m16 16 4 4" />
     <path d="M8.5 11h5M11 8.5v5" />
-  {:else}
-    <circle cx="12" cy="12" r="3" />
-    <path d="M12 3v2M12 19v2M3 12h2M19 12h2" />
-    <path d="m5.6 5.6 1.4 1.4M17 17l1.4 1.4M18.4 5.6 17 7M7 17l-1.4 1.4" />
+  {:else if name === 'about'}
+    <circle cx="12" cy="12" r="8" />
+    <path d="M12 11v5" />
+    <path d="M12 8h.01" />
   {/if}
 </svg>

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -41,7 +41,7 @@
         { view: 'duplicates' as const, labelKey: 'navDuplicates' as const, hash: '#/duplicates', icon: 'duplicates' as const },
         { view: 'ops' as const, labelKey: 'navSystem' as const, hash: '#/ops', icon: 'system' as const },
         { view: 'settings' as const, labelKey: 'navSettings' as const, hash: '#/settings', icon: 'diagnostics' as const },
-        { view: 'about' as const, labelKey: 'navAbout' as const, hash: '#/about', icon: 'system' as const },
+        { view: 'about' as const, labelKey: 'navAbout' as const, hash: '#/about', icon: 'about' as const },
       ],
     },
   ]
@@ -105,6 +105,7 @@
               <a
                 href={link.hash}
                 class:active={isActive(link.view)}
+                aria-current={isActive(link.view) ? 'page' : undefined}
                 onclick={(e) => {
                   e.preventDefault()
                   navigate({ view: link.view })


### PR DESCRIPTION
Closes #181

## Summary

- Audited all 11 maintained sidebar destinations; System and About were the only material semantic collision.
- Kept System as the explicit maintenance/operations gear and retained Diagnostics' dedicated inspection magnifier from #187.
- Added a dedicated local information icon for About and exposed stable decorative SVG identities through `data-icon`.
- Added `aria-current="page"` for the active navigation destination while preserving visible labels, focus styles, active/hover behavior, and `currentColor` inheritance.
- Added E2E coverage for the full destination-to-icon mapping, uniqueness, EN/IT stability, decorative SVG behavior, and active navigation state.

No other material icon collisions were found.

## Validation

- `npm run check`
- `npm run build`
- Focused product-shell, localization, and brand E2E tests (27 passed)
- Full `npm run test:e2e` (78 tests, 1 existing skipped documentation-screenshot test)