### PR TITLE
ux: make sidebar groups collapsible

### DIFF
--- a/frontend/e2e/mascot-motion.spec.ts
+++ b/frontend/e2e/mascot-motion.spec.ts
@@ -1,4 +1,32 @@
-import { expect, test } from '@playwright/test'
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+} from '@playwright/test'
+
+async function tabUntilFocused(
+  page: Page,
+  target: Locator,
+  safetyBound: number,
+) {
+  for (let step = 0; step < safetyBound; step += 1) {
+    if (
+      await target.evaluate(
+        (element) => document.activeElement === element,
+      )
+    ) {
+      return
+    }
+
+    await page.keyboard.press('Tab')
+  }
+
+  await expect(
+    target,
+    `Expected the New LeLe CTA to be reachable within ${safetyBound} Tab presses`,
+  ).toBeFocused()
+}
 
 test.describe('LeLe monkey motion', () => {
   test('keeps motion restrained and scoped to the New LeLe mascot', async ({
@@ -61,19 +89,7 @@ test.describe('LeLe monkey motion', () => {
       .getByTestId('lele-monkey-motion')
       .locator('img')
 
-    for (let step = 0; step < 16; step += 1) {
-      if (
-        await action.evaluate(
-          (element) => document.activeElement === element,
-        )
-      ) {
-        break
-      }
-
-      await page.keyboard.press('Tab')
-    }
-
-    await expect(action).toBeFocused()
+    await tabUntilFocused(page, action, 48)
     await expect(action).toHaveAccessibleName('New LeLe')
     await expect(image).toHaveCSS(
       'animation-name',

--- a/frontend/e2e/product-shell.spec.ts
+++ b/frontend/e2e/product-shell.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test'
 
+const navigationGroupsStorageKey =
+  'lele-manager.navigation-groups.v1'
+
 test.describe('product shell hierarchy', () => {
   test('groups navigation into Knowledge, Capture, and Manage', async ({
     page,
@@ -20,6 +23,12 @@ test.describe('product shell hierarchy', () => {
       navigation.getByRole('region', { name: 'Manage' }),
     ).toBeVisible()
 
+    for (const label of ['Knowledge', 'Capture', 'Manage']) {
+      await expect(
+        navigation.getByRole('button', { name: label, exact: true }),
+      ).toHaveAttribute('aria-expanded', 'true')
+    }
+
     for (const label of [
       'Dashboard',
       'Browse',
@@ -39,6 +48,163 @@ test.describe('product shell hierarchy', () => {
     }
   })
 
+  test('toggles independent inactive groups with accessible disclosure semantics', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/settings')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+    const knowledge = navigation.getByRole('button', {
+      name: 'Knowledge',
+      exact: true,
+    })
+    const capture = navigation.getByRole('button', {
+      name: 'Capture',
+      exact: true,
+    })
+    const knowledgeLinks = page.locator('#navigation-group-knowledge')
+
+    await expect(knowledge).toHaveAttribute('aria-controls', 'navigation-group-knowledge')
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'true')
+    await expect(knowledge.locator('svg')).toHaveAttribute('aria-hidden', 'true')
+
+    await knowledge.click()
+
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
+    await expect(knowledgeLinks).toBeHidden()
+    await expect(knowledgeLinks.getByRole('link')).toHaveCount(0)
+    await expect(capture).toHaveAttribute('aria-expanded', 'true')
+
+    await knowledge.focus()
+    await page.keyboard.press('Space')
+
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'true')
+    await expect(knowledgeLinks).toBeVisible()
+  })
+
+  test('opens the active group for deep links and stale stored state', async ({
+    page,
+  }) => {
+    await page.addInitScript((key) => {
+      window.localStorage.setItem(key, JSON.stringify({
+        knowledge: true,
+        capture: true,
+        manage: false,
+      }))
+    }, navigationGroupsStorageKey)
+    await page.goto('/app/#/settings')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+
+    await expect(
+      navigation.getByRole('button', { name: 'Manage', exact: true }),
+    ).toHaveAttribute('aria-expanded', 'true')
+    await expect(
+      navigation.getByRole('link', { name: 'Diagnostics', exact: true }),
+    ).toBeVisible()
+    await expect(
+      navigation.getByRole('link', { name: 'Diagnostics', exact: true }),
+    ).toHaveAttribute('aria-current', 'page')
+    await expect(navigation.locator('a[aria-current="page"]')).toHaveCount(1)
+
+    await navigation.getByRole('button', {
+      name: 'Manage',
+      exact: true,
+    }).click()
+    await expect(
+      navigation.getByRole('button', { name: 'Manage', exact: true }),
+    ).toHaveAttribute('aria-expanded', 'true')
+    await expect(
+      navigation.getByRole('link', { name: 'Diagnostics', exact: true }),
+    ).toBeVisible()
+  })
+
+  test('opens a newly active group without changing unrelated preferences', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/browse')
+
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary',
+    })
+    const manage = navigation.getByRole('button', {
+      name: 'Manage',
+      exact: true,
+    })
+
+    await manage.click()
+    await expect(manage).toHaveAttribute('aria-expanded', 'false')
+
+    await navigation.getByRole('link', {
+      name: 'New LeLe',
+      exact: true,
+    }).click()
+
+    await expect(
+      navigation.getByRole('button', { name: 'Capture', exact: true }),
+    ).toHaveAttribute('aria-expanded', 'true')
+    await expect(
+      navigation.getByRole('link', { name: 'New LeLe', exact: true }),
+    ).toHaveAttribute('aria-current', 'page')
+    await expect(manage).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('persists valid disclosure state and safely ignores malformed storage', async ({
+    page,
+  }) => {
+    await page.goto('/app/#/settings')
+
+    const knowledge = page.getByRole('button', {
+      name: 'Knowledge',
+      exact: true,
+    })
+    await knowledge.click()
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
+    await expect.poll(async () => page.evaluate((key) => (
+      window.localStorage.getItem(key)
+    ), navigationGroupsStorageKey)).toBe(JSON.stringify({
+      knowledge: false,
+      capture: true,
+      manage: true,
+    }))
+
+    await page.reload()
+    await expect.poll(async () => page.evaluate((key) => (
+      window.localStorage.getItem(key)
+    ), navigationGroupsStorageKey)).toBe(JSON.stringify({
+      knowledge: false,
+      capture: true,
+      manage: true,
+    }))
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
+
+    await page.evaluate((key) => {
+      window.localStorage.setItem(key, '{not valid json')
+    }, navigationGroupsStorageKey)
+    await page.reload()
+
+    for (const label of ['Knowledge', 'Capture', 'Manage']) {
+      await expect(
+        page.getByRole('button', { name: label, exact: true }),
+      ).toHaveAttribute('aria-expanded', 'true')
+    }
+
+    await page.evaluate((key) => {
+      window.localStorage.setItem(key, JSON.stringify({ obsolete: false }))
+    }, navigationGroupsStorageKey)
+    await page.reload()
+
+    for (const label of ['Knowledge', 'Capture', 'Manage']) {
+      await expect(
+        page.getByRole('button', { name: label, exact: true }),
+      ).toHaveAttribute('aria-expanded', 'true')
+    }
+  })
+
   test('uses deterministic local SVG navigation icons', async ({
     page,
   }) => {
@@ -48,7 +214,7 @@ test.describe('product shell hierarchy', () => {
       name: 'Primary',
     })
 
-    await expect(navigation.locator('svg')).toHaveCount(11)
+    await expect(navigation.locator('svg[data-icon]')).toHaveCount(11)
 
     for (const emoji of [
       '🏠',
@@ -177,6 +343,10 @@ test.describe('product shell hierarchy', () => {
     ).toBeVisible()
 
     await expect(
+      navigation.getByRole('button', { name: 'Conoscenza', exact: true }),
+    ).toHaveAttribute('aria-expanded', 'true')
+
+    await expect(
       navigation.getByRole('link', { name: 'Dashboard' }),
     ).toHaveAttribute('href', '#/')
     await expect(
@@ -188,6 +358,26 @@ test.describe('product shell hierarchy', () => {
     await expect(
       navigation.getByRole('link', { name: 'Sistema' }),
     ).toHaveAttribute('href', '#/ops')
+  })
+
+  test('keeps disclosure state when the locale changes', async ({ page }) => {
+    await page.goto('/app/#/settings')
+
+    const knowledge = page.getByRole('button', {
+      name: 'Knowledge',
+      exact: true,
+    })
+    await knowledge.click()
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
+
+    await page.getByLabel('Language').selectOption('it')
+
+    await expect(
+      page.getByRole('button', { name: 'Conoscenza', exact: true }),
+    ).toHaveAttribute('aria-expanded', 'false')
+    await expect(
+      page.getByRole('button', { name: 'Acquisizione', exact: true }),
+    ).toHaveAttribute('aria-expanded', 'true')
   })
 })
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -15,7 +15,11 @@
   import About from './routes/About.svelte'
   import { parseRoute, type Route } from './lib/router'
 
-  let route = $state<Route>({ view: 'dashboard' })
+  let route = $state<Route>(
+    typeof window === 'undefined'
+      ? { view: 'dashboard' }
+      : parseRoute(),
+  )
 
   onMount(() => {
     route = parseRoute()

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -17,8 +17,28 @@
 
   let { route, children }: Props = $props()
 
+  type NavigationGroupId = 'knowledge' | 'capture' | 'manage'
+
+  type NavigationGroupState = Record<NavigationGroupId, boolean>
+
+  const NAVIGATION_GROUPS_STORAGE_KEY =
+    'lele-manager.navigation-groups.v1'
+
+  const navigationGroupIds: NavigationGroupId[] = [
+    'knowledge',
+    'capture',
+    'manage',
+  ]
+
+  const defaultNavigationGroupState: NavigationGroupState = {
+    knowledge: true,
+    capture: true,
+    manage: true,
+  }
+
   const navigationGroups = [
     {
+      id: 'knowledge' as const,
       labelKey: 'navGroupKnowledge' as const,
       links: [
         { view: 'dashboard' as const, labelKey: 'navDashboard' as const, hash: '#/', icon: 'dashboard' as const },
@@ -28,6 +48,7 @@
       ],
     },
     {
+      id: 'capture' as const,
       labelKey: 'navGroupCapture' as const,
       links: [
         { view: 'editor' as const, labelKey: 'navNewLele' as const, hash: '#/editor', icon: 'new' as const },
@@ -35,6 +56,7 @@
       ],
     },
     {
+      id: 'manage' as const,
       labelKey: 'navGroupManage' as const,
       links: [
         { view: 'vault' as const, labelKey: 'navVault' as const, hash: '#/vault', icon: 'vault' as const },
@@ -48,6 +70,9 @@
 
   let appVersion = $state<string | null>(null)
   let workspaceName = $state<string | null>(null)
+  let navigationGroupState = $state<NavigationGroupState>(
+    loadNavigationGroupState(),
+  )
 
   function basename(path: string): string {
     const parts = path.split(/[\\/]+/).filter(Boolean)
@@ -80,6 +105,86 @@
   function isActive(view: Route['view']) {
     return route.view === view || (view === 'editor' && route.view === 'editor')
   }
+
+  function activeNavigationGroup(): NavigationGroupId | undefined {
+    return navigationGroups.find((group) =>
+      group.links.some((link) => isActive(link.view)),
+    )?.id
+  }
+
+  function loadNavigationGroupState(): NavigationGroupState {
+    if (typeof window === 'undefined') {
+      return { ...defaultNavigationGroupState }
+    }
+
+    try {
+      const persisted = JSON.parse(
+        window.localStorage.getItem(NAVIGATION_GROUPS_STORAGE_KEY) ?? 'null',
+      )
+
+      if (!persisted || typeof persisted !== 'object' || Array.isArray(persisted)) {
+        return { ...defaultNavigationGroupState }
+      }
+
+      if (Object.keys(persisted).some((key) => !navigationGroupIds.includes(
+        key as NavigationGroupId,
+      ))) {
+        return { ...defaultNavigationGroupState }
+      }
+
+      return {
+        knowledge: typeof persisted.knowledge === 'boolean'
+          ? persisted.knowledge
+          : defaultNavigationGroupState.knowledge,
+        capture: typeof persisted.capture === 'boolean'
+          ? persisted.capture
+          : defaultNavigationGroupState.capture,
+        manage: typeof persisted.manage === 'boolean'
+          ? persisted.manage
+          : defaultNavigationGroupState.manage,
+      }
+    } catch {
+      return { ...defaultNavigationGroupState }
+    }
+  }
+
+  function persistNavigationGroupState() {
+    if (typeof window === 'undefined') return
+
+    try {
+      window.localStorage.setItem(
+        NAVIGATION_GROUPS_STORAGE_KEY,
+        JSON.stringify(navigationGroupState),
+      )
+    } catch {
+      // Persistence is best-effort; disclosure still works in this session.
+    }
+  }
+
+  function expandActiveNavigationGroup() {
+    const groupId = activeNavigationGroup()
+
+    if (groupId && !navigationGroupState[groupId]) {
+      navigationGroupState[groupId] = true
+      persistNavigationGroupState()
+    }
+  }
+
+  function toggleNavigationGroup(groupId: NavigationGroupId) {
+    if (groupId === activeNavigationGroup()) {
+      expandActiveNavigationGroup()
+      return
+    }
+
+    navigationGroupState[groupId] = !navigationGroupState[groupId]
+    persistNavigationGroupState()
+  }
+
+  $effect(() => {
+    route.view
+    expandActiveNavigationGroup()
+  })
+
 </script>
 
 <div class="shell">
@@ -97,10 +202,28 @@
           class="nav-group"
           aria-label={$messages[group.labelKey]}
         >
-          <span class="nav-group-title">
-            {$messages[group.labelKey]}
-          </span>
-          <div class="nav-group-links">
+          <button
+            class="nav-group-title"
+            type="button"
+            aria-expanded={navigationGroupState[group.id]}
+            aria-controls={`navigation-group-${group.id}`}
+            onclick={() => toggleNavigationGroup(group.id)}
+          >
+            <span>{$messages[group.labelKey]}</span>
+            <svg
+              class:expanded={navigationGroupState[group.id]}
+              class="nav-group-chevron"
+              viewBox="0 0 16 16"
+              aria-hidden="true"
+            >
+              <path d="m4 6 4 4 4-4" />
+            </svg>
+          </button>
+          <div
+            id={`navigation-group-${group.id}`}
+            class="nav-group-links"
+            hidden={!navigationGroupState[group.id]}
+          >
             {#each group.links as link}
               <a
                 href={link.hash}
@@ -340,19 +463,59 @@
   }
 
   .nav-group-title {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
     margin: 0;
-    padding: 0 12px;
+    padding: 6px 12px;
+    border: 0;
+    border-radius: var(--radius-sm);
     color: var(--color-text-inverse-muted);
+    background: transparent;
+    font: inherit;
     font-size: 0.68rem;
     font-weight: 700;
     letter-spacing: 0.08em;
+    line-height: 1.25;
+    text-align: left;
     text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  .nav-group-title:hover {
+    color: var(--sidebar-text);
+    background: rgb(255 255 255 / 8%);
+  }
+
+  .nav-group-title:focus-visible,
+  nav a:focus-visible {
+    outline: 0;
+    box-shadow: var(--focus-ring);
+  }
+
+  .nav-group-chevron {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 auto;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .nav-group-chevron.expanded {
+    transform: rotate(180deg);
   }
 
   .nav-group-links {
     display: grid;
     gap: 3px;
+  }
+
+  .nav-group-links[hidden] {
+    display: none;
   }
 
   nav a {
@@ -568,7 +731,7 @@
     }
 
     .nav-group-title {
-      padding: 0 4px;
+      padding: 6px 4px;
     }
 
     .nav-group-links {


### PR DESCRIPTION
## Summary

- make Knowledge, Capture, and Manage accessible, independently collapsible sidebar groups
- keep every active destination visible by expanding its group during initial and subsequent route activation
- persist only the three stable group IDs in `lele-manager.navigation-groups.v1`, with safe defaults for malformed or obsolete storage
- preserve EN/IT labels, destination icon identities, `aria-current="page"`, and narrow-layout navigation

## Accessibility and behavior

Each group uses a native button with `aria-expanded` and `aria-controls`; its decorative chevron is hidden from assistive technology. Collapsed link containers use `hidden`, so child links leave both keyboard navigation and the accessibility tree. The active group cannot be collapsed, preventing its current destination from being hidden.

## Validation

- `npm run check`
- `npm run build`
- focused product-shell, localization, and brand E2E coverage (32 passing)
- `npm run test:e2e` (83 passing, 1 existing documentation screenshot test skipped)

## Scope

This PR owns disclosure inside the existing sidebar only. Issue #190 remains separate: no whole-sidebar visibility control, global header redesign, command palette/search, Help menu, or workspace architecture changes are included.

Closes #180
