### PR TITLE
ux: redesign global application header

### DIFF
--- a/docs/gui-user-guide.md
+++ b/docs/gui-user-guide.md
@@ -48,8 +48,8 @@ imported and the topic model retrained.
 ## GUI language
 
 LeLe Manager starts in **English** when no explicit language choice is stored.
-The language selector is in the sidebar, immediately above the GiadaWare
-signature. The maintained GUI languages are **English** and **Italiano**.
+The language selector is in the always-reachable global header. The maintained
+GUI languages are **English** and **Italiano**.
 
 Changing language updates the GUI immediately without reloading the page. The
 explicit choice is stored locally in the browser under
@@ -60,6 +60,31 @@ used.
 GUI localization affects product presentation only. It does not translate or
 modify user-authored LeLe, Markdown vault content, dataset values, topic names,
 source names, paths, IDs, API payloads or navigation identities.
+
+## Application shell
+
+The global header contains application-wide context and utilities: the current
+workspace name, compact API/dataset/search-model status, language control,
+**Search or commands**, and **Help**. It deliberately does not contain page
+actions such as Save, Delete, model refresh, or a permanent creation CTA.
+Version and full product identity remain authoritative in **About**.
+
+Use the navigation button in the header to show or hide the complete sidebar.
+This preference is stored locally as `lele-manager.sidebar-visible.v1` and is
+independent from the collapsible **Knowledge**, **Capture**, and **Manage**
+groups. Hiding the sidebar never removes the header controls; showing it again
+preserves group disclosure and the current navigation item.
+
+Use **Search or commands** or **Ctrl+K** to quickly open real destinations,
+including Dashboard, Browse, Timeline, Statistics, Collection, Vault,
+Duplicates, System, Diagnostics, About, and **New LeLe**. Search LeLe opens
+Browse; it does not create a second search system. **New LeLe** remains under
+**Capture** in navigation and is also available as an explicit command.
+
+**Help** provides the user guide, Diagnostics, the maintained GitHub bug-report
+form, About, and the command shortcut reminder. It neither generates nor sends
+diagnostic data. On narrow screens the header stays available above recoverable
+navigation and avoids horizontal overflow.
 
 ## Daily workflow
 

--- a/docs/it/gui-user-guide.md
+++ b/docs/it/gui-user-guide.md
@@ -49,8 +49,8 @@ Markdown e riaddestrare il modello topic.
 ## Lingua della GUI
 
 LeLe Manager parte in **inglese** quando non è memorizzata una scelta esplicita
-della lingua. Il selettore si trova nella sidebar, immediatamente sopra la
-firma GiadaWare. Le lingue mantenute della GUI sono **English** e **Italiano**.
+della lingua. Il selettore si trova nell’header globale sempre raggiungibile.
+Le lingue mantenute della GUI sono **English** e **Italiano**.
 
 Il cambio di lingua aggiorna immediatamente la GUI senza ricaricare la pagina.
 La scelta esplicita viene conservata localmente nel browser con la chiave
@@ -61,6 +61,34 @@ lingua del browser è intenzionalmente assente.
 La localizzazione riguarda soltanto la presentazione della GUI. Non traduce né
 modifica LeLe scritte dall'utente, contenuto Markdown del vault, valori del
 dataset, topic, fonti, percorsi, ID, payload API o identità di navigazione.
+
+## Shell applicativa
+
+L’header globale contiene contesto e utilità dell’applicazione: nome dello
+spazio di lavoro corrente, stato compatto di API/dataset/modello di ricerca,
+controllo della lingua, **Cerca o comandi** e **Aiuto**. Non contiene
+deliberatamente azioni di pagina quali Salva, Elimina, refresh del modello o
+una CTA permanente di creazione. Versione e identità completa del prodotto
+restano autorevoli in **Informazioni**.
+
+Usa il pulsante di navigazione nell’header per mostrare o nascondere l’intera
+sidebar. Questa preferenza è conservata localmente come
+`lele-manager.sidebar-visible.v1` ed è indipendente dai gruppi comprimibili
+**Conoscenza**, **Acquisizione** e **Gestione**. Nascondere la sidebar non
+rimuove i controlli dell’header; quando la riapri, disclosure dei gruppi e
+destinazione corrente restano preservate.
+
+Usa **Cerca o comandi** o **Ctrl+K** per aprire rapidamente destinazioni reali,
+incluse Dashboard, Esplora, Cronologia, Statistiche, Raccolta, Vault,
+Duplicati, Sistema, Diagnostica, Informazioni e **Nuova LeLe**. La ricerca di
+LeLe apre Esplora e non crea un secondo sistema di ricerca. **Nuova LeLe**
+resta sotto **Acquisizione** nella navigazione ed è disponibile anche come
+comando esplicito.
+
+**Aiuto** offre guida utente, Diagnostica, il modulo GitHub mantenuto per le
+segnalazioni bug, Informazioni e il promemoria della scorciatoia. Non genera né
+invia dati diagnostici. Su schermi stretti l’header resta disponibile sopra una
+navigazione recuperabile ed evita overflow orizzontale.
 
 ## Flusso quotidiano
 

--- a/frontend/e2e/brand-design-system.spec.ts
+++ b/frontend/e2e/brand-design-system.spec.ts
@@ -90,8 +90,6 @@ test('shows the GiadaWare product signature without crowding the product brand',
     '/app/brand/lele-cameo/05-walk-right-a.png',
   )
 })
-
-
 test('pins the maker signature to the desktop viewport across routes', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 600 })
   await page.goto('/app/')
@@ -177,20 +175,4 @@ test('keeps browse filter controls clear of the right edge', async ({ page }) =>
 
   expect(geometry.rightGap).toBeGreaterThanOrEqual(16)
   expect(geometry.controlsInside).toBe(true)
-})
-
-
-test('presents the new lesson action with the LeLe monkey balloon', async ({ page }) => {
-  await page.goto('/app/')
-
-  const action = page.getByTestId('new-lesson-cta')
-
-  await expect(action).toBeVisible()
-  await expect(action).toHaveAccessibleName('New LeLe')
-  await expect(action.getByText('+ New')).toBeVisible()
-  await expect(action.getByText('LeLe')).toBeVisible()
-  await expect(action.locator('img')).toHaveAttribute(
-    'src',
-    '/app/brand/lele-cameo/05-walk-right-a.png',
-  )
 })

--- a/frontend/e2e/localization.spec.ts
+++ b/frontend/e2e/localization.spec.ts
@@ -32,10 +32,6 @@ test.describe('GUI localization', () => {
     ).toBeVisible()
 
     await expect(
-      page.getByTestId('new-lesson-cta'),
-    ).toHaveAccessibleName('New LeLe')
-
-    await expect(
       page.getByLabel('Language'),
     ).toHaveValue('en')
   })
@@ -67,10 +63,6 @@ test.describe('GUI localization', () => {
         exact: true,
       }),
     ).toBeVisible()
-
-    await expect(
-      page.getByTestId('new-lesson-cta'),
-    ).toHaveAccessibleName('Nuova LeLe')
 
     expect(
       await page.evaluate(() => {
@@ -110,10 +102,6 @@ test.describe('GUI localization', () => {
     await expect(
       page.getByLabel('Language'),
     ).toHaveValue('en')
-
-    await expect(
-      page.getByTestId('new-lesson-cta'),
-    ).toHaveAccessibleName('New LeLe')
 
     await page.reload()
 

--- a/frontend/e2e/mascot-motion.spec.ts
+++ b/frontend/e2e/mascot-motion.spec.ts
@@ -1,223 +1,43 @@
-import {
-  expect,
-  test,
-  type Locator,
-  type Page,
-} from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
-async function tabUntilFocused(
-  page: Page,
-  target: Locator,
-  safetyBound: number,
-) {
-  for (let step = 0; step < safetyBound; step += 1) {
-    if (
-      await target.evaluate(
-        (element) => document.activeElement === element,
-      )
-    ) {
-      return
-    }
-
-    await page.keyboard.press('Tab')
-  }
-
-  await expect(
-    target,
-    `Expected the New LeLe CTA to be reachable within ${safetyBound} Tab presses`,
-  ).toBeFocused()
-}
-
-test.describe('LeLe monkey motion', () => {
-  test('keeps motion restrained and scoped to the New LeLe mascot', async ({
-    page,
-  }) => {
-    await page.goto('/app/#/')
-
-    const action = page.getByTestId('new-lesson-cta')
-    const face = page.getByTestId('lele-monkey-motion')
-    const image = face.locator('img')
-    const signatureMascot = page.getByTestId(
-      'giadaware-signature-mascot',
-    )
-    const signatureThought = page.getByTestId(
-      'giadaware-signature-thought',
-    )
-
-    await expect(action).toHaveAccessibleName('New LeLe')
-    await expect(action.getByText('+ New')).toBeVisible()
-    await expect(action.getByText('LeLe')).toBeVisible()
-
-    await expect(face).toHaveCSS(
-      'animation-name',
-      /lele-monkey-idle$/,
-    )
-    await expect(face).toHaveCSS('animation-duration', '18s')
-
-    await expect(signatureMascot).toHaveCSS(
-      'animation-name',
-      /lele-signature-think$/,
-    )
-    await expect(signatureThought).toHaveCSS(
-      'animation-name',
-      /lele-thought-bubble$/,
-    )
-
-    await action.hover()
-
-    await expect(face).toHaveCSS(
-      'animation-play-state',
-      'paused',
-    )
-    await expect(image).toHaveCSS(
-      'animation-name',
-      /lele-monkey-react$/,
-    )
-    await expect(image).toHaveCSS(
-      'animation-iteration-count',
-      '2',
-    )
-  })
-
-  test('reacts to keyboard focus without changing CTA semantics', async ({
-    page,
-  }) => {
-    await page.goto('/app/#/')
-
-    const action = page.getByTestId('new-lesson-cta')
-    const image = page
-      .getByTestId('lele-monkey-motion')
-      .locator('img')
-
-    await tabUntilFocused(page, action, 48)
-    await expect(action).toHaveAccessibleName('New LeLe')
-    await expect(image).toHaveCSS(
-      'animation-name',
-      /lele-monkey-react$/,
-    )
-    await expect(image).toHaveCSS(
-      'animation-iteration-count',
-      '2',
-    )
-  })
-
-  test('runs one decorative wandering cameo without looping', async ({
-    page,
-  }) => {
+test.describe('LeLe mascot motion', () => {
+  test('keeps the independent wandering cameo decorative and non-looping', async ({ page }) => {
     await page.goto('/app/#/')
 
     const cameo = page.getByTestId('lele-monkey-cameo')
-    const character = page.getByTestId(
-      'lele-monkey-cameo-character',
-    )
-    const balloon = page.getByTestId(
-      'lele-monkey-cameo-balloon',
-    )
+    const character = page.getByTestId('lele-monkey-cameo-character')
+    const balloon = page.getByTestId('lele-monkey-cameo-balloon')
 
     await expect(cameo).toHaveAttribute('aria-hidden', 'true')
     await expect(cameo).toHaveCSS('pointer-events', 'none')
-    await expect(cameo).toHaveCSS(
-      'animation-name',
-      /lele-cameo-path$/,
-    )
-    await expect(cameo).toHaveCSS(
-      'animation-duration',
-      '12s',
-    )
+    await expect(cameo).toHaveCSS('animation-name', /lele-cameo-path$/)
+    await expect(cameo).toHaveCSS('animation-duration', '12s')
     await expect(cameo).toHaveCSS('animation-delay', '8s')
-    await expect(cameo).toHaveCSS(
-      'animation-iteration-count',
-      '1',
-    )
-
+    await expect(cameo).toHaveCSS('animation-iteration-count', '1')
     await expect(character.locator('img')).toHaveCount(7)
-    await expect(
-      character.locator('img').nth(0),
-    ).toHaveAttribute(
-      'src',
-      '/app/brand/lele-cameo/01-enter.png',
-    )
-    await expect(
-      character.locator('img').nth(6),
-    ).toHaveAttribute(
-      'src',
-      '/app/brand/lele-cameo/07-exit.png',
-    )
     await expect(balloon).toHaveText('LeLe!!')
-    await expect(balloon).toHaveCSS(
-      'animation-name',
-      /lele-cameo-balloon$/,
-    )
   })
 
-  test('keeps the wandering cameo off compact layouts', async ({
-    page,
-  }) => {
+  test('keeps the cameo off compact layouts and disables decorative motion when requested', async ({ page }) => {
     await page.setViewportSize({ width: 700, height: 700 })
     await page.goto('/app/#/')
+    await expect(page.getByTestId('lele-monkey-cameo')).toHaveCSS('display', 'none')
 
-    await expect(
-      page.getByTestId('lele-monkey-cameo'),
-    ).toHaveCSS('display', 'none')
-  })
-
-  test('disables non-essential mascot motion for reduced motion', async ({
-    page,
-  }) => {
     await page.emulateMedia({ reducedMotion: 'reduce' })
-    await page.goto('/app/#/')
-
-    const action = page.getByTestId('new-lesson-cta')
-    const face = page.getByTestId('lele-monkey-motion')
-    const image = face.locator('img')
-    const signatureMascot = page.getByTestId(
-      'giadaware-signature-mascot',
-    )
-    const signatureThought = page.getByTestId(
-      'giadaware-signature-thought',
-    )
-    const cameo = page.getByTestId('lele-monkey-cameo')
-
-    await expect(face).toHaveCSS('animation-name', 'none')
-    await expect(signatureMascot).toHaveCSS(
-      'animation-name',
-      'none',
-    )
-    await expect(signatureThought).toHaveCSS(
-      'animation-name',
-      'none',
-    )
-    await expect(signatureThought).toHaveCSS('opacity', '0')
-    await expect(cameo).toHaveCSS('display', 'none')
-
-    await action.hover()
-
-    await expect(image).toHaveCSS('animation-name', 'none')
-    await expect(action).toHaveAccessibleName('New LeLe')
+    await expect(page.getByTestId('lele-monkey-cameo')).toHaveCSS('display', 'none')
   })
 })
 
-
-test('keeps the GiadaWare signature tongue decorative and motion-safe', async ({
-  page,
-}) => {
+test('keeps the GiadaWare signature tongue decorative and motion-safe', async ({ page }) => {
   await page.goto('/app/#/')
 
   const tongue = page.getByTestId('giadaware-signature-tongue')
   const thought = page.getByTestId('giadaware-signature-thought')
 
   await expect(thought).toBeAttached()
-  await expect(tongue).toBeAttached()
   await expect(tongue).toHaveAttribute('aria-hidden', 'true')
-  await expect(tongue).toHaveCSS(
-    'animation-name',
-    /lele-signature-tongue$/,
-  )
-  await expect(tongue).toHaveCSS('animation-duration', '31s')
-  await expect(tongue).toHaveCSS('left', '18px')
-
+  await expect(tongue).toHaveCSS('animation-name', /lele-signature-tongue$/)
   await page.emulateMedia({ reducedMotion: 'reduce' })
-
   await expect(tongue).toHaveCSS('animation-name', 'none')
   await expect(tongue).toHaveCSS('opacity', '0')
 })

--- a/frontend/e2e/mascot-motion.spec.ts
+++ b/frontend/e2e/mascot-motion.spec.ts
@@ -15,6 +15,14 @@ test.describe('LeLe mascot motion', () => {
     await expect(cameo).toHaveCSS('animation-delay', '8s')
     await expect(cameo).toHaveCSS('animation-iteration-count', '1')
     await expect(character.locator('img')).toHaveCount(7)
+    await expect(character.locator('img').nth(0)).toHaveAttribute(
+      'src',
+      '/app/brand/lele-cameo/01-enter.png',
+    )
+    await expect(character.locator('img').nth(6)).toHaveAttribute(
+      'src',
+      '/app/brand/lele-cameo/07-exit.png',
+    )
     await expect(balloon).toHaveText('LeLe!!')
   })
 
@@ -33,11 +41,19 @@ test('keeps the GiadaWare signature tongue decorative and motion-safe', async ({
 
   const tongue = page.getByTestId('giadaware-signature-tongue')
   const thought = page.getByTestId('giadaware-signature-thought')
+  const mascot = page.getByTestId('giadaware-signature-mascot')
 
   await expect(thought).toBeAttached()
   await expect(tongue).toHaveAttribute('aria-hidden', 'true')
   await expect(tongue).toHaveCSS('animation-name', /lele-signature-tongue$/)
+  await expect(tongue).toHaveCSS('animation-duration', '31s')
+  await expect(tongue).toHaveCSS('left', '18px')
+  await expect(mascot).toHaveCSS('animation-name', /lele-signature-think$/)
+  await expect(thought).toHaveCSS('animation-name', /lele-thought-bubble$/)
   await page.emulateMedia({ reducedMotion: 'reduce' })
   await expect(tongue).toHaveCSS('animation-name', 'none')
   await expect(tongue).toHaveCSS('opacity', '0')
+  await expect(mascot).toHaveCSS('animation-name', 'none')
+  await expect(thought).toHaveCSS('animation-name', 'none')
+  await expect(thought).toHaveCSS('opacity', '0')
 })

--- a/frontend/e2e/product-shell.spec.ts
+++ b/frontend/e2e/product-shell.spec.ts
@@ -1,513 +1,222 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 
-const navigationGroupsStorageKey =
-  'lele-manager.navigation-groups.v1'
+const navigationGroupsStorageKey = 'lele-manager.navigation-groups.v1'
+const sidebarStorageKey = 'lele-manager.sidebar-visible.v1'
 
-test.describe('product shell hierarchy', () => {
-  test('groups navigation into Knowledge, Capture, and Manage', async ({
-    page,
-  }) => {
+async function clearSidebarPreference(page: Page) {
+  await page.goto('/app/#/')
+  await page.evaluate((key) => window.localStorage.removeItem(key), sidebarStorageKey)
+  await page.reload()
+}
+
+test.describe('global application header', () => {
+  test('keeps New LeLe contextual and does not expose false global actions', async ({ page }) => {
     await page.goto('/app/#/')
 
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
+    const header = page.locator('header')
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
 
-    await expect(
-      navigation.getByRole('region', { name: 'Knowledge' }),
-    ).toBeVisible()
-    await expect(
-      navigation.getByRole('region', { name: 'Capture' }),
-    ).toBeVisible()
-    await expect(
-      navigation.getByRole('region', { name: 'Manage' }),
-    ).toBeVisible()
+    await expect(navigation.getByRole('link', { name: 'New LeLe', exact: true })).toHaveAttribute('href', '#/editor')
+    await expect(page.getByTestId('new-lesson-cta')).toHaveCount(0)
+    await expect(header.locator('a[href="#/editor"]')).toHaveCount(0)
 
-    for (const label of ['Knowledge', 'Capture', 'Manage']) {
-      await expect(
-        navigation.getByRole('button', { name: label, exact: true }),
-      ).toHaveAttribute('aria-expanded', 'true')
-    }
-
-    for (const label of [
-      'Dashboard',
-      'Browse',
-      'Timeline',
-      'Statistics',
-      'New LeLe',
-      'Collection',
-      'Vault',
-      'Duplicates',
-      'System',
-      'Diagnostics',
-      'About',
-    ]) {
-      await expect(
-        navigation.getByRole('link', { name: label }),
-      ).toHaveCount(1)
+    for (const label of ['Save', 'Delete', 'Refresh model', 'Logout', 'Sign out']) {
+      await expect(header.getByRole('button', { name: label, exact: true })).toHaveCount(0)
+      await expect(header.getByRole('link', { name: label, exact: true })).toHaveCount(0)
     }
   })
 
-  test('toggles independent inactive groups with accessible disclosure semantics', async ({
-    page,
-  }) => {
-    await page.goto('/app/#/settings')
+  test('shows bounded workspace context and compact runtime health in the header', async ({ page }) => {
+    await page.goto('/app/#/')
 
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
-    const knowledge = navigation.getByRole('button', {
-      name: 'Knowledge',
-      exact: true,
-    })
-    const capture = navigation.getByRole('button', {
-      name: 'Capture',
-      exact: true,
-    })
-    const knowledgeLinks = page.locator('#navigation-group-knowledge')
+    const workspace = page.getByTestId('header-workspace')
+    await expect(workspace).toBeVisible()
+    await expect(workspace.getByText('Workspace', { exact: true })).toBeVisible()
+    await expect(page.getByTestId('shell-workspace')).toHaveText(/\S+/)
+    expect(await page.getByTestId('shell-workspace').textContent()).not.toMatch(/[\\/]/)
+    await expect(page.locator('header .health-bar')).toBeVisible()
+  })
 
-    await expect(knowledge).toHaveAttribute('aria-controls', 'navigation-group-knowledge')
-    await expect(knowledge).toHaveAttribute('aria-expanded', 'true')
-    await expect(knowledge.locator('svg')).toHaveAttribute('aria-hidden', 'true')
+  test('defaults to a visible sidebar and persists whole-sidebar visibility independently', async ({ page }) => {
+    await clearSidebarPreference(page)
 
-    await knowledge.click()
+    const toggle = page.getByTestId('sidebar-toggle')
+    await expect(toggle).toHaveAccessibleName('Hide navigation')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.locator('#primary-sidebar')).toBeVisible()
 
-    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
-    await expect(knowledgeLinks).toBeHidden()
-    await expect(knowledgeLinks.getByRole('link')).toHaveCount(0)
-    await expect(capture).toHaveAttribute('aria-expanded', 'true')
+    await toggle.click()
+    await expect(toggle).toHaveAccessibleName('Show navigation')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
+    await expect.poll(() => page.evaluate((key) => localStorage.getItem(key), sidebarStorageKey)).toBe('false')
 
-    await knowledge.focus()
+    await page.reload()
+    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
+    await page.getByTestId('sidebar-toggle').click()
+    await expect(page.locator('#primary-sidebar')).toBeVisible()
+    await expect.poll(() => page.evaluate((key) => localStorage.getItem(key), sidebarStorageKey)).toBe('true')
+
+    await page.getByTestId('sidebar-toggle').focus()
+    await page.keyboard.press('Enter')
+    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
     await page.keyboard.press('Space')
-
-    await expect(knowledge).toHaveAttribute('aria-expanded', 'true')
-    await expect(knowledgeLinks).toBeVisible()
+    await expect(page.locator('#primary-sidebar')).toBeVisible()
   })
 
-  test('opens the active group for deep links and stale stored state', async ({
-    page,
-  }) => {
-    await page.addInitScript((key) => {
-      window.localStorage.setItem(key, JSON.stringify({
-        knowledge: true,
-        capture: true,
-        manage: false,
-      }))
-    }, navigationGroupsStorageKey)
-    await page.goto('/app/#/settings')
-
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
-
-    await expect(
-      navigation.getByRole('button', { name: 'Manage', exact: true }),
-    ).toHaveAttribute('aria-expanded', 'true')
-    await expect(
-      navigation.getByRole('link', { name: 'Diagnostics', exact: true }),
-    ).toBeVisible()
-    await expect(
-      navigation.getByRole('link', { name: 'Diagnostics', exact: true }),
-    ).toHaveAttribute('aria-current', 'page')
-    await expect(navigation.locator('a[aria-current="page"]')).toHaveCount(1)
-
-    await navigation.getByRole('button', {
-      name: 'Manage',
-      exact: true,
-    }).click()
-    await expect(
-      navigation.getByRole('button', { name: 'Manage', exact: true }),
-    ).toHaveAttribute('aria-expanded', 'true')
-    await expect(
-      navigation.getByRole('link', { name: 'Diagnostics', exact: true }),
-    ).toBeVisible()
-  })
-
-  test('opens a newly active group without changing unrelated preferences', async ({
-    page,
-  }) => {
-    await page.goto('/app/#/browse')
-
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
-    const manage = navigation.getByRole('button', {
-      name: 'Manage',
-      exact: true,
-    })
-
-    await manage.click()
-    await expect(manage).toHaveAttribute('aria-expanded', 'false')
-
-    await navigation.getByRole('link', {
-      name: 'New LeLe',
-      exact: true,
-    }).click()
-
-    await expect(
-      navigation.getByRole('button', { name: 'Capture', exact: true }),
-    ).toHaveAttribute('aria-expanded', 'true')
-    await expect(
-      navigation.getByRole('link', { name: 'New LeLe', exact: true }),
-    ).toHaveAttribute('aria-current', 'page')
-    await expect(manage).toHaveAttribute('aria-expanded', 'false')
-  })
-
-  test('persists valid disclosure state and safely ignores malformed storage', async ({
-    page,
-  }) => {
-    await page.goto('/app/#/settings')
-
-    const knowledge = page.getByRole('button', {
-      name: 'Knowledge',
-      exact: true,
-    })
-    await knowledge.click()
-    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
-    await expect.poll(async () => page.evaluate((key) => (
-      window.localStorage.getItem(key)
-    ), navigationGroupsStorageKey)).toBe(JSON.stringify({
-      knowledge: false,
-      capture: true,
-      manage: true,
-    }))
-
-    await page.reload()
-    await expect.poll(async () => page.evaluate((key) => (
-      window.localStorage.getItem(key)
-    ), navigationGroupsStorageKey)).toBe(JSON.stringify({
-      knowledge: false,
-      capture: true,
-      manage: true,
-    }))
-    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
-
-    await page.evaluate((key) => {
-      window.localStorage.setItem(key, '{not valid json')
-    }, navigationGroupsStorageKey)
-    await page.reload()
-
-    for (const label of ['Knowledge', 'Capture', 'Manage']) {
-      await expect(
-        page.getByRole('button', { name: label, exact: true }),
-      ).toHaveAttribute('aria-expanded', 'true')
-    }
-
-    await page.evaluate((key) => {
-      window.localStorage.setItem(key, JSON.stringify({ obsolete: false }))
-    }, navigationGroupsStorageKey)
-    await page.reload()
-
-    for (const label of ['Knowledge', 'Capture', 'Manage']) {
-      await expect(
-        page.getByRole('button', { name: label, exact: true }),
-      ).toHaveAttribute('aria-expanded', 'true')
-    }
-  })
-
-  test('uses deterministic local SVG navigation icons', async ({
-    page,
-  }) => {
+  test('safely defaults from malformed visibility storage and retains it across locale changes', async ({ page }) => {
+    await page.addInitScript((key) => window.localStorage.setItem(key, '{invalid'), sidebarStorageKey)
     await page.goto('/app/#/')
+    await expect(page.locator('#primary-sidebar')).toBeVisible()
 
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
+    await page.getByTestId('sidebar-toggle').click()
+    await page.getByLabel('Language').selectOption('it')
+    await expect(page.getByTestId('sidebar-toggle')).toHaveAccessibleName('Mostra navigazione')
+    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
+  })
 
+  test('preserves #180 disclosure state and current-route semantics through hide and restore', async ({ page }) => {
+    await page.addInitScript((key) => window.localStorage.setItem(key, JSON.stringify({
+      knowledge: false,
+      capture: true,
+      manage: true,
+    })), navigationGroupsStorageKey)
+    await page.goto('/app/#/settings')
+
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+    await expect(navigation.getByRole('button', { name: 'Knowledge', exact: true })).toHaveAttribute('aria-expanded', 'false')
+    await expect(navigation.getByRole('link', { name: 'Diagnostics', exact: true })).toHaveAttribute('aria-current', 'page')
+
+    await page.getByTestId('sidebar-toggle').click()
+    await expect(page.locator('#primary-sidebar a')).toHaveCount(0)
+    await page.getByTestId('sidebar-toggle').click()
+
+    await expect(navigation.getByRole('button', { name: 'Knowledge', exact: true })).toHaveAttribute('aria-expanded', 'false')
+    await expect(navigation.getByRole('link', { name: 'Diagnostics', exact: true })).toHaveAttribute('aria-current', 'page')
+    await expect(navigation.locator('a[aria-current="page"]')).toHaveCount(1)
+  })
+
+  test('preserves #180 groups and #181 semantic navigation icons', async ({ page }) => {
+    await clearSidebarPreference(page)
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+    await expect(navigation.getByRole('region', { name: 'Knowledge' })).toBeVisible()
+    await expect(navigation.getByRole('region', { name: 'Capture' })).toBeVisible()
+    await expect(navigation.getByRole('region', { name: 'Manage' })).toBeVisible()
     await expect(navigation.locator('svg[data-icon]')).toHaveCount(11)
 
-    for (const emoji of [
-      '🏠',
-      '🕒',
-      '📊',
-      '✨',
-      '🗂️',
-      '🧠',
-      '🧪',
-      '⚙️',
-    ]) {
-      await expect(navigation).not.toContainText(emoji)
+    const expectedIcons = [
+      ['Dashboard', 'dashboard'], ['Browse', 'browse'], ['Timeline', 'timeline'],
+      ['Statistics', 'stats'], ['New LeLe', 'new'], ['Collection', 'collection'],
+      ['Vault', 'vault'], ['Duplicates', 'duplicates'], ['System', 'system'],
+      ['Diagnostics', 'diagnostics'], ['About', 'about'],
+    ] as const
+    for (const [label, icon] of expectedIcons) {
+      await expect(navigation.getByRole('link', { name: label, exact: true }).locator('svg'))
+        .toHaveAttribute('data-icon', icon)
     }
   })
 
-  test('maps every navigation destination to its distinct semantic icon', async ({
-    page,
-  }) => {
-    await page.goto('/app/#/browse')
+  test('opens, filters, navigates, and restores focus through the command palette', async ({ page }) => {
+    await page.goto('/app/#/')
+    const trigger = page.getByTestId('command-palette-trigger')
 
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
-    const expectedIcons = [
-      ['Dashboard', 'dashboard'],
-      ['Browse', 'browse'],
-      ['Timeline', 'timeline'],
-      ['Statistics', 'stats'],
-      ['New LeLe', 'new'],
-      ['Collection', 'collection'],
-      ['Vault', 'vault'],
-      ['Duplicates', 'duplicates'],
-      ['System', 'system'],
-      ['Diagnostics', 'diagnostics'],
-      ['About', 'about'],
-    ] as const
+    await trigger.click()
+    const dialog = page.getByRole('dialog', { name: 'Search or commands' })
+    await expect(dialog).toBeVisible()
+    await expect(page).toHaveURL(/#\/$/)
+    const input = dialog.getByPlaceholder('Filter commands…')
+    await expect(input).toBeFocused()
+    await input.fill('Diagnostics')
+    await expect(dialog.getByRole('button', { name: 'Diagnostics', exact: true })).toBeVisible()
+    await input.press('Enter')
+    await expect(page).toHaveURL(/#\/settings$/)
+    await expect(dialog).not.toBeVisible()
+    await expect(trigger).toBeFocused()
 
-    for (const [label, icon] of expectedIcons) {
-      const link = navigation.getByRole('link', {
-        name: label,
-        exact: true,
-      })
-      const svg = link.locator('svg')
+    await page.keyboard.press('Control+k')
+    await expect(dialog).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(dialog).not.toBeVisible()
+    await expect(trigger).toBeFocused()
 
-      await expect(svg).toHaveAttribute('data-icon', icon)
-      await expect(svg).toHaveAttribute('aria-hidden', 'true')
-    }
+    await page.keyboard.press('Meta+k')
+    await expect(dialog).toBeVisible()
+    await page.keyboard.press('Escape')
+  })
 
-    expect(new Set(expectedIcons.map(([, icon]) => icon)).size).toBe(
-      expectedIcons.length,
+  test('offers New LeLe as a command without restoring a permanent CTA', async ({ page }) => {
+    await page.goto('/app/#/')
+    await page.keyboard.press('Control+k')
+    const dialog = page.getByRole('dialog', { name: 'Search or commands' })
+    await dialog.getByPlaceholder('Filter commands…').fill('New LeLe')
+    await dialog.getByRole('button', { name: 'New LeLe', exact: true }).click()
+    await expect(page).toHaveURL(/#\/editor$/)
+    await expect(page.getByTestId('new-lesson-cta')).toHaveCount(0)
+  })
+
+  test('maps Search LeLe to the maintained Browse route', async ({ page }) => {
+    await page.goto('/app/#/')
+    await page.keyboard.press('Control+k')
+    const dialog = page.getByRole('dialog', { name: 'Search or commands' })
+    await dialog.getByPlaceholder('Filter commands…').fill('Search LeLe')
+    await dialog.getByRole('button', { name: 'Search LeLe', exact: true }).click()
+    await expect(page).toHaveURL(/#\/browse$/)
+  })
+
+  test('keeps Help destinations bounded and internally routes Diagnostics and About', async ({ page }) => {
+    await page.goto('/app/#/')
+    await page.getByTestId('header-help-trigger').click()
+    const help = page.locator('#header-help-menu')
+
+    await expect(help.getByRole('link', { name: 'User guide' })).toHaveAttribute(
+      'href',
+      'https://github.com/gcomneno/lele-manager/blob/main/docs/gui-user-guide.md',
     )
-    await expect(
-      navigation.getByRole('link', { name: 'Browse', exact: true }),
-    ).toHaveAttribute('aria-current', 'page')
-    await expect(
-      navigation.getByRole('link', { name: 'System', exact: true }),
-    ).not.toHaveAttribute('aria-current')
-    await expect(
-      navigation.locator('a[aria-current="page"]'),
-    ).toHaveCount(1)
+    await expect(help.getByRole('link', { name: 'Report a problem' })).toHaveAttribute(
+      'href',
+      'https://github.com/gcomneno/lele-manager/issues/new?template=bug_report.yml',
+    )
+    await expect(help).toContainText('Ctrl K')
+
+    await help.getByRole('button', { name: 'Diagnostics', exact: true }).click()
+    await expect(page).toHaveURL(/#\/settings$/)
+
+    await page.getByTestId('header-help-trigger').click()
+    await page.locator('#header-help-menu').getByRole('button', { name: 'About', exact: true }).click()
+    await expect(page).toHaveURL(/#\/about$/)
   })
 
-  test('keeps semantic icon identities stable when localized', async ({
-    page,
-  }) => {
+  test('keeps palette commands and Help localized without changing route identities', async ({ page }) => {
     await page.goto('/app/#/')
-
     await page.getByLabel('Language').selectOption('it')
+    await page.getByTestId('command-palette-trigger').click()
+    const dialog = page.getByRole('dialog', { name: 'Cerca o comandi' })
+    await dialog.getByPlaceholder('Filtra comandi…').fill('Nuova LeLe')
+    await dialog.getByRole('button', { name: 'Nuova LeLe', exact: true }).click()
+    await expect(page).toHaveURL(/#\/editor$/)
 
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
-    const expectedIcons = [
-      ['Sistema', 'system'],
-      ['Diagnostica', 'diagnostics'],
-      ['Informazioni', 'about'],
-    ] as const
-
-    for (const [label, icon] of expectedIcons) {
-      await expect(
-        navigation.getByRole('link', { name: label, exact: true }).locator('svg'),
-      ).toHaveAttribute('data-icon', icon)
-    }
-  })
-
-  test('shows bounded runtime and workspace context', async ({
-    page,
-  }) => {
-    await page.goto('/app/#/')
-
-    const context = page.getByTestId('shell-context')
-    const version = page.getByTestId('shell-version')
-    const workspace = page.getByTestId('shell-workspace')
-
-    await expect(context).toBeVisible()
-    await expect(version).toHaveText(/\S+/)
-    await expect(workspace).toHaveText(/\S+/)
-
-    const workspaceText = await workspace.textContent()
-
-    expect(workspaceText).not.toContain('/')
-    expect(workspaceText).not.toContain('\\')
-  })
-
-  test('localizes navigation group labels without changing routes', async ({
-    page,
-  }) => {
-    await page.goto('/app/#/')
-
-    await page
-      .getByLabel('Language')
-      .selectOption('it')
-
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
-
-    await expect(
-      navigation.getByRole('region', { name: 'Conoscenza' }),
-    ).toBeVisible()
-    await expect(
-      navigation.getByRole('region', { name: 'Acquisizione' }),
-    ).toBeVisible()
-    await expect(
-      navigation.getByRole('region', { name: 'Gestione' }),
-    ).toBeVisible()
-
-    await expect(
-      navigation.getByRole('button', { name: 'Conoscenza', exact: true }),
-    ).toHaveAttribute('aria-expanded', 'true')
-
-    await expect(
-      navigation.getByRole('link', { name: 'Dashboard' }),
-    ).toHaveAttribute('href', '#/')
-    await expect(
-      navigation.getByRole('link', { name: 'Esplora' }),
-    ).toHaveAttribute('href', '#/browse')
-    await expect(
-      navigation.getByRole('link', { name: 'Cronologia' }),
-    ).toHaveAttribute('href', '#/timeline')
-    await expect(
-      navigation.getByRole('link', { name: 'Sistema' }),
-    ).toHaveAttribute('href', '#/ops')
-  })
-
-  test('keeps disclosure state when the locale changes', async ({ page }) => {
-    await page.goto('/app/#/settings')
-
-    const knowledge = page.getByRole('button', {
-      name: 'Knowledge',
-      exact: true,
-    })
-    await knowledge.click()
-    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
-
-    await page.getByLabel('Language').selectOption('it')
-
-    await expect(
-      page.getByRole('button', { name: 'Conoscenza', exact: true }),
-    ).toHaveAttribute('aria-expanded', 'false')
-    await expect(
-      page.getByRole('button', { name: 'Acquisizione', exact: true }),
-    ).toHaveAttribute('aria-expanded', 'true')
+    await page.getByTestId('header-help-trigger').click()
+    await expect(page.locator('#header-help-menu').getByRole('button', { name: 'Diagnostica', exact: true })).toBeVisible()
   })
 })
 
-test.describe('product shell responsive layouts', () => {
-  test('keeps grouped navigation usable on a narrow desktop', async ({
-    page,
-  }) => {
-    await page.setViewportSize({ width: 900, height: 600 })
-    await page.goto('/app/#/')
-
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
-
-    await expect(navigation).toBeVisible()
-    await expect(
-      navigation.getByRole('region', { name: 'Knowledge' }),
-    ).toBeVisible()
-    await expect(
-      navigation.getByRole('link', { name: 'Browse' }),
-    ).toBeVisible()
-    await expect(
-      navigation.getByRole('link', { name: 'System' }),
-    ).toBeVisible()
-
-    await expect(page.getByTestId('shell-context')).toBeVisible()
-    await expect(
-      page.getByTestId('giadaware-signature'),
-    ).toBeVisible()
-
-    const signatureBox = await page
-      .getByTestId('giadaware-signature')
-      .boundingBox()
-
-    expect(signatureBox).not.toBeNull()
-
-    if (signatureBox) {
-      expect(signatureBox.y).toBeGreaterThanOrEqual(0)
-      expect(signatureBox.y + signatureBox.height)
-        .toBeLessThanOrEqual(600)
-    }
-  })
-
-  test('keeps navigation deterministic on mobile width', async ({
-    page,
-  }) => {
+test.describe('responsive shell recovery', () => {
+  test('keeps the header toggle reachable and navigation recoverable without horizontal overflow on mobile', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 })
-    await page.goto('/app/#/')
+    await clearSidebarPreference(page)
 
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary',
-    })
+    const toggle = page.getByTestId('sidebar-toggle')
+    await expect(toggle).toBeVisible()
+    await toggle.click()
+    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
+    await expect(page.locator('#primary-sidebar a, #primary-sidebar button')).toHaveCount(0)
+    await toggle.click()
+    await expect(page.getByRole('navigation', { name: 'Primary' })).toBeVisible()
 
-    await expect(navigation).toBeVisible()
-
-    for (const group of [
-      'Knowledge',
-      'Capture',
-      'Manage',
-    ]) {
-      await expect(
-        navigation.getByRole('region', { name: group }),
-      ).toBeVisible()
-    }
-
-    for (const label of [
-      'Browse',
-      'Timeline',
-      'Statistics',
-      'New LeLe',
-      'Collection',
-      'Vault',
-      'Duplicates',
-      'System',
-      'Diagnostics',
-      'About',
-    ]) {
-      await expect(
-        navigation.getByRole('link', { name: label }),
-      ).toBeVisible()
-    }
-
-    await expect(
-      page.getByTestId('shell-context'),
-    ).toBeHidden()
-    await expect(
-      page.getByTestId('giadaware-signature'),
-    ).toBeHidden()
-
-    const viewportWidth = await page.evaluate(
-      () => document.documentElement.clientWidth,
-    )
-    const scrollWidth = await page.evaluate(
-      () => document.documentElement.scrollWidth,
-    )
-
-    expect(scrollWidth).toBeLessThanOrEqual(viewportWidth)
-  })
-
-  test('keeps mobile navigation keyboard reachable', async ({
-    page,
-  }) => {
-    await page.setViewportSize({ width: 390, height: 844 })
-    await page.goto('/app/#/')
-
-    const system = page.getByRole('link', {
-      name: 'System',
-    })
-
-    for (let step = 0; step < 24; step += 1) {
-      if (
-        await system.evaluate(
-          (element) => document.activeElement === element,
-        )
-      ) {
-        break
-      }
-
-      await page.keyboard.press('Tab')
-    }
-
-    await expect(system).toBeFocused()
-
-    await page.keyboard.press('Enter')
-
-    await expect(page).toHaveURL(/#\/ops$/)
-    await expect(
-      page.getByRole('heading', {
-        name: 'Status and maintenance',
-      }),
-    ).toBeVisible()
+    const widths = await page.evaluate(() => ({
+      viewport: document.documentElement.clientWidth,
+      scroll: document.documentElement.scrollWidth,
+    }))
+    expect(widths.scroll).toBeLessThanOrEqual(widths.viewport)
   })
 })

--- a/frontend/e2e/product-shell.spec.ts
+++ b/frontend/e2e/product-shell.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test'
+import { expect, test, type Locator, type Page } from '@playwright/test'
 
 const navigationGroupsStorageKey = 'lele-manager.navigation-groups.v1'
 const sidebarStorageKey = 'lele-manager.sidebar-visible.v1'
@@ -8,6 +8,137 @@ async function clearSidebarPreference(page: Page) {
   await page.evaluate((key) => window.localStorage.removeItem(key), sidebarStorageKey)
   await page.reload()
 }
+
+async function tabUntilFocused(
+  page: Page,
+  target: Locator,
+  safetyBound: number,
+) {
+  for (let step = 0; step < safetyBound; step += 1) {
+    if (await target.evaluate((element) => document.activeElement === element)) {
+      return
+    }
+
+    await page.keyboard.press('Tab')
+  }
+
+  await expect(target).toBeFocused()
+}
+
+test.describe('product shell hierarchy', () => {
+  test('keeps all navigation groups expanded by default with their destinations available', async ({ page }) => {
+    await page.goto('/app/#/')
+
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+    for (const label of ['Knowledge', 'Capture', 'Manage']) {
+      await expect(navigation.getByRole('region', { name: label })).toBeVisible()
+      await expect(navigation.getByRole('button', { name: label, exact: true }))
+        .toHaveAttribute('aria-expanded', 'true')
+    }
+
+    for (const label of [
+      'Dashboard', 'Browse', 'Timeline', 'Statistics', 'New LeLe', 'Collection',
+      'Vault', 'Duplicates', 'System', 'Diagnostics', 'About',
+    ]) {
+      await expect(navigation.getByRole('link', { name: label, exact: true })).toHaveCount(1)
+    }
+  })
+
+  test('toggles independent inactive groups with native disclosure semantics', async ({ page }) => {
+    await page.goto('/app/#/settings')
+
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+    const knowledge = navigation.getByRole('button', { name: 'Knowledge', exact: true })
+    const capture = navigation.getByRole('button', { name: 'Capture', exact: true })
+    const knowledgeLinks = page.locator('#navigation-group-knowledge')
+
+    await expect(knowledge).toHaveAttribute('aria-controls', 'navigation-group-knowledge')
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'true')
+    await expect(knowledge.locator('svg')).toHaveAttribute('aria-hidden', 'true')
+    await knowledge.click()
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
+    await expect(knowledgeLinks).toBeHidden()
+    await expect(knowledgeLinks.getByRole('link')).toHaveCount(0)
+    await expect(capture).toHaveAttribute('aria-expanded', 'true')
+
+    await knowledge.focus()
+    await page.keyboard.press('Space')
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'true')
+    await expect(knowledgeLinks).toBeVisible()
+  })
+
+  test('opens the active group for deep links and prevents hiding the current route', async ({ page }) => {
+    await page.addInitScript((key) => window.localStorage.setItem(key, JSON.stringify({
+      knowledge: true,
+      capture: true,
+      manage: false,
+    })), navigationGroupsStorageKey)
+    await page.goto('/app/#/settings')
+
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+    const manage = navigation.getByRole('button', { name: 'Manage', exact: true })
+    const diagnostics = navigation.getByRole('link', { name: 'Diagnostics', exact: true })
+    await expect(manage).toHaveAttribute('aria-expanded', 'true')
+    await expect(diagnostics).toBeVisible()
+    await expect(diagnostics).toHaveAttribute('aria-current', 'page')
+    await expect(navigation.locator('a[aria-current="page"]')).toHaveCount(1)
+
+    await manage.click()
+    await expect(manage).toHaveAttribute('aria-expanded', 'true')
+    await expect(diagnostics).toBeVisible()
+  })
+
+  test('opens a newly active group without changing unrelated preferences', async ({ page }) => {
+    await page.goto('/app/#/browse')
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+    const manage = navigation.getByRole('button', { name: 'Manage', exact: true })
+
+    await manage.click()
+    await expect(manage).toHaveAttribute('aria-expanded', 'false')
+    await navigation.getByRole('link', { name: 'New LeLe', exact: true }).click()
+
+    await expect(navigation.getByRole('button', { name: 'Capture', exact: true }))
+      .toHaveAttribute('aria-expanded', 'true')
+    await expect(navigation.getByRole('link', { name: 'New LeLe', exact: true }))
+      .toHaveAttribute('aria-current', 'page')
+    await expect(manage).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('persists disclosure state and safely falls back from malformed or obsolete group storage', async ({ page }) => {
+    await page.goto('/app/#/settings')
+    const knowledge = page.getByRole('button', { name: 'Knowledge', exact: true })
+    await knowledge.click()
+    await expect.poll(() => page.evaluate((key) => localStorage.getItem(key), navigationGroupsStorageKey))
+      .toBe(JSON.stringify({ knowledge: false, capture: true, manage: true }))
+    await page.reload()
+    await expect(knowledge).toHaveAttribute('aria-expanded', 'false')
+
+    await page.evaluate((key) => localStorage.setItem(key, '{not valid json'), navigationGroupsStorageKey)
+    await page.reload()
+    for (const label of ['Knowledge', 'Capture', 'Manage']) {
+      await expect(page.getByRole('button', { name: label, exact: true })).toHaveAttribute('aria-expanded', 'true')
+    }
+
+    await page.evaluate((key) => localStorage.setItem(key, JSON.stringify({ obsolete: false })), navigationGroupsStorageKey)
+    await page.reload()
+    for (const label of ['Knowledge', 'Capture', 'Manage']) {
+      await expect(page.getByRole('button', { name: label, exact: true })).toHaveAttribute('aria-expanded', 'true')
+    }
+  })
+
+  test('keeps disclosure state when the locale changes without changing route identities', async ({ page }) => {
+    await page.goto('/app/#/settings')
+    await page.getByRole('button', { name: 'Knowledge', exact: true }).click()
+    await page.getByLabel('Language').selectOption('it')
+
+    await expect(page.getByRole('button', { name: 'Conoscenza', exact: true }))
+      .toHaveAttribute('aria-expanded', 'false')
+    await expect(page.getByRole('button', { name: 'Acquisizione', exact: true }))
+      .toHaveAttribute('aria-expanded', 'true')
+    await expect(page.getByRole('link', { name: 'Sistema', exact: true }))
+      .toHaveAttribute('href', '#/ops')
+  })
+})
 
 test.describe('global application header', () => {
   test('keeps New LeLe contextual and does not expose false global actions', async ({ page }) => {
@@ -48,31 +179,54 @@ test.describe('global application header', () => {
     await toggle.click()
     await expect(toggle).toHaveAccessibleName('Show navigation')
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
-    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
+    await expect(toggle).toHaveAttribute('aria-controls', 'primary-sidebar')
+    await expect(page.locator('#primary-sidebar')).toHaveCount(1)
+    await expect(page.locator('#primary-sidebar')).toBeHidden()
+    await expect(page.getByRole('navigation', { name: 'Primary' })).toHaveCount(0)
+    await expect(page.getByRole('link', { name: 'Dashboard', exact: true })).toHaveCount(0)
+    expect(await page.locator('#primary-sidebar a, #primary-sidebar button').evaluateAll(
+      (elements) => elements.every((element) => (element as HTMLElement).offsetParent === null),
+    )).toBe(true)
     await expect.poll(() => page.evaluate((key) => localStorage.getItem(key), sidebarStorageKey)).toBe('false')
 
     await page.reload()
-    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
+    await expect(page.locator('#primary-sidebar')).toHaveCount(1)
+    await expect(page.locator('#primary-sidebar')).toBeHidden()
     await page.getByTestId('sidebar-toggle').click()
     await expect(page.locator('#primary-sidebar')).toBeVisible()
     await expect.poll(() => page.evaluate((key) => localStorage.getItem(key), sidebarStorageKey)).toBe('true')
 
     await page.getByTestId('sidebar-toggle').focus()
     await page.keyboard.press('Enter')
-    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
+    await expect(page.locator('#primary-sidebar')).toBeHidden()
     await page.keyboard.press('Space')
     await expect(page.locator('#primary-sidebar')).toBeVisible()
   })
 
   test('safely defaults from malformed visibility storage and retains it across locale changes', async ({ page }) => {
-    await page.addInitScript((key) => window.localStorage.setItem(key, '{invalid'), sidebarStorageKey)
     await page.goto('/app/#/')
+    await page.evaluate((key) => window.localStorage.setItem(key, '{invalid'), sidebarStorageKey)
+    await page.reload()
     await expect(page.locator('#primary-sidebar')).toBeVisible()
 
-    await page.getByTestId('sidebar-toggle').click()
+    await page.evaluate((key) => window.localStorage.setItem(key, 'unexpected'), sidebarStorageKey)
+    await page.reload()
+    await expect(page.locator('#primary-sidebar')).toBeVisible()
+    await page.evaluate((key) => window.localStorage.setItem(key, 'true'), sidebarStorageKey)
+    await page.reload()
+    await expect(page.locator('#primary-sidebar')).toBeVisible()
+    await page.evaluate((key) => window.localStorage.setItem(key, 'false'), sidebarStorageKey)
+    await page.reload()
+    await expect(page.locator('#primary-sidebar')).toBeHidden()
+
     await page.getByLabel('Language').selectOption('it')
     await expect(page.getByTestId('sidebar-toggle')).toHaveAccessibleName('Mostra navigazione')
-    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
+    await expect(page.locator('#primary-sidebar')).toBeHidden()
+
+    await page.getByTestId('header-help-trigger').click()
+    await page.locator('#header-help-menu').getByRole('button', { name: 'Diagnostica', exact: true }).click()
+    await expect(page).toHaveURL(/#\/settings$/)
+    await expect(page.locator('#primary-sidebar')).toBeHidden()
   })
 
   test('preserves #180 disclosure state and current-route semantics through hide and restore', async ({ page }) => {
@@ -88,7 +242,8 @@ test.describe('global application header', () => {
     await expect(navigation.getByRole('link', { name: 'Diagnostics', exact: true })).toHaveAttribute('aria-current', 'page')
 
     await page.getByTestId('sidebar-toggle').click()
-    await expect(page.locator('#primary-sidebar a')).toHaveCount(0)
+    await expect(page.locator('#primary-sidebar')).toBeHidden()
+    await expect(page.getByRole('navigation', { name: 'Primary' })).toHaveCount(0)
     await page.getByTestId('sidebar-toggle').click()
 
     await expect(navigation.getByRole('button', { name: 'Knowledge', exact: true })).toHaveAttribute('aria-expanded', 'false')
@@ -111,6 +266,34 @@ test.describe('global application header', () => {
       ['Diagnostics', 'diagnostics'], ['About', 'about'],
     ] as const
     for (const [label, icon] of expectedIcons) {
+      const svg = navigation.getByRole('link', { name: label, exact: true }).locator('svg')
+      await expect(svg)
+        .toHaveAttribute('data-icon', icon)
+      await expect(svg).toHaveAttribute('aria-hidden', 'true')
+    }
+    await expect(navigation.getByRole('link', { name: 'Dashboard', exact: true }))
+      .toHaveAttribute('aria-current', 'page')
+    await expect(navigation.locator('a[aria-current="page"]')).toHaveCount(1)
+  })
+
+  test('uses deterministic local SVG navigation icons without emoji fallbacks', async ({ page }) => {
+    await page.goto('/app/#/')
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+
+    await expect(navigation.locator('svg[data-icon]')).toHaveCount(11)
+    for (const emoji of ['🏠', '🕒', '📊', '✨', '🗂️', '🧠', '🧪', '⚙️']) {
+      await expect(navigation).not.toContainText(emoji)
+    }
+  })
+
+  test('keeps semantic icon identities stable when localized', async ({ page }) => {
+    await page.goto('/app/#/')
+    await page.getByLabel('Language').selectOption('it')
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+
+    for (const [label, icon] of [
+      ['Sistema', 'system'], ['Diagnostica', 'diagnostics'], ['Informazioni', 'about'],
+    ]) {
       await expect(navigation.getByRole('link', { name: label, exact: true }).locator('svg'))
         .toHaveAttribute('data-icon', icon)
     }
@@ -201,22 +384,97 @@ test.describe('global application header', () => {
 })
 
 test.describe('responsive shell recovery', () => {
-  test('keeps the header toggle reachable and navigation recoverable without horizontal overflow on mobile', async ({ page }) => {
+  test('keeps the desktop sidebar pinned alongside the global header and content', async ({ page }) => {
+    await page.setViewportSize({ width: 900, height: 600 })
+    await clearSidebarPreference(page)
+
+    await expect(page.getByTestId('header-workspace')).toBeVisible()
+    await expect(page.getByTestId('giadaware-signature')).toBeVisible()
+    const signatureBox = await page.getByTestId('giadaware-signature').boundingBox()
+    expect(signatureBox).not.toBeNull()
+    if (signatureBox) {
+      expect(signatureBox.y).toBeGreaterThanOrEqual(0)
+      expect(signatureBox.y + signatureBox.height).toBeLessThanOrEqual(600)
+    }
+  })
+
+  test('orders header, navigation, and main content on mobile and removes the sidebar reservation when hidden', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 })
     await clearSidebarPreference(page)
 
     const toggle = page.getByTestId('sidebar-toggle')
+    const header = page.locator('header.global-header')
+    const sidebar = page.locator('#primary-sidebar')
+    const navigation = page.getByRole('navigation', { name: 'Primary' })
+    const main = page.locator('main.main')
     await expect(toggle).toBeVisible()
+    await expect(navigation).toBeVisible()
+    for (const group of ['Knowledge', 'Capture', 'Manage']) {
+      await expect(navigation.getByRole('region', { name: group })).toBeVisible()
+    }
+    for (const label of ['Browse', 'Timeline', 'Statistics', 'New LeLe', 'Collection', 'Vault', 'Duplicates', 'System', 'Diagnostics', 'About']) {
+      await expect(navigation.getByRole('link', { name: label, exact: true })).toBeVisible()
+    }
+
+    const visibleBoxes = await Promise.all([
+      header.boundingBox(),
+      sidebar.boundingBox(),
+      main.boundingBox(),
+    ])
+    const [headerBox, sidebarBox, mainBox] = visibleBoxes
+    expect(headerBox).not.toBeNull()
+    expect(sidebarBox).not.toBeNull()
+    expect(mainBox).not.toBeNull()
+    if (headerBox && sidebarBox && mainBox) {
+      expect(headerBox.y + headerBox.height).toBeLessThanOrEqual(sidebarBox.y + 1)
+      expect(sidebarBox.y + sidebarBox.height).toBeLessThanOrEqual(mainBox.y + 1)
+    }
+
     await toggle.click()
-    await expect(page.locator('#primary-sidebar')).toHaveCount(0)
-    await expect(page.locator('#primary-sidebar a, #primary-sidebar button')).toHaveCount(0)
+    await expect(header).toBeVisible()
+    await expect(sidebar).toBeHidden()
+    await expect(navigation).toHaveCount(0)
+    const hiddenBoxes = await Promise.all([header.boundingBox(), main.boundingBox()])
+    const [hiddenHeaderBox, hiddenMainBox] = hiddenBoxes
+    expect(hiddenHeaderBox).not.toBeNull()
+    expect(hiddenMainBox).not.toBeNull()
+    if (hiddenHeaderBox && hiddenMainBox) {
+      expect(hiddenMainBox.y - (hiddenHeaderBox.y + hiddenHeaderBox.height)).toBeLessThanOrEqual(1)
+    }
+
+    const hiddenWidths = await page.evaluate(() => ({
+      viewport: document.documentElement.clientWidth,
+      scroll: document.documentElement.scrollWidth,
+    }))
+    expect(hiddenWidths.scroll).toBeLessThanOrEqual(hiddenWidths.viewport)
+
     await toggle.click()
-    await expect(page.getByRole('navigation', { name: 'Primary' })).toBeVisible()
+    await expect(navigation).toBeVisible()
+    await expect(navigation.getByRole('link', { name: 'Dashboard', exact: true }))
+      .toHaveAttribute('aria-current', 'page')
+    const restoredBoxes = await Promise.all([sidebar.boundingBox(), main.boundingBox()])
+    const [restoredSidebarBox, restoredMainBox] = restoredBoxes
+    expect(restoredSidebarBox).not.toBeNull()
+    expect(restoredMainBox).not.toBeNull()
+    if (restoredSidebarBox && restoredMainBox) {
+      expect(restoredSidebarBox.y + restoredSidebarBox.height).toBeLessThanOrEqual(restoredMainBox.y + 1)
+    }
 
     const widths = await page.evaluate(() => ({
       viewport: document.documentElement.clientWidth,
       scroll: document.documentElement.scrollWidth,
     }))
     expect(widths.scroll).toBeLessThanOrEqual(widths.viewport)
+  })
+
+  test('keeps grouped navigation keyboard reachable on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await clearSidebarPreference(page)
+
+    const system = page.getByRole('link', { name: 'System', exact: true })
+    await tabUntilFocused(page, system, 36)
+    await page.keyboard.press('Enter')
+    await expect(page).toHaveURL(/#\/ops$/)
+    await expect(page.getByRole('heading', { name: 'Status and maintenance' })).toBeVisible()
   })
 })

--- a/frontend/src/components/CommandPalette.svelte
+++ b/frontend/src/components/CommandPalette.svelte
@@ -1,0 +1,265 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte'
+  import { messages } from '../lib/i18n'
+  import { navigate, type Route } from '../lib/router'
+
+  type CommandLabel =
+    | 'navDashboard'
+    | 'navBrowse'
+    | 'commandSearchLele'
+    | 'navTimeline'
+    | 'navStatistics'
+    | 'navCollection'
+    | 'navVault'
+    | 'navDuplicates'
+    | 'navSystem'
+    | 'navSettings'
+    | 'navAbout'
+    | 'navNewLele'
+
+  type Command = {
+    labelKey: CommandLabel
+    route: Route
+  }
+
+  const commands: Command[] = [
+    { labelKey: 'navDashboard', route: { view: 'dashboard' } },
+    { labelKey: 'navBrowse', route: { view: 'browse' } },
+    { labelKey: 'commandSearchLele', route: { view: 'browse' } },
+    { labelKey: 'navTimeline', route: { view: 'timeline' } },
+    { labelKey: 'navStatistics', route: { view: 'stats' } },
+    { labelKey: 'navCollection', route: { view: 'tritalele' } },
+    { labelKey: 'navVault', route: { view: 'vault' } },
+    { labelKey: 'navDuplicates', route: { view: 'duplicates' } },
+    { labelKey: 'navSystem', route: { view: 'ops' } },
+    { labelKey: 'navSettings', route: { view: 'settings' } },
+    { labelKey: 'navAbout', route: { view: 'about' } },
+    { labelKey: 'navNewLele', route: { view: 'editor' } },
+  ]
+
+  let dialog = $state<HTMLDialogElement>()
+  let trigger = $state<HTMLButtonElement>()
+  let input = $state<HTMLInputElement>()
+  let query = $state('')
+  let isOpen = $state(false)
+  let filteredCommands = $derived(commands.filter((command) =>
+    $messages[command.labelKey]
+      .toLocaleLowerCase()
+      .includes(query.trim().toLocaleLowerCase()),
+  ))
+
+  async function openPalette() {
+    if (isOpen) return
+    isOpen = true
+    query = ''
+    await tick()
+    dialog?.showModal()
+    input?.focus()
+  }
+
+  function closePalette() {
+    dialog?.close()
+  }
+
+  function runCommand(command: Command) {
+    navigate(command.route)
+    closePalette()
+  }
+
+  function onDialogClose() {
+    isOpen = false
+    trigger?.focus()
+  }
+
+  function onInputKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && filteredCommands[0]) {
+      event.preventDefault()
+      runCommand(filteredCommands[0])
+    }
+  }
+
+  function isEditableTarget(target: EventTarget | null) {
+    return target instanceof HTMLInputElement
+      || target instanceof HTMLTextAreaElement
+      || target instanceof HTMLSelectElement
+      || (target instanceof HTMLElement && target.isContentEditable)
+  }
+
+  onMount(() => {
+    const onKeydown = (event: KeyboardEvent) => {
+      if (
+        (event.ctrlKey || event.metaKey)
+        && event.key.toLocaleLowerCase() === 'k'
+        && !isEditableTarget(event.target)
+      ) {
+        event.preventDefault()
+        void openPalette()
+      }
+    }
+
+    window.addEventListener('keydown', onKeydown)
+    return () => window.removeEventListener('keydown', onKeydown)
+  })
+</script>
+
+<button
+  bind:this={trigger}
+  class="command-trigger"
+  type="button"
+  aria-haspopup="dialog"
+  aria-expanded={isOpen}
+  aria-controls="global-command-palette"
+  data-testid="command-palette-trigger"
+  onclick={() => void openPalette()}
+>
+  <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m21 21-4.35-4.35m1.35-5.15a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0Z" /></svg>
+  <span>{$messages.commandPaletteTrigger}</span>
+  <kbd aria-label={$messages.commandPaletteShortcut}>Ctrl K</kbd>
+</button>
+
+<dialog
+  bind:this={dialog}
+  id="global-command-palette"
+  aria-labelledby="command-palette-title"
+  onclose={onDialogClose}
+>
+  <div class="palette">
+    <div class="palette-heading">
+      <h2 id="command-palette-title">{$messages.commandPaletteTitle}</h2>
+      <button class="palette-close" type="button" onclick={closePalette}>
+        {$messages.commandPaletteClose}
+      </button>
+    </div>
+    <label class="visually-hidden" for="command-palette-query">
+      {$messages.commandPalettePlaceholder}
+    </label>
+    <input
+      bind:this={input}
+      id="command-palette-query"
+      bind:value={query}
+      placeholder={$messages.commandPalettePlaceholder}
+      onkeydown={onInputKeydown}
+      autocomplete="off"
+    />
+    {#if filteredCommands.length}
+      <p class="palette-hint">{$messages.commandPaletteEnterHint}</p>
+      <ul aria-label={$messages.commandPaletteResults}>
+        {#each filteredCommands as command, index}
+          <li>
+            <button
+              class:default-command={index === 0}
+              type="button"
+              onclick={() => runCommand(command)}
+            >
+              {$messages[command.labelKey]}
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="no-results" role="status">{$messages.commandPaletteNoResults}</p>
+    {/if}
+  </div>
+</dialog>
+
+<style>
+  .command-trigger,
+  .palette-close,
+  li button {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .command-trigger {
+    display: inline-flex;
+    min-height: 36px;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 9px;
+    white-space: nowrap;
+  }
+
+  .command-trigger svg {
+    width: 16px;
+    height: 16px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+  }
+
+  kbd {
+    padding: 1px 4px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--color-text-muted);
+    font-size: 0.7rem;
+  }
+
+  dialog {
+    width: min(560px, calc(100vw - 32px));
+    padding: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    color: var(--color-text);
+    background: var(--color-surface);
+    box-shadow: 0 18px 48px rgb(36 28 22 / 28%);
+  }
+
+  dialog::backdrop { background: rgb(36 28 22 / 42%); }
+
+  .palette { padding: var(--space-4); }
+
+  .palette-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    margin-bottom: var(--space-3);
+  }
+
+  h2 { margin: 0; font-size: var(--font-size-lg); }
+
+  .palette-close { min-height: 32px; padding: 4px 8px; }
+
+  input { width: 100%; }
+
+  ul {
+    display: grid;
+    gap: 4px;
+    margin: var(--space-3) 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li button {
+    width: 100%;
+    min-height: 38px;
+    padding: 7px 10px;
+    text-align: left;
+  }
+
+  li button:hover { background: var(--color-surface-subtle); }
+  li button.default-command {
+    border-color: var(--color-border-accent);
+    background: var(--color-brand-100);
+  }
+  .palette-hint { margin: var(--space-3) 0 0; color: var(--color-text-muted); font-size: var(--font-size-xs); }
+  .no-results { margin: var(--space-4) 0 0; color: var(--color-text-muted); }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  @media (max-width: 800px) {
+    .command-trigger span { display: none; }
+    .command-trigger { padding: 6px 8px; }
+  }
+</style>

--- a/frontend/src/components/HeaderHelp.svelte
+++ b/frontend/src/components/HeaderHelp.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { messages } from '../lib/i18n'
+  import { navigate, type Route } from '../lib/router'
+
+  const DOCUMENTATION_URL =
+    'https://github.com/gcomneno/lele-manager/blob/main/docs/gui-user-guide.md'
+  const SUPPORT_URL =
+    'https://github.com/gcomneno/lele-manager/issues/new?template=bug_report.yml'
+
+  let open = $state(false)
+  let trigger = $state<HTMLButtonElement>()
+
+  function close() {
+    open = false
+    trigger?.focus()
+  }
+
+  function navigateAndClose(route: Route) {
+    navigate(route)
+    close()
+  }
+
+  onMount(() => {
+    const onKeydown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && open) {
+        event.preventDefault()
+        close()
+      }
+    }
+
+    window.addEventListener('keydown', onKeydown)
+    return () => window.removeEventListener('keydown', onKeydown)
+  })
+</script>
+
+<div class="help" role="group" aria-label={$messages.help}>
+  <button
+    bind:this={trigger}
+    class="help-trigger"
+    type="button"
+    aria-expanded={open}
+    aria-controls="header-help-menu"
+    data-testid="header-help-trigger"
+    onclick={() => { open = !open }}
+  >
+    <span aria-hidden="true">?</span>
+    <span>{$messages.help}</span>
+  </button>
+  {#if open}
+    <div id="header-help-menu" class="help-menu" role="region" aria-label={$messages.help}>
+      <a href={DOCUMENTATION_URL} target="_blank" rel="noreferrer">
+        {$messages.helpUserGuide}
+      </a>
+      <button type="button" onclick={() => navigateAndClose({ view: 'settings' })}>
+        {$messages.navSettings}
+      </button>
+      <a href={SUPPORT_URL} target="_blank" rel="noreferrer">
+        {$messages.helpReportProblem}
+      </a>
+      <button type="button" onclick={() => navigateAndClose({ view: 'about' })}>
+        {$messages.navAbout}
+      </button>
+      <p>{$messages.helpShortcut}</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .help { position: relative; }
+  .help-trigger,
+  .help-menu button,
+  .help-menu a {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .help-trigger {
+    display: inline-flex;
+    min-height: 36px;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 9px;
+  }
+
+  .help-trigger > span:first-child {
+    display: inline-flex;
+    width: 16px;
+    height: 16px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--color-brand-700);
+    color: var(--color-text-inverse);
+    font-weight: 700;
+  }
+
+  .help-menu {
+    position: absolute;
+    right: 0;
+    z-index: 4;
+    display: grid;
+    width: max-content;
+    min-width: 210px;
+    gap: 4px;
+    margin-top: 6px;
+    padding: 8px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    box-shadow: var(--elevation-2);
+  }
+
+  .help-menu button,
+  .help-menu a {
+    min-height: 34px;
+    padding: 6px 8px;
+    text-align: left;
+    text-decoration: none;
+  }
+
+  .help-menu button:hover,
+  .help-menu a:hover { background: var(--color-surface-subtle); }
+  .help-menu p { margin: 4px 4px 0; color: var(--color-text-muted); font-size: var(--font-size-xs); }
+
+  @media (max-width: 800px) {
+    .help-trigger > span:last-child { display: none; }
+    .help-trigger { padding: 6px 8px; }
+  }
+</style>

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -8,6 +8,8 @@
     setLocale,
   } from '../lib/i18n'
   import HealthBar from './HealthBar.svelte'
+  import CommandPalette from './CommandPalette.svelte'
+  import HeaderHelp from './HeaderHelp.svelte'
   import NavIcon from './NavIcon.svelte'
 
   interface Props {
@@ -23,6 +25,8 @@
 
   const NAVIGATION_GROUPS_STORAGE_KEY =
     'lele-manager.navigation-groups.v1'
+  const SIDEBAR_VISIBILITY_STORAGE_KEY =
+    'lele-manager.sidebar-visible.v1'
 
   const navigationGroupIds: NavigationGroupId[] = [
     'knowledge',
@@ -68,8 +72,8 @@
     },
   ]
 
-  let appVersion = $state<string | null>(null)
   let workspaceName = $state<string | null>(null)
+  let sidebarVisible = $state(loadSidebarVisibility())
   let navigationGroupState = $state<NavigationGroupState>(
     loadNavigationGroupState(),
   )
@@ -82,19 +86,12 @@
   onMount(() => {
     let active = true
 
-    void Promise.allSettled([
-      api.runtimeInfo(),
-      api.vaultStatus(),
-    ]).then(([runtime, vault]) => {
+    void api.vaultStatus().then((vault) => {
       if (!active) return
 
-      if (runtime.status === 'fulfilled') {
-        appVersion = runtime.value.version
-      }
-
-      if (vault.status === 'fulfilled') {
-        workspaceName = basename(vault.value.vault_dir)
-      }
+      workspaceName = basename(vault.vault_dir)
+    }).catch(() => {
+      // Workspace context is best-effort and must never block the shell.
     })
 
     return () => {
@@ -161,6 +158,33 @@
     }
   }
 
+  function loadSidebarVisibility(): boolean {
+    if (typeof window === 'undefined') return true
+
+    try {
+      const persisted = window.localStorage.getItem(
+        SIDEBAR_VISIBILITY_STORAGE_KEY,
+      )
+      return persisted === 'false' ? false : true
+    } catch {
+      return true
+    }
+  }
+
+  function toggleSidebar() {
+    sidebarVisible = !sidebarVisible
+
+    if (typeof window === 'undefined') return
+    try {
+      window.localStorage.setItem(
+        SIDEBAR_VISIBILITY_STORAGE_KEY,
+        String(sidebarVisible),
+      )
+    } catch {
+      // Persistence is best-effort; the sidebar still works in this session.
+    }
+  }
+
   function expandActiveNavigationGroup() {
     const groupId = activeNavigationGroup()
 
@@ -187,8 +211,9 @@
 
 </script>
 
-<div class="shell">
-  <aside class="sidebar">
+<div class:sidebar-hidden={!sidebarVisible} class="shell">
+  {#if sidebarVisible}
+  <aside id="primary-sidebar" class="sidebar">
     <a class="brand" href="#/" aria-label={$messages.brandHomeAccessible} onclick={(e) => { e.preventDefault(); navigate({ view: 'dashboard' }) }}>
       <img src="/app/brand/lele-manager-mark.svg" alt="" aria-hidden="true" />
       <span>
@@ -245,43 +270,6 @@
       {/each}
     </nav>
 
-    <dl class="shell-context" data-testid="shell-context">
-      {#if workspaceName}
-        <div>
-          <dt>{$messages.shellWorkspace}</dt>
-          <dd data-testid="shell-workspace">{workspaceName}</dd>
-        </div>
-      {/if}
-      {#if appVersion}
-        <div>
-          <dt>{$messages.shellVersion}</dt>
-          <dd data-testid="shell-version">{appVersion}</dd>
-        </div>
-      {/if}
-    </dl>
-    <div
-      class="language-control"
-      data-testid="language-control"
-    >
-      <label for="lele-manager-language">
-        {$messages.languageLabel}
-      </label>
-      <select
-        id="lele-manager-language"
-        value={$locale}
-        onchange={(event) => {
-          setLocale(event.currentTarget.value)
-        }}
-      >
-        <option value="en">
-          {$messages.languageEnglish}
-        </option>
-        <option value="it">
-          {$messages.languageItalian}
-        </option>
-      </select>
-    </div>
-
     <footer class="product-signature" data-testid="giadaware-signature">
       <span
         class="signature-mascot"
@@ -311,36 +299,42 @@
       </span>
     </footer>
   </aside>
+  {/if}
 
   <div class="main">
-    <header>
-      <HealthBar />
-      <a
-        class="btn btn-primary new-lesson-cta"
-        href="#/editor"
-        aria-label={$messages.newLeleAccessible}
-        data-testid="new-lesson-cta"
-        onclick={(e) => {
-          e.preventDefault()
-          navigate({ view: 'editor' })
-        }}
+    <header class="global-header">
+      <button
+        class="sidebar-toggle"
+        type="button"
+        aria-label={sidebarVisible ? $messages.hideNavigation : $messages.showNavigation}
+        aria-expanded={sidebarVisible}
+        aria-controls="primary-sidebar"
+        data-testid="sidebar-toggle"
+        onclick={toggleSidebar}
       >
-        <span class="new-lesson-visible" aria-hidden="true">
-          <span class="new-lesson-prefix">+ {$messages.newLelePrefix}</span>
-          <span class="lele-mascot-badge">
-            <span
-              class="lele-monkey-face"
-              data-testid="lele-monkey-motion"
-            >
-              <img
-                src="/app/brand/lele-cameo/05-walk-right-a.png"
-                alt=""
-              />
-            </span>
-            <span class="lele-balloon">LeLe</span>
-          </span>
-        </span>
-      </a>
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" /></svg>
+      </button>
+      <dl class="workspace-context" data-testid="header-workspace">
+        <dt>{$messages.shellWorkspace}</dt>
+        <dd data-testid="shell-workspace">{workspaceName ?? $messages.shellWorkspaceUnavailable}</dd>
+      </dl>
+      <div class="header-utilities">
+        <CommandPalette />
+      <HealthBar />
+        <label class="header-language" for="lele-manager-language">
+          <span>{$messages.languageLabel}</span>
+          <select
+            id="lele-manager-language"
+            data-testid="language-control"
+            value={$locale}
+            onchange={(event) => setLocale(event.currentTarget.value)}
+          >
+            <option value="en">{$messages.languageEnglish}</option>
+            <option value="it">{$messages.languageItalian}</option>
+          </select>
+        </label>
+        <HeaderHelp />
+      </div>
     </header>
     <div class="content">
       {@render children()}
@@ -407,6 +401,10 @@
     display: grid;
     grid-template-columns: 220px 1fr;
     min-height: 100vh;
+  }
+
+  .shell.sidebar-hidden {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .sidebar {
@@ -546,75 +544,10 @@
     opacity: 1;
   }
 
-  .shell-context {
-    display: grid;
-    gap: 6px;
-    margin: 0;
-    padding: 10px 4px 0;
-    border-top: 1px solid rgb(255 255 255 / 14%);
-  }
-
-  .shell-context div {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 8px;
-    align-items: baseline;
-  }
-
-  .shell-context dt,
-  .shell-context dd {
-    margin: 0;
-    min-width: 0;
-    font-size: 0.68rem;
-  }
-
-  .shell-context dt {
-    color: var(--color-text-inverse-muted);
-  }
-
-  .shell-context dd {
-    max-width: 110px;
-    overflow: hidden;
-    color: var(--sidebar-text);
-    font-weight: 600;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .language-control {
-    display: grid;
-    gap: 5px;
-    margin-top: auto;
-    padding: var(--space-4) 4px 0;
-    border-top: 1px solid rgb(255 255 255 / 14%);
-  }
-
-  .language-control label {
-    color: var(--color-text-inverse-muted);
-    font-size: var(--font-size-xs);
-    font-weight: 600;
-  }
-
-  .language-control select {
-    box-sizing: border-box;
-    width: 100%;
-    min-height: 36px;
-    padding: 6px 28px 6px 9px;
-    border: 1px solid rgb(255 255 255 / 24%);
-    border-radius: var(--radius-sm);
-    color: var(--sidebar-text);
-    background: var(--sidebar);
-    font: inherit;
-  }
-
-  .language-control select:focus-visible {
-    outline: 0;
-    box-shadow: var(--focus-ring);
-  }
-
   .product-signature {
     display: grid;
     gap: 2px;
+    margin-top: auto;
     padding: var(--space-3) 4px 2px;
     color: var(--color-text-inverse-muted);
     font-size: var(--font-size-xs);
@@ -633,9 +566,8 @@
     min-width: 0;
   }
 
-  header {
+  .global-header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     gap: 12px;
     padding: 14px 20px;
@@ -644,6 +576,74 @@
     position: sticky;
     top: 0;
     z-index: 1;
+  }
+
+  .sidebar-toggle {
+    display: inline-flex;
+    width: 36px;
+    min-height: 36px;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    padding: 6px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .sidebar-toggle svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-width: 2;
+  }
+
+  .workspace-context {
+    display: grid;
+    min-width: 0;
+    margin: 0;
+    line-height: 1.15;
+  }
+
+  .workspace-context dt {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .workspace-context dd {
+    max-width: 190px;
+    margin: 2px 0 0;
+    overflow: hidden;
+    font-size: var(--font-size-sm);
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .header-utilities {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-left: auto;
+  }
+
+  .header-language {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--color-text-muted);
+    font-size: var(--font-size-xs);
+  }
+
+  .header-language select {
+    min-height: 36px;
+    max-width: 102px;
+    padding: 5px 26px 5px 7px;
   }
 
   .content {
@@ -667,13 +667,15 @@
 
   @media (max-width: 800px) {
     .shell {
-      grid-template-columns: minmax(0, 1fr);
+      display: flex;
+      flex-direction: column;
       width: 100%;
       max-width: 100%;
       overflow-x: clip;
     }
 
     .sidebar {
+      order: 2;
       box-sizing: border-box;
       width: 100%;
       min-width: 0;
@@ -695,22 +697,35 @@
       align-self: stretch;
     }
 
-    .product-signature,
-    .shell-context {
+    .product-signature {
       display: none;
     }
 
-    .language-control {
-      flex: 0 0 140px;
-      margin-top: 0;
-      margin-left: auto;
-      padding: 0;
-      border-top: 0;
+    .main { order: 1; }
+
+    .global-header {
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 10px;
     }
 
-    .language-control label {
-      color: var(--sidebar-text);
+    .workspace-context {
+      flex: 1 1 auto;
     }
+
+    .workspace-context dd { max-width: 160px; }
+
+    .header-utilities {
+      width: 100%;
+      flex: 1 1 100%;
+      justify-content: space-between;
+      gap: 6px;
+      margin-left: 0;
+    }
+
+    .header-language > span { display: none; }
+
+    .header-language select { max-width: 94px; }
 
     nav {
       box-sizing: border-box;
@@ -933,106 +948,14 @@
     line-height: 1.25;
   }
 
-  /* New lesson mascot call to action */
-  .new-lesson-visible {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    white-space: nowrap;
-  }
-
-  .new-lesson-prefix {
-    line-height: 1;
-  }
-
-  .lele-mascot-badge {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    min-width: 58px;
-    height: 28px;
-  }
-
-  .lele-monkey-face {
-    position: relative;
-    display: inline-flex;
-    width: 25px;
-    height: 25px;
-    flex: 0 0 25px;
-    overflow: hidden;
-    border-radius: 50%;
-    transform-origin: 50% 70%;
-    animation: lele-monkey-idle 18s ease-in-out infinite;
-  }
-
-  .lele-mascot-badge img {
-    position: absolute;
-    top: -6px;
-    left: -13px;
-    display: block;
-    width: 48px;
-    height: 48px;
-    max-width: none;
-    flex: none;
-    transform-origin: 53% 39%;
-  }
-
-  .new-lesson-cta:hover .lele-monkey-face,
-  .new-lesson-cta:focus-visible .lele-monkey-face {
-    animation-play-state: paused;
-  }
-
-  .new-lesson-cta:hover .lele-monkey-face img,
-  .new-lesson-cta:focus-visible .lele-monkey-face img {
-    animation: lele-monkey-react 360ms ease-out 2;
-  }
-
-  @keyframes lele-monkey-idle {
-    0%,
-    90%,
-    100% {
-      transform: translateY(0) rotate(0deg);
-    }
-
-    92% {
-      transform: translateY(-2px) rotate(-5deg);
-    }
-
-    94% {
-      transform: translateY(-1px) rotate(4deg);
-    }
-
-    96% {
-      transform: translateY(0) rotate(0deg);
-    }
-  }
-
-  @keyframes lele-monkey-react {
-    0%,
-    100% {
-      transform: rotate(0deg) scale(1);
-    }
-
-    35% {
-      transform: translateY(-2px) rotate(-8deg) scale(1.08);
-    }
-
-    68% {
-      transform: translateY(-1px) rotate(5deg) scale(1.04);
-    }
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    .lele-monkey-face,
     .signature-mascot,
     .signature-thought,
     .signature-tongue,
     .lele-cameo,
     .lele-cameo-stage,
     .lele-cameo-frame,
-    .lele-cameo-balloon,
-    .new-lesson-cta:hover .lele-monkey-face img,
-    .new-lesson-cta:focus-visible .lele-monkey-face img {
+    .lele-cameo-balloon {
       animation: none;
       transform: none;
     }
@@ -1046,38 +969,6 @@
       display: none;
       opacity: 0;
     }
-  }
-
-  .lele-balloon {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 32px;
-    height: 21px;
-    margin-left: 3px;
-    padding: 0 6px;
-    border: 1px solid rgb(255 255 255 / 58%);
-    border-radius: 999px;
-    background: var(--color-surface);
-    color: var(--color-text);
-    font-size: 11px;
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: 0.01em;
-  }
-
-  .lele-balloon::before {
-    position: absolute;
-    left: -5px;
-    bottom: 2px;
-    width: 7px;
-    height: 7px;
-    border-left: 1px solid rgb(255 255 255 / 58%);
-    border-bottom: 1px solid rgb(255 255 255 / 58%);
-    background: var(--color-surface);
-    content: '';
-    transform: rotate(45deg);
   }
 
   /* One-shot illustrated wandering monkey cameo */
@@ -1514,28 +1405,6 @@
     nav a {
       padding: 2px 10px;
       line-height: 1.15;
-    }
-
-    .shell-context {
-      gap: 2px;
-      padding-top: 5px;
-    }
-
-    .shell-context dt,
-    .shell-context dd {
-      font-size: 0.64rem;
-      line-height: 1.15;
-    }
-
-    .language-control {
-      gap: 2px;
-      padding-top: 5px;
-    }
-
-    .language-control select {
-      min-height: 30px;
-      padding-top: 3px;
-      padding-bottom: 3px;
     }
 
     .product-signature {

--- a/frontend/src/components/Shell.svelte
+++ b/frontend/src/components/Shell.svelte
@@ -212,8 +212,42 @@
 </script>
 
 <div class:sidebar-hidden={!sidebarVisible} class="shell">
-  {#if sidebarVisible}
-  <aside id="primary-sidebar" class="sidebar">
+  <header class="global-header">
+    <button
+      class="sidebar-toggle"
+      type="button"
+      aria-label={sidebarVisible ? $messages.hideNavigation : $messages.showNavigation}
+      aria-expanded={sidebarVisible}
+      aria-controls="primary-sidebar"
+      data-testid="sidebar-toggle"
+      onclick={toggleSidebar}
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" /></svg>
+    </button>
+    <dl class="workspace-context" data-testid="header-workspace">
+      <dt>{$messages.shellWorkspace}</dt>
+      <dd data-testid="shell-workspace">{workspaceName ?? $messages.shellWorkspaceUnavailable}</dd>
+    </dl>
+    <div class="header-utilities">
+      <CommandPalette />
+      <HealthBar />
+      <label class="header-language" for="lele-manager-language">
+        <span>{$messages.languageLabel}</span>
+        <select
+          id="lele-manager-language"
+          data-testid="language-control"
+          value={$locale}
+          onchange={(event) => setLocale(event.currentTarget.value)}
+        >
+          <option value="en">{$messages.languageEnglish}</option>
+          <option value="it">{$messages.languageItalian}</option>
+        </select>
+      </label>
+      <HeaderHelp />
+    </div>
+  </header>
+
+  <aside id="primary-sidebar" class="sidebar" hidden={!sidebarVisible}>
     <a class="brand" href="#/" aria-label={$messages.brandHomeAccessible} onclick={(e) => { e.preventDefault(); navigate({ view: 'dashboard' }) }}>
       <img src="/app/brand/lele-manager-mark.svg" alt="" aria-hidden="true" />
       <span>
@@ -299,43 +333,8 @@
       </span>
     </footer>
   </aside>
-  {/if}
 
-  <div class="main">
-    <header class="global-header">
-      <button
-        class="sidebar-toggle"
-        type="button"
-        aria-label={sidebarVisible ? $messages.hideNavigation : $messages.showNavigation}
-        aria-expanded={sidebarVisible}
-        aria-controls="primary-sidebar"
-        data-testid="sidebar-toggle"
-        onclick={toggleSidebar}
-      >
-        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" /></svg>
-      </button>
-      <dl class="workspace-context" data-testid="header-workspace">
-        <dt>{$messages.shellWorkspace}</dt>
-        <dd data-testid="shell-workspace">{workspaceName ?? $messages.shellWorkspaceUnavailable}</dd>
-      </dl>
-      <div class="header-utilities">
-        <CommandPalette />
-      <HealthBar />
-        <label class="header-language" for="lele-manager-language">
-          <span>{$messages.languageLabel}</span>
-          <select
-            id="lele-manager-language"
-            data-testid="language-control"
-            value={$locale}
-            onchange={(event) => setLocale(event.currentTarget.value)}
-          >
-            <option value="en">{$messages.languageEnglish}</option>
-            <option value="it">{$messages.languageItalian}</option>
-          </select>
-        </label>
-        <HeaderHelp />
-      </div>
-    </header>
+  <main class="main">
     <div class="content">
       {@render children()}
     </div>
@@ -393,27 +392,39 @@
         LeLe!!
       </span>
     </div>
-  </div>
+  </main>
 </div>
 
 <style>
   .shell {
     display: grid;
     grid-template-columns: 220px 1fr;
+    grid-template-areas:
+      'sidebar header'
+      'sidebar main';
+    grid-template-rows: auto minmax(0, 1fr);
     min-height: 100vh;
   }
 
   .shell.sidebar-hidden {
     grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'header'
+      'main';
   }
 
   .sidebar {
+    grid-area: sidebar;
     background: var(--sidebar);
     color: var(--sidebar-text);
     padding: 20px 16px;
     display: flex;
     flex-direction: column;
     gap: 16px;
+  }
+
+  .sidebar[hidden] {
+    display: none;
   }
 
   .brand {
@@ -561,12 +572,14 @@
   }
 
   .main {
+    grid-area: main;
     display: flex;
     flex-direction: column;
     min-width: 0;
   }
 
   .global-header {
+    grid-area: header;
     display: flex;
     align-items: center;
     gap: 12px;
@@ -667,15 +680,18 @@
 
   @media (max-width: 800px) {
     .shell {
-      display: flex;
-      flex-direction: column;
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-areas:
+        'header'
+        'sidebar'
+        'main';
+      grid-template-rows: auto auto minmax(0, 1fr);
       width: 100%;
       max-width: 100%;
       overflow-x: clip;
     }
 
     .sidebar {
-      order: 2;
       box-sizing: border-box;
       width: 100%;
       min-width: 0;
@@ -700,8 +716,6 @@
     .product-signature {
       display: none;
     }
-
-    .main { order: 1; }
 
     .global-header {
       flex-wrap: wrap;

--- a/frontend/src/lib/i18n/en.ts
+++ b/frontend/src/lib/i18n/en.ts
@@ -61,6 +61,22 @@ export const en = {
   navGroupManage: 'Manage',
   shellVersion: 'Version',
   shellWorkspace: 'Workspace',
+  shellWorkspaceUnavailable: 'Unavailable',
+  showNavigation: 'Show navigation',
+  hideNavigation: 'Hide navigation',
+  commandPaletteTrigger: 'Search or commands',
+  commandPaletteShortcut: 'Command palette shortcut: Control K',
+  commandPaletteTitle: 'Search or commands',
+  commandPalettePlaceholder: 'Filter commands…',
+  commandPaletteResults: 'Available commands',
+  commandPaletteNoResults: 'No matching commands.',
+  commandPaletteClose: 'Close',
+  commandPaletteEnterHint: 'Press Enter to open the highlighted first result.',
+  commandSearchLele: 'Search LeLe',
+  help: 'Help',
+  helpUserGuide: 'User guide',
+  helpReportProblem: 'Report a problem',
+  helpShortcut: 'Shortcut: Ctrl K opens Search or commands.',
   settingsTitle: 'Diagnostics',
   settingsIntro:
     'Inspect the current support state and prepare a bounded report only when you choose to generate one.',
@@ -136,9 +152,6 @@ export const en = {
   languageItalian: 'Italian',
 
   makerOpenSource: 'Open-source software',
-
-  newLeleAccessible: 'New LeLe',
-  newLelePrefix: 'New',
 
   commonLoading: 'Loading…',
 

--- a/frontend/src/lib/i18n/it.ts
+++ b/frontend/src/lib/i18n/it.ts
@@ -63,6 +63,22 @@ export const it = {
   navGroupManage: 'Gestione',
   shellVersion: 'Versione',
   shellWorkspace: 'Spazio di lavoro',
+  shellWorkspaceUnavailable: 'Non disponibile',
+  showNavigation: 'Mostra navigazione',
+  hideNavigation: 'Nascondi navigazione',
+  commandPaletteTrigger: 'Cerca o comandi',
+  commandPaletteShortcut: 'Scorciatoia palette comandi: Control K',
+  commandPaletteTitle: 'Cerca o comandi',
+  commandPalettePlaceholder: 'Filtra comandi…',
+  commandPaletteResults: 'Comandi disponibili',
+  commandPaletteNoResults: 'Nessun comando corrispondente.',
+  commandPaletteClose: 'Chiudi',
+  commandPaletteEnterHint: 'Premi Invio per aprire il primo risultato evidenziato.',
+  commandSearchLele: 'Cerca LeLe',
+  help: 'Aiuto',
+  helpUserGuide: 'Guida utente',
+  helpReportProblem: 'Segnala un problema',
+  helpShortcut: 'Scorciatoia: Ctrl K apre Cerca o comandi.',
   settingsTitle: 'Diagnostica',
   settingsIntro:
     'Controlla lo stato utile per l’assistenza e prepara un rapporto bounded solo quando scegli di generarlo.',
@@ -138,9 +154,6 @@ export const it = {
   languageItalian: 'Italiano',
 
   makerOpenSource: 'Software open source',
-
-  newLeleAccessible: 'Nuova LeLe',
-  newLelePrefix: 'Nuova',
 
   commonLoading: 'Caricamento…',
 


### PR DESCRIPTION
Closes #190

## Summary

- Redesigns the global application chrome around a sticky global header with workspace context, HealthBar, command palette, language choice, Help, and a sidebar visibility toggle.
- Keeps creation contextual: **Capture → New LeLe** and the explicit **New LeLe** command-palette action remain canonical. There is no permanent header CTA or header-only mascot animation.
- Preserves #180 grouped navigation and #181 semantic icon/current-page behavior, including their independent persisted preference key.
- Persists whole-sidebar visibility in `lele-manager.sidebar-visible.v1`, independent from navigation-group disclosure state. Missing, malformed, and unrecognised values safely default to visible.
- Keeps the sidebar as one stable `#primary-sidebar` element. When hidden it uses the standard `hidden` mechanism, so the header toggle's `aria-controls` target is always present while hidden descendants leave the accessibility and focus trees.

## Corrective shell architecture

- The shell has three sibling regions: global header, sidebar navigation, and main content.
- Desktop grid areas are `sidebar/header` and `sidebar/main`; the sidebar remains viewport-sticky.
- Narrow grid areas are `header`, `sidebar`, then `main`, so restored navigation is immediately reachable before page content. When hidden, the shell uses only `header` and `main`, with no reserved sidebar track or overflow.

## Accessibility and behavior

- Sidebar toggle exposes its expanded state and permanently controls `#primary-sidebar`.
- Command palette remains bounded, uses a native dialog, supports Ctrl/Meta+K, does not intercept editable fields, returns focus, and removes its global shortcut listener on unmount.
- Help remains bounded to the maintained guide, Diagnostics, the bug-report form, About, and the shortcut reminder; it does not generate or transmit diagnostics.

## Validation

- `npm run check`
- `npm run build`
- Focused Playwright: product shell (22), mascot motion (3), localization (11)
- Full serial `npm run test:e2e`: **86 passed, 1 existing screenshot test skipped** (87 discovered)
